### PR TITLE
fix: resolve IPv6 rate limiting validation error

### DIFF
--- a/draco-nodejs/backend/src/middleware/rateLimitMiddleware.ts
+++ b/draco-nodejs/backend/src/middleware/rateLimitMiddleware.ts
@@ -1,4 +1,4 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { Request, Response } from 'express';
 
 interface RateLimitOptions {
@@ -86,6 +86,6 @@ export const teamsWantedRateLimit = createRateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
   max: 3, // 3 posts per hour
   message: 'Rate limit exceeded: Maximum 3 teams wanted posts per hour per IP',
-  keyGenerator: (req: Request) => `teams-wanted-${req.ip}`, // Always use IP for anonymous submissions
+  keyGenerator: (req: Request) => `teams-wanted-${ipKeyGenerator(req.ip || '')}`, // Use ipKeyGenerator for IPv6 support
   skipSuccessfulRequests: false,
 });


### PR DESCRIPTION
- Import ipKeyGenerator helper from express-rate-limit
- Update teamsWantedRateLimit to use ipKeyGenerator for proper IPv6 handling
- Fixes ERR_ERL_KEY_GEN_IPV6 validation error on server startup
- Ensures IPv6 addresses are properly normalized to prevent rate limit bypass

🤖 Generated with [Claude Code](https://claude.ai/code)