### PR TITLE
fix: enhance role assignment and removal functionality

### DIFF
--- a/draco-nodejs/backend/src/routes/accounts-contacts.ts
+++ b/draco-nodejs/backend/src/routes/accounts-contacts.ts
@@ -150,7 +150,19 @@ router.delete(
       throw new ValidationError('Role data is required');
     }
 
-    await roleService.removeRole(req.user!.id, contactId, roleId, BigInt(roleData), accountId);
+    const wasRemoved = await roleService.removeRole(
+      req.user!.id,
+      contactId,
+      roleId,
+      BigInt(roleData),
+      accountId,
+    );
+
+    if (!wasRemoved) {
+      throw new ValidationError(
+        'Role not found or roleData does not match. Unable to remove role.',
+      );
+    }
 
     res.json({
       success: true,

--- a/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
@@ -61,9 +61,11 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
     handleAssignRole,
     handleRemoveRole,
     openAssignRoleDialog,
+    closeAssignRoleDialog,
     openRemoveRoleDialog,
     setAssignRoleDialogOpen,
     setRemoveRoleDialogOpen,
+    setSelectedUser,
     setSelectedRole,
     setNewUserContactId,
     setSelectedLeagueId,
@@ -90,6 +92,8 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
             variant="contained"
             startIcon={<AddIcon />}
             onClick={async () => {
+              setSelectedUser(null); // Clear any preselected user
+              setNewUserContactId(''); // Clear contact ID
               setAssignRoleDialogOpen(true);
               await loadContextData();
             }}
@@ -156,7 +160,7 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
       {/* Dialog Sections */}
       <AssignRoleDialog
         open={assignRoleDialogOpen}
-        onClose={() => setAssignRoleDialogOpen(false)}
+        onClose={closeAssignRoleDialog}
         onAssign={handleAssignRole}
         selectedRole={selectedRole}
         newUserContactId={newUserContactId}
@@ -165,6 +169,9 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
         onRoleChange={setSelectedRole}
         loading={formLoading}
         accountId={accountId}
+        // Pre-population props
+        preselectedUser={selectedUser}
+        isUserReadonly={!!selectedUser}
         // Context data props
         leagues={leagues}
         teams={teams}

--- a/draco-nodejs/frontend-next/components/users/AssignRoleDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/AssignRoleDialog.tsx
@@ -13,13 +13,14 @@ import {
   Select,
   MenuItem,
   CircularProgress,
+  Typography,
 } from '@mui/material';
-import { Add as AddIcon } from '@mui/icons-material';
+import { Add as AddIcon, Person as PersonIcon } from '@mui/icons-material';
 import { AssignRoleDialogProps } from '../../types/users';
 import ContactAutocomplete from '../ContactAutocomplete';
 import LeagueSelector from '../LeagueSelector';
 import TeamSelector from '../TeamSelector';
-import { getRoleDisplayName } from '../../utils/roleUtils';
+import { getRoleDisplayName, isTeamBasedRole, isLeagueBasedRole } from '../../utils/roleUtils';
 
 /**
  * AssignRoleDialog Component
@@ -36,6 +37,9 @@ const AssignRoleDialog: React.FC<AssignRoleDialogProps> = ({
   onRoleChange,
   loading,
   accountId,
+  // Pre-population props
+  preselectedUser,
+  isUserReadonly = false,
   // Context data props
   leagues = [],
   teams = [],
@@ -47,23 +51,49 @@ const AssignRoleDialog: React.FC<AssignRoleDialogProps> = ({
   contextDataLoading = false,
 }) => {
   // Determine which role is selected to show appropriate context selector
-  const selectedRoleData = roles.find((role) => role.id === selectedRole);
-  const roleDisplayName = selectedRoleData ? getRoleDisplayName(selectedRoleData.id) : '';
-  const isLeagueAdmin = roleDisplayName === 'League Administrator';
-  const isTeamAdmin = roleDisplayName === 'Team Administrator';
+  const isLeagueAdmin = selectedRole ? isLeagueBasedRole(selectedRole) : false;
+  const isTeamAdmin = selectedRole ? isTeamBasedRole(selectedRole) : false;
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Assign Role to User</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
-          <ContactAutocomplete
-            label="Select User"
-            value={newUserContactId}
-            onChange={onUserChange}
-            required
-            accountId={accountId}
-          />
+          {preselectedUser && isUserReadonly ? (
+            <Stack spacing={1}>
+              <Typography variant="body2" color="text.secondary">
+                Assigning role to:
+              </Typography>
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={1}
+                sx={{
+                  p: 2,
+                  bgcolor: 'grey.50',
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'grey.300',
+                }}
+              >
+                <PersonIcon color="action" />
+                <Typography variant="subtitle2" fontWeight="bold">
+                  {preselectedUser.firstName} {preselectedUser.lastName}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  ({preselectedUser.email})
+                </Typography>
+              </Stack>
+            </Stack>
+          ) : (
+            <ContactAutocomplete
+              label="Select User"
+              value={newUserContactId}
+              onChange={onUserChange}
+              required
+              accountId={accountId}
+            />
+          )}
           <FormControl fullWidth required>
             <InputLabel>Role</InputLabel>
             <Select

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -393,7 +393,12 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
       setFormLoading(true);
       setError(null);
 
-      await userService.removeRole(accountId, selectedUser.id, selectedRoleToRemove.roleId);
+      await userService.removeRole(
+        accountId,
+        selectedUser.id,
+        selectedRoleToRemove.roleId,
+        selectedRoleToRemove.roleData,
+      );
 
       setSuccess('Role removed successfully');
       setRemoveRoleDialogOpen(false);
@@ -406,18 +411,6 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
       setFormLoading(false);
     }
   }, [selectedUser, selectedRoleToRemove, userService, accountId, page, loadUsers]);
-
-  // Dialog open handlers
-  const openAssignRoleDialog = useCallback((user: User) => {
-    setSelectedUser(user);
-    setAssignRoleDialogOpen(true);
-  }, []);
-
-  const openRemoveRoleDialog = useCallback((user: User, role: UserRole) => {
-    setSelectedUser(user);
-    setSelectedRoleToRemove(role);
-    setRemoveRoleDialogOpen(true);
-  }, []);
 
   // Context data loading function
   const loadContextData = useCallback(async () => {
@@ -447,6 +440,32 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
       setContextDataLoading(false);
     }
   }, [contextDataService, accountId, currentSeasonId]);
+
+  // Dialog open handlers
+  const openAssignRoleDialog = useCallback(
+    async (user: User) => {
+      setSelectedUser(user);
+      setNewUserContactId(user.id); // Pre-populate with the user's contact ID
+      setAssignRoleDialogOpen(true);
+      await loadContextData(); // Load leagues and teams data
+    },
+    [loadContextData],
+  );
+
+  const closeAssignRoleDialog = useCallback(() => {
+    setAssignRoleDialogOpen(false);
+    setSelectedUser(null);
+    setSelectedRole('');
+    setNewUserContactId('');
+    setSelectedLeagueId('');
+    setSelectedTeamId('');
+  }, []);
+
+  const openRemoveRoleDialog = useCallback((user: User, role: UserRole) => {
+    setSelectedUser(user);
+    setSelectedRoleToRemove(role);
+    setRemoveRoleDialogOpen(true);
+  }, []);
 
   // Role display name helper - now uses contextName from backend for role display
   const getRoleDisplayNameHelper = useCallback(
@@ -508,6 +527,7 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     handleAssignRole,
     handleRemoveRole,
     openAssignRoleDialog,
+    closeAssignRoleDialog,
     openRemoveRoleDialog,
     setAssignRoleDialogOpen,
     setRemoveRoleDialogOpen,

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -245,7 +245,12 @@ export class UserManagementService {
   /**
    * Remove a role from a user
    */
-  async removeRole(accountId: string, contactId: string, roleId: string): Promise<void> {
+  async removeRole(
+    accountId: string,
+    contactId: string,
+    roleId: string,
+    roleData: string,
+  ): Promise<void> {
     const response = await fetch(
       `/api/accounts/${accountId}/contacts/${contactId}/roles/${roleId}`,
       {
@@ -255,7 +260,7 @@ export class UserManagementService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          roleData: accountId,
+          roleData: roleData,
         }),
       },
     );

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -80,7 +80,7 @@ export interface UserSearchParams {
 export interface UserTableProps {
   users: User[];
   loading: boolean;
-  onAssignRole: (user: User) => void;
+  onAssignRole: (user: User) => Promise<void>;
   onRemoveRole: (user: User, role: UserRole) => void;
   canManageUsers: boolean;
   page: number;
@@ -108,7 +108,7 @@ export interface UserSearchBarProps {
 export interface UserCardProps {
   user: User;
   canManageUsers: boolean;
-  onAssignRole: (user: User) => void;
+  onAssignRole: (user: User) => Promise<void>;
   onRemoveRole: (user: User, role: UserRole) => void;
   getRoleDisplayName: (
     roleOrRoleId:
@@ -139,6 +139,9 @@ export interface AssignRoleDialogProps {
   onRoleChange: (roleId: string) => void;
   loading: boolean;
   accountId: string;
+  // Pre-population props
+  preselectedUser?: User | null;
+  isUserReadonly?: boolean;
   // Context data props
   leagues?: League[];
   teams?: Team[];
@@ -162,7 +165,7 @@ export interface RemoveRoleDialogProps {
 export interface UserActionsProps {
   user: User;
   canManageUsers: boolean;
-  onAssignRole: (user: User) => void;
+  onAssignRole: (user: User) => Promise<void>;
 }
 
 // Hook return types
@@ -207,7 +210,8 @@ export interface UseUserManagementReturn {
   handleRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleAssignRole: () => void;
   handleRemoveRole: () => void;
-  openAssignRoleDialog: (user: User) => void;
+  openAssignRoleDialog: (user: User) => Promise<void>;
+  closeAssignRoleDialog: () => void;
   openRemoveRoleDialog: (user: User, role: UserRole) => void;
   setAssignRoleDialogOpen: (open: boolean) => void;
   setRemoveRoleDialogOpen: (open: boolean) => void;

--- a/draco-nodejs/frontend-next/utils/roleUtils.ts
+++ b/draco-nodejs/frontend-next/utils/roleUtils.ts
@@ -136,3 +136,27 @@ export function getAvailableRoleNames(): string[] {
 export function getAvailableRoleIds(): string[] {
   return Object.values(ROLE_NAME_TO_ID);
 }
+
+// Role classification for UI behavior
+export const TEAM_BASED_ROLES = ['TeamAdmin', 'TeamPhotoAdmin'];
+export const LEAGUE_BASED_ROLES = ['LeagueAdmin'];
+
+/**
+ * Check if a role requires team selection
+ * @param roleId - The role ID (GUID) or role name
+ * @returns True if the role requires team selection
+ */
+export function isTeamBasedRole(roleId: string): boolean {
+  const roleName = ROLE_ID_TO_NAME[roleId] || roleId;
+  return TEAM_BASED_ROLES.includes(roleName);
+}
+
+/**
+ * Check if a role requires league selection
+ * @param roleId - The role ID (GUID) or role name
+ * @returns True if the role requires league selection
+ */
+export function isLeagueBasedRole(roleId: string): boolean {
+  const roleName = ROLE_ID_TO_NAME[roleId] || roleId;
+  return LEAGUE_BASED_ROLES.includes(roleName);
+}


### PR DESCRIPTION
Fixes multiple issues with role assignment and removal workflow:

**Role Assignment Improvements:**
- Auto-populate user field when assigning roles from UserCard
- Make user field readonly when pre-selected to prevent errors
- Add role classification utilities for maintainable UI logic
- Replace hardcoded role checks with `isTeamBasedRole()` and `isLeagueBasedRole()`
- Ensure Team Photo Administrator role shows team selection dropdown
- Apply DRY principles - both assign role flows now load context data consistently

**Role Removal Fixes:**
- Fix backend route handler to check if role was actually removed
- Return proper error when role removal fails instead of always claiming success
- Update frontend to pass correct roleData (team/league ID) instead of always using account ID
- Ensures team and league roles can be properly removed

**Key Benefits:**
- Team Photo Admin and other team-based roles now show appropriate selectors
- Role removal works correctly for all role types (account, team, league)
- Better error handling with accurate success/failure responses
- Improved UX with pre-populated user selection and readonly fields
- Maintainable role classification system for future role additions

🤖 Generated with [Claude Code](https://claude.ai/code)