### PR TITLE
Implement automatic roles display system

### DIFF
--- a/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
+++ b/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
@@ -165,3 +165,26 @@ export interface TeamManagerRaw {
   teamseasonid: bigint;
   teamname: string;
 }
+
+// Interface for raw account owner query result from getAutomaticRoleHolders
+export interface AccountOwnerRaw {
+  id: bigint;
+  firstname: string;
+  lastname: string;
+  email: string | null;
+  userid: string | null;
+}
+
+// Team manager with associated teams (extends BaseContact)
+export interface TeamManagerWithTeams extends BaseContact {
+  teams: Array<{
+    teamSeasonId: string;
+    teamName: string;
+  }>;
+}
+
+// Clean return type for getAutomaticRoleHolders
+export interface AutomaticRoleHoldersResponse {
+  accountOwner: BaseContact; // NOT nullable - every account must have owner
+  teamManagers: TeamManagerWithTeams[];
+}

--- a/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
+++ b/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
@@ -155,3 +155,13 @@ export interface RawManager {
     email: string | null;
   };
 }
+
+// Interface for raw team manager query result from getAutomaticRoleHolders
+export interface TeamManagerRaw {
+  contactid: bigint;
+  firstname: string;
+  lastname: string;
+  email: string | null;
+  teamseasonid: bigint;
+  teamname: string;
+}

--- a/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
+++ b/draco-nodejs/backend/src/interfaces/contactInterfaces.ts
@@ -156,16 +156,6 @@ export interface RawManager {
   };
 }
 
-// Interface for raw team manager query result from getAutomaticRoleHolders
-export interface TeamManagerRaw {
-  contactid: bigint;
-  firstname: string;
-  lastname: string;
-  email: string | null;
-  teamseasonid: bigint;
-  teamname: string;
-}
-
 // Interface for raw account owner query result from getAutomaticRoleHolders
 export interface AccountOwnerRaw {
   id: bigint;

--- a/draco-nodejs/backend/src/routes/accounts-contacts.ts
+++ b/draco-nodejs/backend/src/routes/accounts-contacts.ts
@@ -260,6 +260,27 @@ router.get(
 );
 
 /**
+ * GET /api/accounts/:accountId/automatic-role-holders
+ * Get automatic role holders (Account Owner and Team Managers) for the current season
+ */
+router.get(
+  '/:accountId/automatic-role-holders',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('account.contacts.manage'),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId } = extractAccountParams(req.params);
+
+    const result = await ContactService.getAutomaticRoleHolders(accountId);
+
+    res.json({
+      success: true,
+      data: result,
+    });
+  }),
+);
+
+/**
  * PUT /api/accounts/:accountId/contacts/:contactId
  * Update contact information (includes photo upload)
  */

--- a/draco-nodejs/backend/src/services/roleService.ts
+++ b/draco-nodejs/backend/src/services/roleService.ts
@@ -291,7 +291,9 @@ export class RoleService implements IRoleService {
 
           if (isTeamManager) {
             const roleName =
-              roleId === ROLE_IDS[RoleType.TEAM_ADMIN] ? 'TeamAdmin' : 'TeamPhotoAdmin';
+              roleId === ROLE_IDS[RoleType.TEAM_ADMIN]
+                ? RoleType.TEAM_ADMIN
+                : RoleType.TEAM_PHOTO_ADMIN;
             throw new Error(
               `Cannot assign ${roleName} role - user is already a team manager and has this role automatically`,
             );
@@ -307,13 +309,13 @@ export class RoleService implements IRoleService {
         // Account roles: roleData must be the accountId
         if (roleData !== accountId) {
           throw new Error(
-            `For ${roleId === ROLE_IDS[RoleType.ACCOUNT_ADMIN] ? 'AccountAdmin' : 'AccountPhotoAdmin'} role, roleData must be the accountId (${accountId}), but received ${roleData}`,
+            `For ${roleId === ROLE_IDS[RoleType.ACCOUNT_ADMIN] ? RoleType.ACCOUNT_ADMIN : RoleType.ACCOUNT_PHOTO_ADMIN} role, roleData must be the accountId (${accountId}), but received ${roleData}`,
           );
         }
       } else if (roleId === ROLE_IDS[RoleType.LEAGUE_ADMIN]) {
         // League role: seasonId is required
         if (!seasonId) {
-          throw new Error('For LeagueAdmin role, seasonId is required');
+          throw new Error(`For ${RoleType.LEAGUE_ADMIN} role, seasonId is required`);
         }
         // roleData must be a valid leagueSeasonId
         const leagueSeason = await this.prisma.leagueseason.findFirst({
@@ -330,7 +332,7 @@ export class RoleService implements IRoleService {
         });
         if (!leagueSeason) {
           throw new Error(
-            `For LeagueAdmin role, roleData must be a valid leagueSeasonId for account ${accountId} and season ${seasonId}, but ${roleData} is not valid`,
+            `For ${RoleType.LEAGUE_ADMIN} role, roleData must be a valid leagueSeasonId for account ${accountId} and season ${seasonId}, but ${roleData} is not valid`,
           );
         }
       } else if (
@@ -340,7 +342,7 @@ export class RoleService implements IRoleService {
         // Team roles: seasonId is required
         if (!seasonId) {
           throw new Error(
-            `For ${roleId === ROLE_IDS[RoleType.TEAM_ADMIN] ? 'TeamAdmin' : 'TeamPhotoAdmin'} role, seasonId is required`,
+            `For ${roleId === ROLE_IDS[RoleType.TEAM_ADMIN] ? RoleType.TEAM_ADMIN : RoleType.TEAM_PHOTO_ADMIN} role, seasonId is required`,
           );
         }
         // roleData must be a valid teamSeasonId
@@ -357,7 +359,7 @@ export class RoleService implements IRoleService {
         });
         if (!teamSeason) {
           throw new Error(
-            `For ${roleId === ROLE_IDS[RoleType.TEAM_ADMIN] ? 'TeamAdmin' : 'TeamPhotoAdmin'} role, roleData must be a valid teamSeasonId for account ${accountId} and season ${seasonId}, but ${roleData} is not valid`,
+            `For ${roleId === ROLE_IDS[RoleType.TEAM_ADMIN] ? RoleType.TEAM_ADMIN : RoleType.TEAM_PHOTO_ADMIN} role, roleData must be a valid teamSeasonId for account ${accountId} and season ${seasonId}, but ${roleData} is not valid`,
           );
         }
       }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
@@ -11,6 +11,7 @@ import {
 import EditContactDialog from '../../../../components/users/EditContactDialog';
 import DeleteContactDialog from '../../../../components/users/DeleteContactDialog';
 import ConfirmationDialog from '../../../../components/common/ConfirmationDialog';
+import { AutomaticRolesSection } from '../../../../components/users/automatic-roles';
 
 interface UserManagementProps {
   accountId: string;
@@ -60,6 +61,10 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
     selectedLeagueId,
     selectedTeamId,
     contextDataLoading,
+
+    // Automatic role holders states
+    accountOwner,
+    teamManagers,
 
     // Actions
     handleSearch,
@@ -130,6 +135,9 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
           {success}
         </Alert>
       )}
+
+      {/* Automatic Role Holders Section */}
+      <AutomaticRolesSection accountOwner={accountOwner} teamManagers={teamManagers} />
 
       {/* Enhanced User Table with Modern Features */}
       <UserTableEnhanced

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box, Typography, Avatar, Card, CardContent } from '@mui/material';
+import { AccountCircle as CrownIcon } from '@mui/icons-material';
+
+interface AccountOwnerDisplayProps {
+  accountOwner: {
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+  } | null;
+}
+
+const AccountOwnerDisplay: React.FC<AccountOwnerDisplayProps> = ({ accountOwner }) => {
+  if (!accountOwner) {
+    return null;
+  }
+
+  return (
+    <Card
+      sx={{
+        backgroundColor: '#FFF8E1', // Light gold background
+        borderLeft: '4px solid #FFD700', // Gold left border
+        mb: 2,
+      }}
+    >
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <CrownIcon sx={{ color: '#FFD700', fontSize: 32 }} />
+        <Avatar
+          src={accountOwner.photoUrl}
+          alt={`${accountOwner.firstName} ${accountOwner.lastName}`}
+          sx={{ width: 40, height: 40 }}
+        >
+          {accountOwner.firstName[0]}
+          {accountOwner.lastName[0]}
+        </Avatar>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 'bold', color: '#E65100' }}>
+            Account Owner
+          </Typography>
+          <Typography variant="body1">
+            {accountOwner.firstName} {accountOwner.lastName}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {accountOwner.email}
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AccountOwnerDisplay;

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
@@ -9,7 +9,7 @@ interface AccountOwnerDisplayProps {
     lastName: string;
     email: string | null;
     photoUrl?: string;
-  } | null;
+  } | null; // Keep nullable for component safety, but expect it to always have value
 }
 
 const AccountOwnerDisplay: React.FC<AccountOwnerDisplayProps> = ({ accountOwner }) => {

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
@@ -10,7 +10,7 @@ interface AutomaticRolesSectionProps {
     lastName: string;
     email: string | null;
     photoUrl?: string;
-  } | null;
+  } | null; // Keep nullable for component safety, but expect it to always have value
   teamManagers: Array<{
     contactId: string;
     firstName: string;

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box, Typography, Divider } from '@mui/material';
+import AccountOwnerDisplay from './AccountOwnerDisplay';
+import TeamManagersList from './TeamManagersList';
+
+interface AutomaticRolesSectionProps {
+  accountOwner: {
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+  } | null;
+  teamManagers: Array<{
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+    teams: Array<{
+      teamSeasonId: string;
+      teamName: string;
+    }>;
+  }>;
+}
+
+const AutomaticRolesSection: React.FC<AutomaticRolesSectionProps> = ({
+  accountOwner,
+  teamManagers,
+}) => {
+  // Don't render anything if there's no data
+  if (!accountOwner && teamManagers.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography
+        variant="h5"
+        sx={{
+          mb: 2,
+          color: 'text.primary',
+          fontWeight: 'bold',
+        }}
+      >
+        Automatic Role Holders
+      </Typography>
+
+      <AccountOwnerDisplay accountOwner={accountOwner} />
+      <TeamManagersList teamManagers={teamManagers} />
+
+      <Divider sx={{ mt: 3, mb: 3 }} />
+    </Box>
+  );
+};
+
+export default AutomaticRolesSection;

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/TeamManagersList.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/TeamManagersList.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Avatar,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Collapse,
+  IconButton,
+} from '@mui/material';
+import { Groups as ManagerIcon, ExpandMore, ExpandLess } from '@mui/icons-material';
+
+interface TeamManagersListProps {
+  teamManagers: Array<{
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+    teams: Array<{
+      teamSeasonId: string;
+      teamName: string;
+    }>;
+  }>;
+}
+
+const TeamManagersList: React.FC<TeamManagersListProps> = ({ teamManagers }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (teamManagers.length === 0) {
+    return null;
+  }
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <Card
+      sx={{
+        backgroundColor: '#E3F2FD', // Light blue background
+        borderLeft: '4px solid #1976D2', // Blue left border
+        mb: 2,
+      }}
+    >
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ManagerIcon sx={{ color: '#1976D2', fontSize: 24 }} />
+            <Typography variant="h6" sx={{ fontWeight: 'bold', color: '#0D47A1' }}>
+              Team Managers (Current Season) ({teamManagers.length})
+            </Typography>
+          </Box>
+          <IconButton onClick={handleToggle} size="small" sx={{ color: '#1976D2' }}>
+            {isExpanded ? <ExpandLess /> : <ExpandMore />}
+          </IconButton>
+        </Box>
+
+        <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+          <Stack spacing={2} sx={{ mt: 2 }}>
+            {teamManagers.map((manager) => (
+              <Box
+                key={manager.contactId}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  p: 1,
+                  borderRadius: 1,
+                  backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                }}
+              >
+                <Avatar
+                  src={manager.photoUrl}
+                  alt={`${manager.firstName} ${manager.lastName}`}
+                  sx={{ width: 32, height: 32 }}
+                >
+                  {manager.firstName[0]}
+                  {manager.lastName[0]}
+                </Avatar>
+
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="body1" sx={{ fontWeight: 'medium' }}>
+                    {manager.firstName} {manager.lastName}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.85em' }}>
+                    {manager.email}
+                  </Typography>
+                </Box>
+
+                <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                  {manager.teams.map((team) => (
+                    <Chip
+                      key={team.teamSeasonId}
+                      label={team.teamName}
+                      size="small"
+                      variant="outlined"
+                      sx={{
+                        fontSize: '0.75rem',
+                        height: '24px',
+                        borderColor: '#1976D2',
+                        color: '#1976D2',
+                      }}
+                    />
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        </Collapse>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TeamManagersList;

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/index.ts
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/index.ts
@@ -1,0 +1,3 @@
+export { default as AccountOwnerDisplay } from './AccountOwnerDisplay';
+export { default as TeamManagersList } from './TeamManagersList';
+export { default as AutomaticRolesSection } from './AutomaticRolesSection';

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -147,6 +147,29 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
   const [selectedTeamId, setSelectedTeamId] = useState<string>('');
   const [contextDataLoading, setContextDataLoading] = useState(false);
 
+  // Automatic role holders state
+  const [accountOwner, setAccountOwner] = useState<{
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+  } | null>(null);
+  const [teamManagers, setTeamManagers] = useState<
+    Array<{
+      contactId: string;
+      firstName: string;
+      lastName: string;
+      email: string | null;
+      photoUrl?: string;
+      teams: Array<{
+        teamSeasonId: string;
+        teamName: string;
+      }>;
+    }>
+  >([]);
+  const [automaticRolesLoading, setAutomaticRolesLoading] = useState(false);
+
   // Service instances
   const userService = token ? createUserManagementService(token) : null;
   const contextDataService = token ? createContextDataService(token) : null;
@@ -259,6 +282,24 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
       console.error('Failed to load roles:', err);
     }
   }, [userService]);
+  // Load automatic role holders
+  const loadAutomaticRoleHolders = useCallback(async () => {
+    if (!userService) return;
+
+    try {
+      setAutomaticRolesLoading(true);
+      setError(null);
+
+      const automaticRoleHolders = await userService.fetchAutomaticRoleHolders(accountId);
+      setAccountOwner(automaticRoleHolders.accountOwner);
+      setTeamManagers(automaticRoleHolders.teamManagers);
+    } catch (err) {
+      console.error('Failed to load automatic role holders:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load automatic role holders');
+    } finally {
+      setAutomaticRolesLoading(false);
+    }
+  }, [userService, accountId]);
 
   // Update ref when rowsPerPage changes
   useEffect(() => {
@@ -274,6 +315,7 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
           // Load users with the fetched season ID
           loadUsersWithSeason(seasonId);
           loadRoles();
+          loadAutomaticRoleHolders();
           setInitialized(true);
         })
         .catch((err) => {
@@ -281,10 +323,19 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
           // Still load users and roles even if season fetch fails
           loadUsersWithSeason(null);
           loadRoles();
+          loadAutomaticRoleHolders();
           setInitialized(true);
         });
     }
-  }, [token, accountId, initialized, loadRoles, fetchCurrentSeason, loadUsersWithSeason]);
+  }, [
+    token,
+    accountId,
+    initialized,
+    loadRoles,
+    fetchCurrentSeason,
+    loadUsersWithSeason,
+    loadAutomaticRoleHolders,
+  ]);
 
   // Search handler
   const handleSearch = useCallback(async () => {
@@ -1050,6 +1101,11 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     selectedLeagueId,
     selectedTeamId,
     contextDataLoading,
+
+    // Automatic role holders states
+    accountOwner,
+    teamManagers,
+    automaticRolesLoading,
 
     // Actions
     handleSearch,

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -154,7 +154,7 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     lastName: string;
     email: string | null;
     photoUrl?: string;
-  } | null>(null);
+  } | null>(null); // Initialize as null, but will be set once loaded
   const [teamManagers, setTeamManagers] = useState<
     Array<{
       contactId: string;

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -215,14 +215,14 @@ export class UserManagementService {
       contactId: string;
       firstName: string;
       lastName: string;
-      email: string;
+      email: string | null;
       photoUrl?: string;
-    } | null;
+    }; // NOT nullable - every account must have owner
     teamManagers: Array<{
       contactId: string;
       firstName: string;
       lastName: string;
-      email: string;
+      email: string | null;
       photoUrl?: string;
       teams: Array<{
         teamSeasonId: string;

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -208,6 +208,49 @@ export class UserManagementService {
   }
 
   /**
+   * Fetch automatic role holders (Account Owner and Team Managers)
+   */
+  async fetchAutomaticRoleHolders(accountId: string): Promise<{
+    accountOwner: {
+      contactId: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      photoUrl?: string;
+    } | null;
+    teamManagers: Array<{
+      contactId: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      photoUrl?: string;
+      teams: Array<{
+        teamSeasonId: string;
+        teamName: string;
+      }>;
+    }>;
+  }> {
+    const response = await fetch(`/api/accounts/${accountId}/automatic-role-holders`, {
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || 'Failed to load automatic role holders');
+    }
+
+    const data = await response.json();
+    if (!data.success) {
+      throw new Error(data.message || 'Failed to load automatic role holders');
+    }
+
+    return data.data;
+  }
+
+  /**
    * Get current user's roles for debugging
    */
   async getCurrentUserRoles(accountId: string): Promise<{

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -281,6 +281,27 @@ export interface UseUserManagementReturn {
   selectedTeamId: string;
   contextDataLoading: boolean;
 
+  // Automatic role holders states
+  accountOwner: {
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+  } | null;
+  teamManagers: Array<{
+    contactId: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    photoUrl?: string;
+    teams: Array<{
+      teamSeasonId: string;
+      teamName: string;
+    }>;
+  }>;
+  automaticRolesLoading: boolean;
+
   // Actions
   handleSearch: () => void;
   handleClearSearch: () => void;

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -288,7 +288,7 @@ export interface UseUserManagementReturn {
     lastName: string;
     email: string | null;
     photoUrl?: string;
-  } | null;
+  } | null; // Nullable during initialization, but API guarantees account owner exists
   teamManagers: Array<{
     contactId: string;
     firstName: string;


### PR DESCRIPTION
- Remove synthetic AccountAdmin role injection from contacts endpoints
- Remove synthetic TeamAdmin role injection from roleService
- Add getAutomaticRoleHolders method in ContactService with proper transformation pattern
- Add /automatic-role-holders API endpoint with role validation
- Create frontend automatic roles display components:
  * AccountOwnerDisplay: Gold card with crown icon
  * TeamManagersList: Collapsible blue card (collapsed by default) with team chips
  * AutomaticRolesSection: Container component with divider
- Update UserManagement page to display automatic roles separately
- Add role assignment validations to prevent assigning roles to account owners/team managers
- Fix TypeScript interfaces to allow nullable email fields
- Add TeamManagerRaw interface following established database transformation pattern

🤖 Generated with [Claude Code](https://claude.ai/code)