### PR TITLE
fix: enforce JWT_SECRET environment variable and add rate limiting to…

### DIFF
--- a/draco-nodejs/backend/package-lock.json
+++ b/draco-nodejs/backend/package-lock.json
@@ -24,6 +24,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.0.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
@@ -7218,6 +7219,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7955,6 +7974,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/draco-nodejs/backend/package.json
+++ b/draco-nodejs/backend/package.json
@@ -39,6 +39,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",

--- a/draco-nodejs/backend/src/middleware/authMiddleware.ts
+++ b/draco-nodejs/backend/src/middleware/authMiddleware.ts
@@ -47,7 +47,14 @@ export const authenticateToken = async (
       return;
     }
 
-    const JWT_SECRET = process.env.JWT_SECRET || 'draco-sports-manager-secret';
+    const JWT_SECRET = process.env.JWT_SECRET;
+    if (!JWT_SECRET) {
+      res.status(500).json({
+        success: false,
+        message: 'Server configuration error',
+      });
+      return;
+    }
 
     const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload;
 
@@ -117,7 +124,10 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
       return next(); // Continue without user
     }
 
-    const JWT_SECRET = process.env.JWT_SECRET || 'draco-sports-manager-secret';
+    const JWT_SECRET = process.env.JWT_SECRET;
+    if (!JWT_SECRET) {
+      return next(); // Continue without user if JWT_SECRET not configured
+    }
 
     const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload;
 

--- a/draco-nodejs/backend/src/middleware/rateLimitMiddleware.ts
+++ b/draco-nodejs/backend/src/middleware/rateLimitMiddleware.ts
@@ -1,0 +1,76 @@
+import rateLimit from 'express-rate-limit';
+import { Request, Response } from 'express';
+
+interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  message?: string;
+  skipSuccessfulRequests?: boolean;
+  standardHeaders?: boolean;
+  legacyHeaders?: boolean;
+}
+
+/**
+ * Creates a rate limit middleware with custom configuration
+ */
+export const createRateLimit = (options: RateLimitOptions = {}) => {
+  const {
+    windowMs = 15 * 60 * 1000, // 15 minutes default
+    max = 100, // 100 requests per window default
+    message = 'Too many requests, please try again later.',
+    skipSuccessfulRequests = false,
+    standardHeaders = true,
+    legacyHeaders = false,
+  } = options;
+
+  return rateLimit({
+    windowMs,
+    max,
+    message: {
+      success: false,
+      message,
+    },
+    skipSuccessfulRequests,
+    standardHeaders,
+    legacyHeaders,
+    handler: (req: Request, res: Response) => {
+      res.status(429).json({
+        success: false,
+        message,
+      });
+    },
+    // Use default key generator which properly handles IPv6
+  });
+};
+
+/**
+ * Strict rate limiting for authentication endpoints
+ * 5 attempts per 15 minutes per IP
+ */
+export const authRateLimit = createRateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // 5 attempts per window
+  message: 'Too many authentication attempts, please try again in 15 minutes.',
+  skipSuccessfulRequests: true, // Don't count successful logins against the limit
+});
+
+/**
+ * More lenient rate limiting for password-related endpoints
+ * 3 attempts per 15 minutes per IP
+ */
+export const passwordRateLimit = createRateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 3, // 3 attempts per window
+  message: 'Too many password change attempts, please try again in 15 minutes.',
+  skipSuccessfulRequests: true,
+});
+
+/**
+ * General API rate limiting
+ * 100 requests per 15 minutes per IP
+ */
+export const generalRateLimit = createRateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // 100 requests per window
+  message: 'Too many requests, please try again later.',
+});

--- a/draco-nodejs/backend/src/routes/auth.ts
+++ b/draco-nodejs/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { AuthService, LoginCredentials, RegisterData } from '../services/authService';
 import { authenticateToken } from '../middleware/authMiddleware';
+import { authRateLimit, passwordRateLimit } from '../middleware/rateLimitMiddleware';
 import { ServiceFactory } from '../lib/serviceFactory';
 import { asyncHandler } from '../utils/asyncHandler';
 import { ValidationError, AuthenticationError } from '../utils/customErrors';
@@ -64,6 +65,7 @@ const roleService = ServiceFactory.getRoleVerification();
  */
 router.post(
   '/login',
+  authRateLimit,
   asyncHandler(async (req: Request, res: Response) => {
     const { username, password }: LoginCredentials = req.body;
 
@@ -126,6 +128,7 @@ router.post(
  */
 router.post(
   '/register',
+  authRateLimit,
   asyncHandler(async (req: Request, res: Response) => {
     const { username, email, password, firstName, lastName }: RegisterData = req.body;
 
@@ -317,6 +320,7 @@ router.get(
  */
 router.post(
   '/verify',
+  authRateLimit,
   asyncHandler(async (req: Request, res: Response) => {
     const { token } = req.body;
 
@@ -389,6 +393,7 @@ router.post(
  */
 router.post(
   '/change-password',
+  passwordRateLimit,
   authenticateToken,
   asyncHandler(async (req: Request, res: Response) => {
     const { currentPassword, newPassword } = req.body;

--- a/draco-nodejs/backend/src/services/authService.ts
+++ b/draco-nodejs/backend/src/services/authService.ts
@@ -34,7 +34,13 @@ export interface JWTPayload {
 }
 
 export class AuthService {
-  private readonly JWT_SECRET = process.env.JWT_SECRET || 'draco-sports-manager-secret';
+  private readonly JWT_SECRET = (() => {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    return secret;
+  })();
   private readonly JWT_EXPIRES_IN = '24h';
 
   /**


### PR DESCRIPTION
… auth endpoints

- Remove hardcoded fallback JWT secret to prevent production security risks
- Add comprehensive rate limiting middleware with IPv6 support
- Apply strict rate limits to login, register, and verify endpoints (5/15min)
- Apply password-specific rate limits to change-password endpoint (3/15min)
- Skip successful requests in rate limiting to avoid penalizing legitimate users

🤖 Generated with [Claude Code](https://claude.ai/code)