### PR TITLE
Add delete functionality for Players Wanted ads

### DIFF
--- a/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
+++ b/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
@@ -430,11 +430,10 @@ router.delete(
   '/players-wanted/:classifiedId',
   authenticateToken,
   routeProtection.enforceAccountBoundary(),
-  routeProtection.requirePermission('player-classified.manage'),
   ...validatePlayersWantedDeletion,
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, classifiedId } = extractClassifiedParams(req.params);
-    const contactId = BigInt(req.user!.id);
+    const contactId = req.accountBoundary!.contactId;
 
     const playerClassifiedService = ServiceFactory.getPlayerClassifiedService();
 

--- a/draco-nodejs/frontend-next/components/player-classifieds/DeletePlayersWantedDialog.tsx
+++ b/draco-nodejs/frontend-next/components/player-classifieds/DeletePlayersWantedDialog.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Chip,
+} from '@mui/material';
+import { format } from 'date-fns';
+import { IPlayersWantedResponse } from '../../types/playerClassifieds';
+
+interface DeletePlayersWantedDialogProps {
+  open: boolean;
+  classified: IPlayersWantedResponse | null;
+  onClose: () => void;
+  onConfirm: () => void;
+  loading?: boolean;
+}
+
+const DeletePlayersWantedDialog: React.FC<DeletePlayersWantedDialogProps> = ({
+  open,
+  classified,
+  onClose,
+  onConfirm,
+  loading = false,
+}) => {
+  if (!classified) return null;
+
+  const createdDate = classified.dateCreated ? new Date(classified.dateCreated) : null;
+  const positionsNeeded = classified.positionsNeeded.split(',').map((pos) => pos.trim());
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Delete Players Wanted Ad</DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          Are you sure you want to delete this Players Wanted ad?
+        </Typography>
+
+        <Box sx={{ p: 2, backgroundColor: 'grey.100', borderRadius: 1 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
+            Ad Details:
+          </Typography>
+
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            <strong>Team/Event:</strong> {classified.teamEventName}
+          </Typography>
+
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            <strong>Created:</strong>{' '}
+            {createdDate ? format(createdDate, 'MMMM d, yyyy') : 'Unknown'}
+          </Typography>
+
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            <strong>Created by:</strong> {classified.creator.firstName}{' '}
+            {classified.creator.lastName}
+          </Typography>
+
+          {classified.description && (
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              <strong>Description:</strong> {classified.description}
+            </Typography>
+          )}
+
+          <Box sx={{ mb: 1 }}>
+            <Typography variant="body2" sx={{ mb: 0.5 }}>
+              <strong>Positions Needed:</strong>
+            </Typography>
+            <Box display="flex" flexWrap="wrap" gap={0.5}>
+              {positionsNeeded.map((position: string) => (
+                <Chip
+                  key={position}
+                  label={position}
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                />
+              ))}
+            </Box>
+          </Box>
+        </Box>
+
+        <Typography variant="body2" color="error" sx={{ mt: 2, fontWeight: 'medium' }}>
+          This action cannot be undone.
+        </Typography>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button onClick={onConfirm} color="error" variant="contained" disabled={loading}>
+          {loading ? 'Deleting...' : 'Delete'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeletePlayersWantedDialog;

--- a/draco-nodejs/frontend-next/components/player-classifieds/index.ts
+++ b/draco-nodejs/frontend-next/components/player-classifieds/index.ts
@@ -5,3 +5,4 @@ export { default as ClassifiedsHeader } from './ClassifiedsHeader';
 export { default as PlayersWantedCard } from './PlayersWantedCard';
 export { default as CreateTeamsWantedDialog } from './CreateTeamsWantedDialog';
 export { default as CreatePlayersWantedDialog } from './CreatePlayersWantedDialog';
+export { default as DeletePlayersWantedDialog } from './DeletePlayersWantedDialog';

--- a/draco-nodejs/frontend-next/hooks/usePlayersWantedDialogs.ts
+++ b/draco-nodejs/frontend-next/hooks/usePlayersWantedDialogs.ts
@@ -5,7 +5,9 @@ interface UsePlayersWantedDialogsReturn {
   // Dialog state
   createDialogOpen: boolean;
   editDialogOpen: boolean;
+  deleteDialogOpen: boolean;
   editingClassified: IPlayersWantedResponse | null;
+  deletingClassified: IPlayersWantedResponse | null;
 
   // Success/error state
   success: string | null;
@@ -16,6 +18,8 @@ interface UsePlayersWantedDialogsReturn {
   closeCreateDialog: () => void;
   openEditDialog: (classified: IPlayersWantedResponse) => void;
   closeEditDialog: () => void;
+  openDeleteDialog: (classified: IPlayersWantedResponse) => void;
+  closeDeleteDialog: () => void;
 
   // Success/error handlers
   setSuccess: (message: string | null) => void;
@@ -31,7 +35,9 @@ export const usePlayersWantedDialogs = (): UsePlayersWantedDialogsReturn => {
   // Dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [editingClassified, setEditingClassified] = useState<IPlayersWantedResponse | null>(null);
+  const [deletingClassified, setDeletingClassified] = useState<IPlayersWantedResponse | null>(null);
 
   // Success/error notification state
   const [success, setSuccess] = useState<string | null>(null);
@@ -54,6 +60,16 @@ export const usePlayersWantedDialogs = (): UsePlayersWantedDialogsReturn => {
   const closeEditDialog = useCallback(() => {
     setEditDialogOpen(false);
     setEditingClassified(null);
+  }, []);
+
+  const openDeleteDialog = useCallback((classified: IPlayersWantedResponse) => {
+    setDeletingClassified(classified);
+    setDeleteDialogOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    setDeleteDialogOpen(false);
+    setDeletingClassified(null);
   }, []);
 
   // Success/error handlers
@@ -86,7 +102,9 @@ export const usePlayersWantedDialogs = (): UsePlayersWantedDialogsReturn => {
     // Dialog state
     createDialogOpen,
     editDialogOpen,
+    deleteDialogOpen,
     editingClassified,
+    deletingClassified,
 
     // Success/error state
     success,
@@ -97,6 +115,8 @@ export const usePlayersWantedDialogs = (): UsePlayersWantedDialogsReturn => {
     closeCreateDialog,
     openEditDialog,
     closeEditDialog,
+    openDeleteDialog,
+    closeDeleteDialog,
 
     // Success/error handlers
     setSuccess,


### PR DESCRIPTION
- Add delete Players Wanted API endpoint in backend
- Create DeletePlayersWantedDialog component with confirmation
- Update PlayersWanted page to handle delete operations
- Add delete dialog state management to usePlayersWantedDialogs hook
- Remove permission requirement for delete - use account boundary
- Export new dialog component from player-classifieds index

🤖 Generated with [Claude Code](https://claude.ai/code)