### PR TITLE
feat: copy Claude settings to worktrees

### DIFF
--- a/worktree-init.sh
+++ b/worktree-init.sh
@@ -99,6 +99,15 @@ else
     print_warning "Backend certs directory not found in main repo"
 fi
 
+# Claude settings file
+if [ -f "$MAIN_REPO_PATH/.claude/settings.local.json" ]; then
+    mkdir -p ".claude"
+    cp "$MAIN_REPO_PATH/.claude/settings.local.json" ".claude/settings.local.json"
+    print_success "Copied Claude settings file"
+else
+    print_warning "Claude settings file not found in main repo"
+fi
+
 # Step 2: Copy node_modules if they exist (optional - can save time)
 if [ "$COPY_NODE_MODULES" = true ]; then
     print_status "Checking for existing node_modules..."
@@ -195,6 +204,7 @@ echo ""
 print_status "Summary of actions:"
 echo "  ✓ Copied environment files from main repo"
 echo "  ✓ Copied SSL certificates from main repo"
+echo "  ✓ Copied Claude settings from main repo"
 echo "  ✓ Installed all dependencies"
 echo "  ✓ Generated Prisma client"
 echo "  ✓ Verified build setup"


### PR DESCRIPTION
Add .claude/settings.local.json copying to worktree-init.sh so that worktrees inherit the main repo's Claude Code permissions and settings.

🤖 Generated with [Claude Code](https://claude.ai/code)