### PR TITLE
refactor: use backend-provided role names in UserManagement

### DIFF
--- a/draco-nodejs/frontend-next/components/users/UserRoleChips.tsx
+++ b/draco-nodejs/frontend-next/components/users/UserRoleChips.tsx
@@ -27,7 +27,7 @@ const UserRoleChips: React.FC<UserRoleChipsProps> = ({
       {roles.map((role) => (
         <Chip
           key={role.id}
-          label={getRoleDisplayName(role.roleId)}
+          label={getRoleDisplayName(role)}
           size="small"
           color="primary"
           variant="outlined"

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -338,10 +338,19 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     setRemoveRoleDialogOpen(true);
   }, []);
 
-  // Role display name helper
-  const getRoleDisplayNameHelper = useCallback((roleId: string): string => {
-    return getRoleDisplayName(roleId);
-  }, []);
+  // Role display name helper - now uses roleName from backend when available
+  const getRoleDisplayNameHelper = useCallback(
+    (roleOrRoleId: string | { roleId: string; roleName?: string }): string => {
+      // Handle both string (roleId) and object (role) parameters for backward compatibility
+      if (typeof roleOrRoleId === 'string') {
+        return getRoleDisplayName(roleOrRoleId);
+      }
+
+      // Use roleName from backend if available, otherwise fall back to conversion
+      return roleOrRoleId.roleName || getRoleDisplayName(roleOrRoleId.roleId);
+    },
+    [],
+  );
 
   return {
     // State

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -68,7 +68,7 @@ export class UserManagementService {
         contact.contactroles?.map((cr: ContactRole) => ({
           id: cr.id,
           roleId: cr.roleId,
-          roleName: getRoleDisplayName(cr.roleId),
+          roleName: cr.roleName || getRoleDisplayName(cr.roleId),
           roleData: cr.roleData,
         })) || [],
     }));
@@ -131,7 +131,7 @@ export class UserManagementService {
         contact.contactroles?.map((cr: ContactRole) => ({
           id: cr.id,
           roleId: cr.roleId,
-          roleName: getRoleDisplayName(cr.roleId),
+          roleName: cr.roleName || getRoleDisplayName(cr.roleId),
           roleData: cr.roleData,
         })) || [],
     }));

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -2,6 +2,7 @@
 export interface ContactRole {
   id: string;
   roleId: string;
+  roleName?: string;
   roleData: string;
 }
 
@@ -84,7 +85,7 @@ export interface UserTableProps {
   onNextPage: () => void;
   onPrevPage: () => void;
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  getRoleDisplayName: (roleId: string) => string;
+  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
 }
 
 export interface UserSearchBarProps {
@@ -100,14 +101,14 @@ export interface UserCardProps {
   canManageUsers: boolean;
   onAssignRole: (user: User) => void;
   onRemoveRole: (user: User, role: UserRole) => void;
-  getRoleDisplayName: (roleId: string) => string;
+  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
 }
 
 export interface UserRoleChipsProps {
   roles: UserRole[];
   canManageUsers: boolean;
   onRemoveRole: (role: UserRole) => void;
-  getRoleDisplayName: (roleId: string) => string;
+  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
 }
 
 export interface AssignRoleDialogProps {
@@ -182,5 +183,5 @@ export interface UseUserManagementReturn {
   setSearchTerm: (term: string) => void;
   setError: (error: string | null) => void;
   setSuccess: (success: string | null) => void;
-  getRoleDisplayName: (roleId: string) => string;
+  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
 }


### PR DESCRIPTION
- Update ContactRole interface to include optional roleName field
- Modify userManagementService to use cr.roleName with fallback to getRoleDisplayName
- Update useUserManagement hook to support both role object and roleId parameters
- Update UserRoleChips component to pass role object instead of roleId
- Update TypeScript interfaces to support new function signatures
- Eliminate unnecessary role ID to name conversions in frontend
- Improve performance by using authoritative role names from backend
- Maintain backward compatibility with fallback behavior