### PR TITLE
Fix team logos to use teamId instead of teamSeasonId

### DIFF
--- a/draco-nodejs/frontend/src/components/Teams.tsx
+++ b/draco-nodejs/frontend/src/components/Teams.tsx
@@ -130,7 +130,18 @@ const Teams: React.FC<TeamsProps> = ({ accountId }) => {
       const timestamp = logoUpdateTracker[teamId] || Date.now();
       const seasonId = teamsData?.season.id;
       if (!seasonId) return false;
-      const response = await fetch(getLogoUrl(accountId, teamId, seasonId, teamId, timestamp), { method: "HEAD" });
+
+      // Find the team season ID for this team
+      const teamSeason = teamsData?.leagueSeasons
+        .flatMap((ls) => ls.divisions.flatMap((d) => d.teams))
+        .find((team) => team.teamId === teamId);
+
+      if (!teamSeason) return false;
+
+      const response = await fetch(
+        getLogoUrl(accountId, teamId, seasonId, teamSeason.id, timestamp),
+        { method: "HEAD" },
+      );
       return response.ok;
     } catch {
       return false;
@@ -379,7 +390,9 @@ const Teams: React.FC<TeamsProps> = ({ accountId }) => {
     const timestamp = logoUpdateTracker[team.teamId] || Date.now();
     const seasonId = teamsData?.season.id;
     if (seasonId) {
-      setLogoPreview(getLogoUrl(accountId, team.teamId, seasonId, team.id, timestamp));
+      setLogoPreview(
+        getLogoUrl(accountId, team.teamId, seasonId, team.id, timestamp),
+      );
     }
     setEditDialogError(null);
     setEditDialogOpen(true);
@@ -573,7 +586,17 @@ const Teams: React.FC<TeamsProps> = ({ accountId }) => {
       }}
     >
       <Avatar
-        src={teamsData?.season.id ? getLogoUrl(accountId, team.teamId, teamsData.season.id, team.id, logoUpdateTracker[team.teamId]) : undefined}
+        src={
+          teamsData?.season.id
+            ? getLogoUrl(
+                accountId,
+                team.teamId,
+                teamsData.season.id,
+                team.id,
+                logoUpdateTracker[team.teamId],
+              )
+            : undefined
+        }
         sx={{
           width: LOGO_SIZE,
           height: LOGO_SIZE,

--- a/draco-nodejs/frontend/src/config/teams.ts
+++ b/draco-nodejs/frontend/src/config/teams.ts
@@ -26,14 +26,21 @@ export const getLogoSize = (): number => {
 };
 
 // Helper function to generate logo URL based on storage provider
-export const getLogoUrl = (accountId: string, teamId: string, seasonId: string, teamSeasonId: string, timestamp?: number): string => {
+export const getLogoUrl = (
+  accountId: string,
+  teamId: string,
+  seasonId: string,
+  teamSeasonId: string,
+  timestamp?: number,
+): string => {
   const cacheBuster = timestamp || Date.now();
-  
+
   if (TEAM_CONFIG.STORAGE_PROVIDER === "s3") {
     // For S3, we'll use a backend proxy endpoint to serve the images
+    // The backend will query the teamId from the teamSeasonId
     return `/api/accounts/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/logo?t=${cacheBuster}`;
   } else {
-    // For local storage, use the direct uploads path
+    // For local storage, use the direct uploads path with teamId
     return `/uploads/${accountId}/team-logos/${teamId}-logo.png?t=${cacheBuster}`;
   }
 };


### PR DESCRIPTION
- Update backend logo serving endpoint to query teamId from teamSeasonId
- Fix frontend checkLogoExists function to use correct parameters
- Ensure S3 storage uses teamId for consistent logo storage across seasons
- Maintain account isolation in S3 key structure
- Team logos now persist across seasons using consistent teamId