### PR TITLE
feat: Enhance role display with contextName support

### DIFF
--- a/draco-nodejs/frontend-next/components/users/UserRoleChips.tsx
+++ b/draco-nodejs/frontend-next/components/users/UserRoleChips.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Stack, Chip, Typography } from '@mui/material';
+import { Stack, Chip } from '@mui/material';
 import { UserRoleChipsProps } from '../../types/users';
 
 /**
@@ -15,11 +15,7 @@ const UserRoleChips: React.FC<UserRoleChipsProps> = ({
   getRoleDisplayName,
 }) => {
   if (!roles || roles.length === 0) {
-    return (
-      <Typography variant="body2" color="text.secondary">
-        No roles assigned
-      </Typography>
-    );
+    return null;
   }
 
   return (

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -338,16 +338,20 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     setRemoveRoleDialogOpen(true);
   }, []);
 
-  // Role display name helper - now uses roleName from backend when available
+  // Role display name helper - now uses contextName from backend for role display
   const getRoleDisplayNameHelper = useCallback(
-    (roleOrRoleId: string | { roleId: string; roleName?: string }): string => {
+    (
+      roleOrRoleId:
+        | string
+        | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+    ): string => {
       // Handle both string (roleId) and object (role) parameters for backward compatibility
       if (typeof roleOrRoleId === 'string') {
         return getRoleDisplayName(roleOrRoleId);
       }
 
-      // Use roleName from backend if available, otherwise fall back to conversion
-      return roleOrRoleId.roleName || getRoleDisplayName(roleOrRoleId.roleId);
+      // Pass the full role object to getRoleDisplayName to handle contextName
+      return getRoleDisplayName(roleOrRoleId);
     },
     [],
   );

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -70,6 +70,7 @@ export class UserManagementService {
           roleId: cr.roleId,
           roleName: cr.roleName || getRoleDisplayName(cr.roleId),
           roleData: cr.roleData,
+          contextName: cr.contextName,
         })) || [],
     }));
 
@@ -133,6 +134,7 @@ export class UserManagementService {
           roleId: cr.roleId,
           roleName: cr.roleName || getRoleDisplayName(cr.roleId),
           roleData: cr.roleData,
+          contextName: cr.contextName,
         })) || [],
     }));
 

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -4,6 +4,7 @@ export interface ContactRole {
   roleId: string;
   roleName?: string;
   roleData: string;
+  contextName?: string;
 }
 
 export interface Contact {
@@ -43,6 +44,7 @@ export interface UserRole {
   roleId: string;
   roleName: string;
   roleData: string;
+  contextName?: string;
 }
 
 export interface Role {
@@ -85,7 +87,11 @@ export interface UserTableProps {
   onNextPage: () => void;
   onPrevPage: () => void;
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
+  getRoleDisplayName: (
+    roleOrRoleId:
+      | string
+      | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+  ) => string;
 }
 
 export interface UserSearchBarProps {
@@ -101,14 +107,22 @@ export interface UserCardProps {
   canManageUsers: boolean;
   onAssignRole: (user: User) => void;
   onRemoveRole: (user: User, role: UserRole) => void;
-  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
+  getRoleDisplayName: (
+    roleOrRoleId:
+      | string
+      | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+  ) => string;
 }
 
 export interface UserRoleChipsProps {
   roles: UserRole[];
   canManageUsers: boolean;
   onRemoveRole: (role: UserRole) => void;
-  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
+  getRoleDisplayName: (
+    roleOrRoleId:
+      | string
+      | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+  ) => string;
 }
 
 export interface AssignRoleDialogProps {
@@ -183,5 +197,9 @@ export interface UseUserManagementReturn {
   setSearchTerm: (term: string) => void;
   setError: (error: string | null) => void;
   setSuccess: (success: string | null) => void;
-  getRoleDisplayName: (roleOrRoleId: string | { roleId: string; roleName?: string }) => string;
+  getRoleDisplayName: (
+    roleOrRoleId:
+      | string
+      | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+  ) => string;
 }

--- a/draco-nodejs/frontend-next/utils/roleUtils.ts
+++ b/draco-nodejs/frontend-next/utils/roleUtils.ts
@@ -34,12 +34,46 @@ export const ROLE_DISPLAY_NAMES: Record<string, string> = {
   PhotoAdmin: 'Photo Administrator',
 };
 
+// Account-level roles that should not display contextName
+export const ACCOUNT_LEVEL_ROLES = [
+  'Administrator',
+  'AccountAdmin',
+  'AccountPhotoAdmin',
+  'PhotoAdmin',
+];
+
 /**
- * Get human-readable display name for a role ID
- * @param roleId - The role ID (GUID or name)
+ * Get human-readable display name for a role ID or role object
+ * @param roleOrRoleId - The role ID (GUID or name) or role object with contextName
  * @returns The display name for the role
  */
-export function getRoleDisplayName(roleId: string): string {
+export function getRoleDisplayName(
+  roleOrRoleId:
+    | string
+    | { roleId: string; roleName?: string; roleData?: string; contextName?: string },
+): string {
+  // Handle role object with contextName
+  if (typeof roleOrRoleId === 'object' && roleOrRoleId.contextName) {
+    const roleId = roleOrRoleId.roleId;
+    const contextName = roleOrRoleId.contextName;
+
+    // Get the role name from the roleId
+    const roleName = ROLE_ID_TO_NAME[roleId];
+
+    // Check if this is an account-level role
+    if (roleName && ACCOUNT_LEVEL_ROLES.includes(roleName)) {
+      // For account-level roles, don't show contextName
+      return ROLE_DISPLAY_NAMES[roleName] || roleName || roleId;
+    }
+
+    // For non-account-level roles, combine contextName with the base display name
+    const baseDisplayName = ROLE_DISPLAY_NAMES[roleName] || roleName || roleId;
+    return `${contextName} ${baseDisplayName}`;
+  }
+
+  // Handle string roleId (backward compatibility)
+  const roleId = roleOrRoleId as string;
+
   // If it's already a display name, return it
   if (ROLE_DISPLAY_NAMES[roleId]) {
     return ROLE_DISPLAY_NAMES[roleId];


### PR DESCRIPTION
- Update role display to use contextName from backend for contextual role information
- Add contextName field to UserRole and ContactRole interfaces
- Implement logic to exclude contextName for account-level roles (Administrator, AccountAdmin, AccountPhotoAdmin, PhotoAdmin)
- Update getRoleDisplayName function to handle role objects with contextName
- Modify userManagementService to include contextName in data transformations
- Remove 'No roles assigned' text from UserRoleChips component for cleaner UI
- Maintain backward compatibility with existing string-based role ID parameters

Examples:
- Account-level roles: 'Account Administrator' (no context)
- Team roles: 'Tigers Team Administrator' (with team context)
- League roles: '30+ League Administrator' (with league context)