### PR TITLE
fix: disable no-img-element ESLint rule for test files

### DIFF
--- a/draco-nodejs/frontend-next/eslint.config.mjs
+++ b/draco-nodejs/frontend-next/eslint.config.mjs
@@ -17,6 +17,12 @@ const eslintConfig = [
     },
   },
   {
+    files: ["**/__tests__/**/*"],
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
+  {
     ignores: [
       "app/social-hub-test/**/*",
     ],


### PR DESCRIPTION
Resolves build warnings in AccountLogoHeader.test.tsx and AccountPageHeader.test.tsx by allowing <img> elements in test mock components where they are appropriate.

🤖 Generated with [Claude Code](https://claude.ai/code)