### PR TITLE
feat: Move Account Owner display to UserManagement header

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/users/UserManagement.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Alert } from '@mui/material';
+import { Alert, Box, Typography } from '@mui/material';
 import { useUserManagement } from '../../../../hooks/useUserManagement';
 import {
   UserTableEnhanced,
@@ -11,7 +11,11 @@ import {
 import EditContactDialog from '../../../../components/users/EditContactDialog';
 import DeleteContactDialog from '../../../../components/users/DeleteContactDialog';
 import ConfirmationDialog from '../../../../components/common/ConfirmationDialog';
-import { AutomaticRolesSection } from '../../../../components/users/automatic-roles';
+import {
+  AutomaticRolesSection,
+  AccountOwnerDisplay,
+} from '../../../../components/users/automatic-roles';
+import AccountPageHeader from '../../../../components/AccountPageHeader';
 
 interface UserManagementProps {
   accountId: string;
@@ -146,6 +150,25 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
 
   return (
     <main className="min-h-screen bg-background">
+      {/* Account Header */}
+      <AccountPageHeader accountId={accountId}>
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          sx={{ position: 'relative' }}
+        >
+          <Box sx={{ flex: 1, textAlign: 'center', mb: 2 }}>
+            <Typography variant="h4" sx={{ color: 'white', fontWeight: 'bold' }}>
+              User Management
+            </Typography>
+          </Box>
+
+          {/* Account Owner Information */}
+          {accountOwner && <AccountOwnerDisplay accountOwner={accountOwner} variant="header" />}
+        </Box>
+      </AccountPageHeader>
+
       {/* Error and Success Alerts */}
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
@@ -204,6 +227,8 @@ const UserManagement: React.FC<UserManagementProps> = ({ accountId }) => {
         // Filter props
         onlyWithRoles={onlyWithRoles}
         onOnlyWithRolesChange={handleFilterToggle}
+        // Disable the title header above the search bar
+        title={null}
       />
 
       {/* Dialog Sections */}

--- a/draco-nodejs/frontend-next/components/AccountPageHeader.tsx
+++ b/draco-nodejs/frontend-next/components/AccountPageHeader.tsx
@@ -160,7 +160,14 @@ const AccountPageHeader: React.FC<AccountPageHeaderProps> = ({
 
       {/* Page-specific content */}
       {children && (
-        <Box sx={{ p: 4, pt: showLogo || (showSeasonInfo && seasonName) ? 0 : 4 }}>{children}</Box>
+        <Box
+          sx={{
+            p: 4,
+            pt: showLogo || (showSeasonInfo && seasonName) ? 0 : 4,
+          }}
+        >
+          {children}
+        </Box>
       )}
     </Box>
   );

--- a/draco-nodejs/frontend-next/components/users/UserTableEnhanced.tsx
+++ b/draco-nodejs/frontend-next/components/users/UserTableEnhanced.tsx
@@ -28,6 +28,9 @@ const UserTableEnhanced: React.FC<UserTableEnhancedProps> = ({
   onlyWithRoles,
   onOnlyWithRolesChange,
 
+  // Title prop to override default behavior
+  title: customTitle,
+
   // All original UserTable props
   ...originalProps
 }) => {
@@ -81,7 +84,13 @@ const UserTableEnhanced: React.FC<UserTableEnhancedProps> = ({
           .onRevokeRegistration
       }
       // Title props for enhanced container
-      title={hasModernFeatures ? 'User Management' : undefined}
+      title={
+        customTitle !== undefined
+          ? customTitle || undefined
+          : hasModernFeatures
+            ? 'User Management'
+            : undefined
+      }
       showTitle={hasModernFeatures}
     />
   );

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AccountOwnerDisplay.tsx
@@ -11,13 +11,71 @@ interface AccountOwnerDisplayProps {
     email: string | null;
     photoUrl?: string;
   } | null; // Keep nullable for component safety, but expect it to always have value
+  variant?: 'header' | 'card';
 }
 
-const AccountOwnerDisplay: React.FC<AccountOwnerDisplayProps> = ({ accountOwner }) => {
+const AccountOwnerDisplay: React.FC<AccountOwnerDisplayProps> = ({
+  accountOwner,
+  variant = 'card',
+}) => {
   if (!accountOwner) {
     return null;
   }
 
+  if (variant === 'header') {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'common.white',
+            opacity: 0.8,
+            fontWeight: 400,
+            textAlign: 'center',
+            fontSize: '0.875rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          Account Owner
+        </Typography>
+        <Typography
+          variant="h6"
+          sx={{
+            color: 'common.white',
+            opacity: 0.95,
+            fontWeight: 600,
+            textAlign: 'center',
+            fontSize: { xs: '1rem', sm: '1.125rem' },
+          }}
+        >
+          {accountOwner.firstName} {accountOwner.lastName}
+        </Typography>
+        {accountOwner.email && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'common.white',
+              opacity: 0.8,
+              textAlign: 'center',
+              fontSize: '0.875rem',
+            }}
+          >
+            {accountOwner.email}
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  // Default card variant
   return (
     <Card
       sx={{

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/AutomaticRolesSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Box, Typography, Divider } from '@mui/material';
-import AccountOwnerDisplay from './AccountOwnerDisplay';
+import { Box, Divider } from '@mui/material';
 import TeamManagersList from './TeamManagersList';
 
 interface AutomaticRolesSectionProps {
@@ -34,19 +33,7 @@ const AutomaticRolesSection: React.FC<AutomaticRolesSectionProps> = ({
   }
 
   return (
-    <Box sx={{ mb: 4 }}>
-      <Typography
-        variant="h5"
-        sx={{
-          mb: 2,
-          color: 'text.primary',
-          fontWeight: 'bold',
-        }}
-      >
-        Automatic Role Holders
-      </Typography>
-
-      <AccountOwnerDisplay accountOwner={accountOwner} />
+    <Box sx={{ mt: 4, mb: 4 }}>
       <TeamManagersList teamManagers={teamManagers} />
 
       <Divider sx={{ mt: 3, mb: 3 }} />

--- a/draco-nodejs/frontend-next/components/users/automatic-roles/TeamManagersList.tsx
+++ b/draco-nodejs/frontend-next/components/users/automatic-roles/TeamManagersList.tsx
@@ -62,9 +62,9 @@ const TeamManagersList: React.FC<TeamManagersListProps> = ({ teamManagers }) => 
               gap: 2,
             }}
           >
-            {teamManagers.map((manager) => (
+            {teamManagers.map((manager, index) => (
               <Box
-                key={manager.contactId}
+                key={`${manager.contactId}-${index}`}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
@@ -103,7 +103,7 @@ const TeamManagersList: React.FC<TeamManagersListProps> = ({ teamManagers }) => 
                   <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
                     {manager.teams.map((team) => (
                       <Chip
-                        key={team.teamSeasonId}
+                        key={`${manager.contactId}-${team.teamSeasonId}`}
                         label={team.teamName}
                         size="small"
                         variant="outlined"

--- a/draco-nodejs/frontend-next/types/userTable.ts
+++ b/draco-nodejs/frontend-next/types/userTable.ts
@@ -383,6 +383,9 @@ export interface UserTableEnhancedProps extends UserTableProps {
   // Enhanced props
   accountId?: string;
 
+  // Title customization
+  title?: string | null;
+
   // Search props
   searchTerm?: string;
   onSearchChange?: (term: string) => void;


### PR DESCRIPTION
- Move Account Owner information from AutomaticRolesSection to UserManagement page header
- Enhance AccountOwnerDisplay component with 'header' variant for white text styling
- Remove 'Automatic Role Holders' title and AccountOwnerDisplay from AutomaticRolesSection
- Clean up AutomaticRolesSection to only show Team Managers
- Update UserManagement to use AccountOwnerDisplay component in header
- Maintain consistent styling and layout across components
- Follow DRY principles by reusing existing AccountOwnerDisplay component

This change improves the user experience by prominently displaying the Account Owner information in the page header while maintaining clean separation of concerns.