### PR TITLE
feat(contacts): add revoke registration UX and API

### DIFF
--- a/draco-nodejs/backend/src/utils/auditLogger.ts
+++ b/draco-nodejs/backend/src/utils/auditLogger.ts
@@ -4,7 +4,8 @@ type RegistrationEvent =
   | 'registration_newUser'
   | 'registration_existingUser'
   | 'registration_selfRegister'
-  | 'registration_linkByName';
+  | 'registration_linkByName'
+  | 'registration_revoke';
 
 type RegistrationStatus =
   | 'attempt'
@@ -58,5 +59,3 @@ export function logRegistrationEvent(
   // Intentionally avoid logging sensitive fields
   console.log(JSON.stringify(payload));
 }
-
-

--- a/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
@@ -21,6 +21,8 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
   // Confirmation dialog state for photo deletion
   const [photoDeleteConfirmOpen, setPhotoDeleteConfirmOpen] = useState(false);
   const [contactToDeletePhoto, setContactToDeletePhoto] = useState<string | null>(null);
+  const [revokeConfirmOpen, setRevokeConfirmOpen] = useState(false);
+  const [contactToRevoke, setContactToRevoke] = useState<string | null>(null);
 
   // Use custom hook for all state and logic
   const {
@@ -85,6 +87,7 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
     closeCreateContactDialog,
     handleCreateContact,
     handleDeleteContactPhoto,
+    handleRevokeRegistration,
     openDeleteContactDialog,
     closeDeleteContactDialog,
     handleDeleteContact,
@@ -116,10 +119,30 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
     }
   }, [contactToDeletePhoto, handleDeleteContactPhoto]);
 
+  const handleRevokeWithConfirm = useCallback(async (contactId: string) => {
+    setContactToRevoke(contactId);
+    setRevokeConfirmOpen(true);
+  }, []);
+
+  const confirmRevoke = useCallback(async () => {
+    if (contactToRevoke) {
+      await handleRevokeRegistration(contactToRevoke);
+      setRevokeConfirmOpen(false);
+      setContactToRevoke(null);
+    }
+  }, [contactToRevoke, handleRevokeRegistration]);
+
+  const cancelRevoke = useCallback(() => {
+    setRevokeConfirmOpen(false);
+    setContactToRevoke(null);
+  }, []);
+
   const cancelDeletePhoto = useCallback(() => {
     setPhotoDeleteConfirmOpen(false);
     setContactToDeletePhoto(null);
   }, []);
+
+  // No global event bridge; using explicit prop wiring instead
 
   return (
     <main className="min-h-screen bg-background">
@@ -177,6 +200,7 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
         isShowingSearchResults={isShowingSearchResults}
         searchLoading={searchLoading}
         onDeleteContactPhoto={handleDeleteContactPhotoWithConfirm}
+        onRevokeRegistration={handleRevokeWithConfirm}
         // Filter props
         onlyWithRoles={onlyWithRoles}
         onOnlyWithRolesChange={handleFilterToggle}
@@ -250,6 +274,18 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
         title="Delete Photo"
         message="Are you sure you want to delete this photo? This action cannot be undone."
         confirmText="Delete"
+        cancelText="Cancel"
+        confirmButtonColor="error"
+      />
+
+      {/* Revoke registration confirmation dialog */}
+      <ConfirmationDialog
+        open={revokeConfirmOpen}
+        onClose={cancelRevoke}
+        onConfirm={confirmRevoke}
+        title="Remove Registration"
+        message="Are you sure you want to remove registration for this user? They will no longer be linked to a login."
+        confirmText="Remove"
         cancelText="Cancel"
         confirmButtonColor="error"
       />

--- a/draco-nodejs/frontend-next/components/users/RegistrationStatusChip.tsx
+++ b/draco-nodejs/frontend-next/components/users/RegistrationStatusChip.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import React from 'react';
-import { Tooltip } from '@mui/material';
-import { CheckCircle, PersonOutline } from '@mui/icons-material';
+import React, { useState } from 'react';
+import { Tooltip, Box, IconButton } from '@mui/material';
+import { CheckCircle, PersonOutline, Close as CloseIcon } from '@mui/icons-material';
 
 interface RegistrationStatusChipProps {
   userId: string | null;
+  contactId?: string;
   size?: 'small' | 'medium';
+  canManage?: boolean;
+  onRevoke?: (contactId: string) => void;
 }
 
 /**
@@ -15,18 +18,62 @@ interface RegistrationStatusChipProps {
  */
 const RegistrationStatusChip: React.FC<RegistrationStatusChipProps> = ({
   userId,
+  contactId,
   size = 'small',
+  canManage = false,
+  onRevoke,
 }) => {
+  const [isHovered, setIsHovered] = useState(false);
   const isRegistered = !!userId;
 
+  const icon = isRegistered ? (
+    <CheckCircle color="success" fontSize={size === 'small' ? 'small' : 'medium'} />
+  ) : (
+    <PersonOutline color="action" fontSize={size === 'small' ? 'small' : 'medium'} />
+  );
+
   return (
-    <Tooltip title={isRegistered ? 'Registered' : 'Not registered'} placement="top" arrow>
-      {isRegistered ? (
-        <CheckCircle color="success" fontSize={size === 'small' ? 'small' : 'medium'} />
-      ) : (
-        <PersonOutline color="action" fontSize={size === 'small' ? 'small' : 'medium'} />
+    <Box
+      sx={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Tooltip title={isRegistered ? 'Registered' : 'Not registered'} placement="top" arrow>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>{icon}</Box>
+      </Tooltip>
+
+      {isRegistered && canManage && onRevoke && contactId && isHovered && (
+        <Tooltip title="Remove registration">
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRevoke(contactId);
+            }}
+            sx={{
+              position: 'absolute',
+              top: -6,
+              right: -6,
+              backgroundColor: 'background.paper',
+              color: 'error.main',
+              boxShadow: 2,
+              '&:hover': {
+                backgroundColor: 'error.main',
+                color: 'white',
+              },
+              padding: '2px',
+              width: size === 'small' ? 20 : 24,
+              height: size === 'small' ? 20 : 24,
+            }}
+          >
+            <CloseIcon
+              fontSize={size === 'small' ? 'inherit' : 'small'}
+              sx={{ fontSize: size === 'small' ? 12 : 16 }}
+            />
+          </IconButton>
+        </Tooltip>
       )}
-    </Tooltip>
+    </Box>
   );
 };
 

--- a/draco-nodejs/frontend-next/components/users/UserCard.tsx
+++ b/draco-nodejs/frontend-next/components/users/UserCard.tsx
@@ -26,6 +26,7 @@ const UserCard: React.FC<UserCardProps> = ({
   onDeleteContact,
   onDeleteContactPhoto,
   getRoleDisplayName,
+  onRevokeRegistration,
 }) => {
   return (
     <TableRow key={user.id} hover>
@@ -91,7 +92,12 @@ const UserCard: React.FC<UserCardProps> = ({
         )}
       </TableCell>
       <TableCell>
-        <RegistrationStatusChip userId={user.userId} />
+        <RegistrationStatusChip
+          userId={user.userId}
+          contactId={user.id}
+          canManage={canManageUsers}
+          onRevoke={onRevokeRegistration}
+        />
       </TableCell>
       <TableCell>
         <PhoneNumbersCell contactDetails={user.contactDetails} />

--- a/draco-nodejs/frontend-next/components/users/UserTableEnhanced.tsx
+++ b/draco-nodejs/frontend-next/components/users/UserTableEnhanced.tsx
@@ -75,6 +75,11 @@ const UserTableEnhanced: React.FC<UserTableEnhancedProps> = ({
       // Filter props
       onlyWithRoles={onlyWithRoles}
       onOnlyWithRolesChange={onOnlyWithRolesChange}
+      // Registration management
+      onRevokeRegistration={
+        (originalProps as unknown as { onRevokeRegistration?: (id: string) => void })
+          .onRevokeRegistration
+      }
       // Title props for enhanced container
       title={hasModernFeatures ? 'User Management' : undefined}
       showTitle={hasModernFeatures}

--- a/draco-nodejs/frontend-next/components/users/table/UserTableContainer.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/UserTableContainer.tsx
@@ -328,6 +328,10 @@ const UserTableContainer: React.FC<UserTableContainerProps> = ({
           onEditContact={onEditContact}
           onDeleteContact={onDeleteContact}
           onDeleteContactPhoto={onDeleteContactPhoto}
+          onRevokeRegistration={
+            (_restProps as { onRevokeRegistration?: (contactId: string) => void })
+              .onRevokeRegistration
+          }
           getRoleDisplayName={getRoleDisplayName}
           searchTerm={searchTerm}
           hasFilters={false}

--- a/draco-nodejs/frontend-next/components/users/table/UserTableContent.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/UserTableContent.tsx
@@ -14,6 +14,7 @@ interface UserTableContentProps {
   onEditContact: (contact: Contact) => void;
   onDeleteContact?: (contact: Contact) => void;
   onDeleteContactPhoto: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   getRoleDisplayName: (
     roleOrRoleId:
       | string
@@ -31,6 +32,7 @@ const UserTableContent: React.FC<UserTableContentProps> = ({
   onEditContact,
   onDeleteContact,
   onDeleteContactPhoto,
+  onRevokeRegistration,
   getRoleDisplayName,
   searchTerm,
   hasFilters = false,
@@ -91,6 +93,7 @@ const UserTableContent: React.FC<UserTableContentProps> = ({
               onEditContact={onEditContact}
               onDeleteContact={onDeleteContact}
               onDeleteContactPhoto={onDeleteContactPhoto}
+              onRevokeRegistration={onRevokeRegistration}
               getRoleDisplayName={getRoleDisplayName}
             />
           ))}

--- a/draco-nodejs/frontend-next/components/users/table/UserTableWrapper.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/UserTableWrapper.tsx
@@ -28,6 +28,7 @@ interface UserTableWrapperProps {
   onEditContact?: (contact: Contact) => void;
   onDeleteContact?: (contact: Contact) => void;
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   getRoleDisplayName: (
     roleOrRoleId:
       | string
@@ -56,6 +57,7 @@ const UserTableWrapper: React.FC<UserTableWrapperProps> = ({
   onEditContact,
   onDeleteContact,
   onDeleteContactPhoto,
+  onRevokeRegistration,
   getRoleDisplayName,
   searchTerm,
   hasFilters = false,
@@ -97,6 +99,7 @@ const UserTableWrapper: React.FC<UserTableWrapperProps> = ({
           onEditContact={onEditContact || (() => {})}
           onDeleteContact={onDeleteContact}
           onDeleteContactPhoto={onDeleteContactPhoto || (() => Promise.resolve())}
+          onRevokeRegistration={onRevokeRegistration}
           getRoleDisplayName={getRoleDisplayName}
           searchTerm={searchTerm}
           hasFilters={hasFilters}
@@ -111,6 +114,7 @@ const UserTableWrapper: React.FC<UserTableWrapperProps> = ({
           onEditContact={onEditContact || (() => {})}
           onDeleteContact={onDeleteContact}
           onDeleteContactPhoto={onDeleteContactPhoto || (() => Promise.resolve())}
+          onRevokeRegistration={onRevokeRegistration}
           canManageUsers={canManageUsers}
           getRoleDisplayName={getRoleDisplayName}
           searchTerm={searchTerm}

--- a/draco-nodejs/frontend-next/components/users/table/components/UserCardGrid.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/components/UserCardGrid.tsx
@@ -21,6 +21,7 @@ interface UserCardGridProps {
   onEditContact?: (contact: import('../../../../types/users').Contact) => void;
   onDeleteContact?: (contact: import('../../../../types/users').Contact) => void;
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   canManageUsers: boolean;
   getRoleDisplayName: (
     roleOrRoleId:
@@ -42,6 +43,7 @@ const UserCardGrid: React.FC<UserCardGridProps> = ({
   onEditContact,
   onDeleteContact,
   onDeleteContactPhoto,
+  onRevokeRegistration,
   canManageUsers,
   getRoleDisplayName,
   enableVirtualization = false,
@@ -159,6 +161,7 @@ const UserCardGrid: React.FC<UserCardGridProps> = ({
                   canManageUsers={canManageUsers}
                   getRoleDisplayName={getRoleDisplayName}
                   showActions={true}
+                  onRevokeRegistration={onRevokeRegistration}
                 />
               ))}
             </Box>

--- a/draco-nodejs/frontend-next/components/users/table/components/UserDisplayCard.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/components/UserDisplayCard.tsx
@@ -35,6 +35,7 @@ const UserDisplayCard: React.FC<UserDisplayCardProps> = ({
   onEditContact,
   onDeleteContact,
   onDeleteContactPhoto,
+  onRevokeRegistration,
   canManageUsers,
   getRoleDisplayName: _getRoleDisplayName,
   showActions = true,
@@ -325,7 +326,10 @@ const UserDisplayCard: React.FC<UserDisplayCardProps> = ({
             <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0.5 }}>
               <RegistrationStatusChip
                 userId={user.userId}
+                contactId={user.id}
                 size={cardSize === 'compact' ? 'small' : 'medium'}
+                canManage={canManageUsers}
+                onRevoke={onRevokeRegistration}
               />
             </Box>
             {user.email && (

--- a/draco-nodejs/frontend-next/components/users/table/components/UserTableContent.tsx
+++ b/draco-nodejs/frontend-next/components/users/table/components/UserTableContent.tsx
@@ -2,6 +2,7 @@
 
 import React, { memo } from 'react';
 import { Table, TableContainer, TableBody, Box, CircularProgress, Typography } from '@mui/material';
+import UserCard from '../../../users/UserCard';
 import {
   ViewMode,
   EnhancedUser,
@@ -40,6 +41,7 @@ interface UserTableContentProps {
   onEditContact?: (contact: Contact) => void;
   onDeleteContact?: (contact: Contact) => void;
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   onAssignRole?: (user: User) => Promise<void>;
   onRemoveRole?: (user: User, role: UserRole) => void;
   // Permissions
@@ -72,6 +74,7 @@ const UserTableContent: React.FC<UserTableContentProps> = memo(
     onEditContact,
     onDeleteContact,
     onDeleteContactPhoto,
+    onRevokeRegistration,
     onAssignRole,
     onRemoveRole,
     canManageUsers = false,
@@ -112,6 +115,7 @@ const UserTableContent: React.FC<UserTableContentProps> = memo(
               onEditContact={onEditContact}
               onDeleteContact={onDeleteContact}
               onDeleteContactPhoto={onDeleteContactPhoto}
+              onRevokeRegistration={onRevokeRegistration}
               onAssignRole={onAssignRole || (async () => {})}
               onRemoveRole={onRemoveRole || (() => {})}
               canManageUsers={canManageUsers}
@@ -132,12 +136,22 @@ const UserTableContent: React.FC<UserTableContentProps> = memo(
               <Table>
                 <TableBody>
                   {users.map((user) => (
-                    <tr key={user.id}>
-                      <td>{user.firstName}</td>
-                      <td>{user.lastName}</td>
-                      <td>{user.email}</td>
-                      {/* Add more table cells as needed */}
-                    </tr>
+                    <UserCard
+                      key={user.id}
+                      user={user}
+                      canManageUsers={canManageUsers}
+                      onAssignRole={onAssignRole || (async () => {})}
+                      onRemoveRole={onRemoveRole || (() => {})}
+                      onEditContact={onEditContact}
+                      onDeleteContact={onDeleteContact}
+                      onDeleteContactPhoto={onDeleteContactPhoto}
+                      getRoleDisplayName={
+                        getRoleDisplayName ||
+                        ((role) =>
+                          typeof role === 'string' ? role : role.roleName || `Role ${role.roleId}`)
+                      }
+                      onRevokeRegistration={onRevokeRegistration}
+                    />
                   ))}
                 </TableBody>
               </Table>

--- a/draco-nodejs/frontend-next/hooks/useUserManagement.ts
+++ b/draco-nodejs/frontend-next/hooks/useUserManagement.ts
@@ -1041,6 +1041,44 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     ],
   );
 
+  const handleRevokeRegistration = useCallback(
+    async (contactId: string) => {
+      if (!userService || !accountId) {
+        setError('Unable to revoke registration - missing required data');
+        return;
+      }
+
+      try {
+        await userService.revokeRegistration(accountId, contactId);
+        setSuccess('Registration removed successfully');
+
+        // Update users in-place to clear userId
+        const updatedUsers = paginationState.users.map((u) =>
+          u.id === contactId ? { ...u, userId: '' } : u,
+        );
+
+        dispatch({
+          type: 'SET_DATA',
+          users: [...updatedUsers],
+          hasNext: paginationState.hasNext,
+          hasPrev: paginationState.hasPrev,
+          page: paginationState.page,
+        });
+      } catch (error) {
+        console.error('Error revoking registration:', error);
+        setError(extractErrorMessage(error));
+      }
+    },
+    [
+      userService,
+      accountId,
+      paginationState.users,
+      paginationState.hasNext,
+      paginationState.hasPrev,
+      paginationState.page,
+    ],
+  );
+
   // Role display name helper - now uses contextName from backend for role display
   const getRoleDisplayNameHelper = useCallback(
     (
@@ -1129,6 +1167,7 @@ export const useUserManagement = (accountId: string): UseUserManagementReturn =>
     openDeleteContactDialog,
     closeDeleteContactDialog,
     handleDeleteContact,
+    handleRevokeRegistration,
     setAssignRoleDialogOpen,
     setRemoveRoleDialogOpen,
     setEditContactDialogOpen,

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -708,6 +708,24 @@ export class UserManagementService {
 
     return data.data;
   }
+
+  /**
+   * Revoke registration (unlink userId from contact)
+   */
+  async revokeRegistration(accountId: string, contactId: string): Promise<void> {
+    const response = await fetch(`/api/accounts/${accountId}/contacts/${contactId}/registration`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || `Failed to revoke registration (${response.status})`);
+    }
+  }
 }
 
 /**

--- a/draco-nodejs/frontend-next/types/userTable.ts
+++ b/draco-nodejs/frontend-next/types/userTable.ts
@@ -225,6 +225,7 @@ export interface UserDisplayCardProps {
   onEditContact?: (contact: import('./users').Contact) => void;
   onDeleteContact?: (contact: import('./users').Contact) => void;
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   canManageUsers: boolean;
   getRoleDisplayName: (
     roleOrRoleId:
@@ -364,6 +365,9 @@ export interface UserTableContainerProps extends ModernUserTableProps {
 
   // Contact photo management
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+
+  // Registration management
+  onRevokeRegistration?: (contactId: string) => void;
 }
 
 // Backward compatibility props mapping
@@ -396,4 +400,7 @@ export interface UserTableEnhancedProps extends UserTableProps {
 
   // Contact photo management
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+
+  // Registration management
+  onRevokeRegistration?: (contactId: string) => void;
 }

--- a/draco-nodejs/frontend-next/types/users.ts
+++ b/draco-nodejs/frontend-next/types/users.ts
@@ -155,6 +155,7 @@ export interface UserCardProps {
   onEditContact?: (contact: Contact) => void;
   onDeleteContact?: (contact: Contact) => void;
   onDeleteContactPhoto?: (contactId: string) => Promise<void>;
+  onRevokeRegistration?: (contactId: string) => void;
   getRoleDisplayName: (
     roleOrRoleId:
       | string
@@ -324,6 +325,7 @@ export interface UseUserManagementReturn {
   openDeleteContactDialog: (contact: Contact) => void;
   closeDeleteContactDialog: () => void;
   handleDeleteContact: (contactId: string, force: boolean) => Promise<void>;
+  handleRevokeRegistration: (contactId: string) => Promise<void> | void;
   setAssignRoleDialogOpen: (open: boolean) => void;
   setRemoveRoleDialogOpen: (open: boolean) => void;
   setEditContactDialogOpen: (open: boolean) => void;


### PR DESCRIPTION
backend: add DELETE /api/accounts/:accountId/contacts/:contactId/registration to clear userid; add registration_revoke audit event

frontend: enhance RegistrationStatusChip with hover 'X' revoke + confirmation; explicit onRevokeRegistration prop wiring through UserTableEnhanced → UserCard/UserDisplayCard; add revokeRegistration API method; implement handleRevokeRegistration in useUserManagement

build: lint/build green