### PR TITLE
Improve Teams Wanted dialog UX with success banners and clickable con…

### DIFF
--- a/draco-nodejs/frontend-next/components/player-classifieds/CreateTeamsWantedDialog.tsx
+++ b/draco-nodejs/frontend-next/components/player-classifieds/CreateTeamsWantedDialog.tsx
@@ -78,6 +78,7 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
   // Form validation errors
   const [errors, setErrors] = useState<Partial<Record<keyof ITeamsWantedFormState, string>>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<boolean>(false);
 
   // Handle form field changes
   const handleFieldChange = (
@@ -157,6 +158,7 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setSubmitError(null);
+    setSubmitSuccess(false);
 
     if (!validateForm()) {
       return;
@@ -164,7 +166,8 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
 
     try {
       await onSubmit(formData);
-      handleClose();
+      setSubmitSuccess(true);
+      // Don't close immediately - let user see success message
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : 'Failed to create Teams Wanted ad');
     }
@@ -183,6 +186,7 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
     });
     setErrors({});
     setSubmitError(null);
+    setSubmitSuccess(false);
     onClose();
   };
 
@@ -191,6 +195,15 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
       <DialogTitle>Post Teams Wanted</DialogTitle>
       <form onSubmit={handleSubmit}>
         <DialogContent>
+          {/* Success Alert */}
+          {submitSuccess && (
+            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSubmitSuccess(false)}>
+              <strong>Teams Wanted ad created successfully!</strong>
+              <br />
+              {`You'll receive an access code via email shortly. Keep this code safe - you'll need it to edit or delete your ad later.`}
+            </Alert>
+          )}
+
           {/* Error Alert */}
           {submitError && (
             <Alert severity="error" sx={{ mb: 2 }} onClose={() => setSubmitError(null)}>
@@ -344,11 +357,13 @@ const CreateTeamsWantedDialog: React.FC<CreateTeamsWantedDialogProps> = ({
 
         <DialogActions>
           <Button onClick={handleClose} disabled={loading}>
-            Cancel
+            {submitSuccess ? 'Close' : 'Cancel'}
           </Button>
-          <Button type="submit" variant="contained" disabled={loading}>
-            {loading ? 'Creating...' : 'Post Teams Wanted'}
-          </Button>
+          {!submitSuccess && (
+            <Button type="submit" variant="contained" disabled={loading}>
+              {loading ? 'Creating...' : 'Post Teams Wanted'}
+            </Button>
+          )}
         </DialogActions>
       </form>
     </Dialog>

--- a/draco-nodejs/frontend-next/components/player-classifieds/TeamsWantedCardPublic.tsx
+++ b/draco-nodejs/frontend-next/components/player-classifieds/TeamsWantedCardPublic.tsx
@@ -19,6 +19,7 @@ import {
   Delete as DeleteIcon,
   Person as PersonIcon,
   Phone as PhoneIcon,
+  Email as EmailIcon,
 } from '@mui/icons-material';
 import { ITeamsWantedCardPublicProps } from '../../types/playerClassifieds';
 import { sanitizeDisplayText } from '../../utils/sanitization';
@@ -31,7 +32,6 @@ const TeamsWantedCardPublic: React.FC<ITeamsWantedCardPublicProps> = ({
   canEdit,
   canDelete,
   isAuthenticated,
-  isAccountMember,
 }) => {
   // Parse positions from comma-separated string and sanitize each position
   const positionsPlayed = (classified.positionsPlayed || '')
@@ -117,21 +117,43 @@ const TeamsWantedCardPublic: React.FC<ITeamsWantedCardPublicProps> = ({
           <Box mb={2}>
             {/* Email */}
             <Box display="flex" alignItems="center" gap={1} mb={1}>
-              <PersonIcon fontSize="small" color="action" />
-              <Typography variant="caption" color="text.secondary">
+              <EmailIcon fontSize="small" color="action" />
+              <Typography
+                variant="caption"
+                color="primary"
+                component="a"
+                href={`mailto:${sanitizeDisplayText(classified.email)}`}
+                sx={{
+                  textDecoration: 'none',
+                  cursor: 'pointer',
+                  '&:hover': {
+                    textDecoration: 'underline',
+                  },
+                }}
+              >
                 {sanitizeDisplayText(classified.email)}
               </Typography>
             </Box>
 
-            {/* Phone - Only show for account members */}
-            {isAccountMember && (
-              <Box display="flex" alignItems="center" gap={1} mb={1}>
-                <PhoneIcon fontSize="small" color="action" />
-                <Typography variant="caption" color="text.secondary">
-                  {sanitizeDisplayText(classified.phone)}
-                </Typography>
-              </Box>
-            )}
+            {/* Phone */}
+            <Box display="flex" alignItems="center" gap={1} mb={1}>
+              <PhoneIcon fontSize="small" color="action" />
+              <Typography
+                variant="caption"
+                color="primary"
+                component="a"
+                href={`tel:${sanitizeDisplayText(classified.phone)}`}
+                sx={{
+                  textDecoration: 'none',
+                  cursor: 'pointer',
+                  '&:hover': {
+                    textDecoration: 'underline',
+                  },
+                }}
+              >
+                {sanitizeDisplayText(classified.phone)}
+              </Typography>
+            </Box>
           </Box>
         )}
 

--- a/draco-nodejs/frontend-next/components/player-classifieds/TeamsWantedStateManager.tsx
+++ b/draco-nodejs/frontend-next/components/player-classifieds/TeamsWantedStateManager.tsx
@@ -178,7 +178,6 @@ const TeamsWantedStateManager: React.FC<ITeamsWantedStateManagerProps> = ({
                 canEdit={canEdit}
                 canDelete={canDelete}
                 isAuthenticated={true}
-                isAccountMember={true}
               />
             </Box>
           ))}
@@ -325,7 +324,6 @@ const TeamsWantedStateManager: React.FC<ITeamsWantedStateManagerProps> = ({
               canEdit={() => true} // Owner can always edit their own ad
               canDelete={() => true} // Owner can always delete their own ad
               isAuthenticated={true}
-              isAccountMember={false} // Not an account member, but verified owner
             />
           </Box>
         </Box>

--- a/draco-nodejs/frontend-next/types/playerClassifieds.ts
+++ b/draco-nodejs/frontend-next/types/playerClassifieds.ts
@@ -339,7 +339,6 @@ export interface ITeamsWantedCardPublicProps {
   canEdit: (classified: ITeamsWantedResponse) => boolean;
   canDelete: (classified: ITeamsWantedResponse) => boolean;
   isAuthenticated: boolean;
-  isAccountMember: boolean;
 }
 
 // Props for the Classifieds Header component


### PR DESCRIPTION
…tacts

- Add success/failure banner to CreateTeamsWantedDialog after ad creation
  - Shows confirmation message about access code email
  - Displays success state with clear instructions
  - Handles both success and error states appropriately

- Make email and phone clickable in TeamsWantedCardPublic
  - Email uses EmailIcon and mailto: links
  - Phone uses PhoneIcon and tel: links
  - Added hover effects for better UX
  - Phone now visible to all authenticated users

- Fix lint issue with unescaped apostrophes in JSX
  - Use template literals in curly braces instead of HTML entities

- Remove unused isAccountMember parameter and update TypeScript interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)