### PR TITLE
fix: standardize role system to use role IDs consistently

### DIFF
--- a/draco-nodejs/backend/src/config/roles.ts
+++ b/draco-nodejs/backend/src/config/roles.ts
@@ -13,6 +13,10 @@ export const ROLE_IDS: Record<string, string> = {
   [RoleType.TEAM_PHOTO_ADMIN]: '',
 };
 
+// Role name mappings (these should match the actual names in the aspnetroles table)
+// These will be populated from the database during initialization
+export const ROLE_NAMES: Record<string, string> = {};
+
 // Role context types
 export enum RoleContextType {
   GLOBAL = 'global',
@@ -80,7 +84,11 @@ export const validateRoleAssignment = (
   _context: RoleDataContext,
 ): boolean => {
   const allowedAssigners = ROLE_ASSIGNMENT_RULES[targetRole] || [];
-  return allowedAssigners.some((role: string) => assignerRoles.includes(role));
+  console.log('allowedAssigners:', allowedAssigners);
+  const isAllowed = allowedAssigners.some((role: string) => assignerRoles.includes(role));
+  console.log('validateRoleAssignment:', assignerRoles, targetRole, _context);
+  console.log('isAllowed:', isAllowed);
+  return isAllowed;
 };
 
 export const getInheritedRoles = (role: string): string[] => {
@@ -123,6 +131,7 @@ export const initializeRoleIds = async (prisma: {
     roles.forEach((role: { id: string; name: string }) => {
       if (Object.prototype.hasOwnProperty.call(ROLE_IDS, role.name)) {
         ROLE_IDS[role.name] = role.id;
+        ROLE_NAMES[role.id] = role.name;
       }
     });
   } catch (error) {

--- a/draco-nodejs/backend/src/routes/accounts.ts
+++ b/draco-nodejs/backend/src/routes/accounts.ts
@@ -7,7 +7,7 @@ import { ServiceFactory } from '../lib/serviceFactory';
 import { Prisma } from '@prisma/client';
 import { isEmail } from 'validator';
 import { isValidAccountUrl, normalizeUrl } from '../utils/validation';
-import { ContactRole } from '../types/roles';
+import { ContactRole, RoleType } from '../types/roles';
 import { asyncHandler } from '../utils/asyncHandler';
 import {
   ValidationError,
@@ -27,6 +27,7 @@ import { getLogoUrl } from '../config/logo';
 import { PaginationHelper } from '../utils/pagination';
 import prisma from '../lib/prisma';
 import { ContactService } from '../services/contactService';
+import { ROLE_IDS } from '../config/roles';
 
 const router = Router({ mergeParams: true });
 export const roleService = ServiceFactory.getRoleService();
@@ -372,7 +373,7 @@ router.get(
     const userId = req.user!.id;
 
     // Check if user is global administrator
-    const isAdmin = await roleService.hasRole(userId, 'Administrator', {
+    const isAdmin = await roleService.hasRole(userId, ROLE_IDS[RoleType.ADMINISTRATOR], {
       accountId: undefined,
     });
 

--- a/draco-nodejs/backend/src/services/roleService.ts
+++ b/draco-nodejs/backend/src/services/roleService.ts
@@ -109,7 +109,7 @@ export class RoleService implements IRoleService {
       }
 
       // TeamAdmin roleId constant (should match your config)
-      const TEAM_ADMIN_ROLE_ID = ROLE_IDS['TeamAdmin'];
+      const TEAM_ADMIN_ROLE_ID = ROLE_IDS[RoleType.TEAM_ADMIN];
 
       // Build a set of teamSeasonIds where the user already has TeamAdmin via contactRoles
       const existingTeamAdminIds = new Set(

--- a/draco-nodejs/backend/src/services/roleService.ts
+++ b/draco-nodejs/backend/src/services/roleService.ts
@@ -8,6 +8,7 @@ import {
   RoleCheckResult,
   RoleContext,
   ROLE_PERMISSIONS,
+  RoleType,
 } from '../types/roles';
 import { ROLE_IDS, validateRoleAssignment, hasRoleOrHigher } from '../config/roles';
 import { IRoleService } from '../interfaces/roleInterfaces';
@@ -108,7 +109,7 @@ export class RoleService implements IRoleService {
       }
 
       // TeamAdmin roleId constant (should match your config)
-      const TEAM_ADMIN_ROLE_ID = '777D771B-1CBA-4126-B8F3-DD7F3478D40E';
+      const TEAM_ADMIN_ROLE_ID = ROLE_IDS['TeamAdmin'];
 
       // Build a set of teamSeasonIds where the user already has TeamAdmin via contactRoles
       const existingTeamAdminIds = new Set(
@@ -430,11 +431,15 @@ export class RoleService implements IRoleService {
    * Get role level based on role ID
    */
   private getRoleLevel(roleId: string): 'global' | 'account' | 'team' | 'league' | 'none' {
-    if (roleId === ROLE_IDS['Administrator']) return 'global';
-    if (roleId === ROLE_IDS['AccountAdmin'] || roleId === ROLE_IDS['AccountPhotoAdmin'])
+    if (roleId === ROLE_IDS[RoleType.ADMINISTRATOR]) return 'global';
+    if (
+      roleId === ROLE_IDS[RoleType.ACCOUNT_ADMIN] ||
+      roleId === ROLE_IDS[RoleType.ACCOUNT_PHOTO_ADMIN]
+    )
       return 'account';
-    if (roleId === ROLE_IDS['TeamAdmin'] || roleId === ROLE_IDS['TeamPhotoAdmin']) return 'team';
-    if (roleId === ROLE_IDS['LeagueAdmin']) return 'league';
+    if (roleId === ROLE_IDS[RoleType.TEAM_ADMIN] || roleId === ROLE_IDS[RoleType.TEAM_PHOTO_ADMIN])
+      return 'team';
+    if (roleId === ROLE_IDS[RoleType.LEAGUE_ADMIN]) return 'league';
     return 'none';
   }
 

--- a/draco-nodejs/frontend-next/components/RoleBasedNavigation.tsx
+++ b/draco-nodejs/frontend-next/components/RoleBasedNavigation.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { useRole } from '../context/RoleContext';
+import { ROLE_NAME_TO_ID } from '@/utils/roleUtils';
 
 interface RoleBasedNavigationProps {
   children: ReactNode;
@@ -19,7 +20,7 @@ export const RoleBasedNavigation: React.FC<RoleBasedNavigationProps> = ({
   requiredRole,
   requiredPermission,
   context,
-  fallback = null
+  fallback = null,
 }) => {
   const { hasRole, hasPermission } = useRole();
 
@@ -43,25 +44,22 @@ export const RoleBasedNavigation: React.FC<RoleBasedNavigationProps> = ({
 };
 
 // Convenience components for common navigation patterns
-export const AdminOnly: React.FC<{ children: ReactNode; fallback?: ReactNode }> = ({ 
-  children, 
-  fallback 
+export const AdminOnly: React.FC<{ children: ReactNode; fallback?: ReactNode }> = ({
+  children,
+  fallback,
 }) => (
-  <RoleBasedNavigation 
-    requiredRole="93DAC465-4C64-4422-B444-3CE79C549329"
-    fallback={fallback}
-  >
+  <RoleBasedNavigation requiredRole={ROLE_NAME_TO_ID['Administrator']} fallback={fallback}>
     {children}
   </RoleBasedNavigation>
 );
 
-export const AccountAdminOnly: React.FC<{ 
-  children: ReactNode; 
+export const AccountAdminOnly: React.FC<{
+  children: ReactNode;
   accountId?: string;
   fallback?: ReactNode;
 }> = ({ children, accountId, fallback }) => (
-  <RoleBasedNavigation 
-    requiredRole="5F00A9E0-F42E-49B4-ABD9-B2DCEDD2BB8A"
+  <RoleBasedNavigation
+    requiredRole={ROLE_NAME_TO_ID['AccountAdmin']}
     context={accountId ? { accountId } : undefined}
     fallback={fallback}
   >
@@ -69,13 +67,13 @@ export const AccountAdminOnly: React.FC<{
   </RoleBasedNavigation>
 );
 
-export const LeagueAdminOnly: React.FC<{ 
-  children: ReactNode; 
+export const LeagueAdminOnly: React.FC<{
+  children: ReactNode;
   leagueId?: string;
   fallback?: ReactNode;
 }> = ({ children, leagueId, fallback }) => (
-  <RoleBasedNavigation 
-    requiredRole="672DDF06-21AC-4D7C-B025-9319CC69281A"
+  <RoleBasedNavigation
+    requiredRole={ROLE_NAME_TO_ID['LeagueAdmin']}
     context={leagueId ? { leagueId } : undefined}
     fallback={fallback}
   >
@@ -83,13 +81,13 @@ export const LeagueAdminOnly: React.FC<{
   </RoleBasedNavigation>
 );
 
-export const TeamAdminOnly: React.FC<{ 
-  children: ReactNode; 
+export const TeamAdminOnly: React.FC<{
+  children: ReactNode;
   teamId?: string;
   fallback?: ReactNode;
 }> = ({ children, teamId, fallback }) => (
-  <RoleBasedNavigation 
-    requiredRole="777D771B-1CBA-4126-B8F3-DD7F3478D40E"
+  <RoleBasedNavigation
+    requiredRole={ROLE_NAME_TO_ID['TeamAdmin']}
     context={teamId ? { teamId } : undefined}
     fallback={fallback}
   >
@@ -97,17 +95,13 @@ export const TeamAdminOnly: React.FC<{
   </RoleBasedNavigation>
 );
 
-export const PermissionBasedNavigation: React.FC<{ 
-  children: ReactNode; 
+export const PermissionBasedNavigation: React.FC<{
+  children: ReactNode;
   permission: string;
   context?: RoleBasedNavigationProps['context'];
   fallback?: ReactNode;
 }> = ({ children, permission, context, fallback }) => (
-  <RoleBasedNavigation 
-    requiredPermission={permission}
-    context={context}
-    fallback={fallback}
-  >
+  <RoleBasedNavigation requiredPermission={permission} context={context} fallback={fallback}>
     {children}
   </RoleBasedNavigation>
-); 
+);


### PR DESCRIPTION
- Update roleService.ts to return role IDs instead of role names for global roles
- Modify routeProtection.ts to compare against ROLE_IDS instead of RoleType values
- Update contactService.ts to use role ID comparisons consistently
- Enhance roles.ts configuration with better role ID mapping
- Update accounts.ts routes to use standardized role checking
- Fix RoleBasedNavigation.tsx to handle role ID-based permissions
- Ensure consistent behavior between global and contact roles
- Improve system robustness by removing dependency on role name strings

This change addresses the inconsistency where global roles returned names while contact roles returned IDs, making the system more maintainable and aligned with database design principles.