### PR TITLE
feat: add project-specific MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena-mcp-server",
+        "--context",
+        "ide-assistant",
+        "--project",
+        "."
+      ],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,3 +205,27 @@ Priority tasks remaining:
 ## Tool Preferences
 
 - **Always use Serena tools when available**
+
+## MCP Server Configuration
+
+This project uses **project-specific MCP server configuration** via `.mcp.json` to ensure consistent tooling across all team members and git worktrees.
+
+### Available MCP Servers
+
+- **serena**: Advanced code analysis and semantic search tools
+- **context7**: Up-to-date library documentation and code examples
+
+### Configuration Details
+
+The `.mcp.json` file in the project root automatically configures:
+- **serena** with proper project path resolution for all worktrees
+- **context7** for accessing latest library documentation
+
+### Benefits
+
+- ✅ **Worktree Compatibility**: MCP servers work in main repo and all git worktrees
+- ✅ **Team Consistency**: All team members get identical MCP server setup
+- ✅ **Version Control**: MCP configuration is tracked and versioned
+- ✅ **Zero Setup**: New team members get MCP servers automatically
+
+**Note**: If you're not seeing MCP servers in a worktree, ensure `.mcp.json` exists in the project root and restart Claude Code.


### PR DESCRIPTION
- Add .mcp.json with serena and context7 MCP servers
- Configure serena with dynamic project path using "." instead of hardcoded path
- Enable MCP servers to work in main repo and all git worktrees
- Update CLAUDE.md with MCP server configuration documentation
- Ensure team consistency with version-controlled MCP setup

Fixes issue where MCP servers weren't available in git worktrees due to hardcoded project paths in user-level ~/.claude.json configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)