### PR TITLE
Add league selection functionality and season participants API endpoints

### DIFF
--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -2910,6 +2910,199 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/api/accounts/{accountId}/seasons/{seasonId}/participants/count":
+    get:
+      summary: Get season participants count
+      description: Get the count of participants (contacts with roster entries) for a specific season
+      operationId: getSeasonParticipantsCount
+      tags:
+        - Seasons
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: accountId
+          required: true
+          schema:
+            type: string
+          description: Account ID
+          example: "123"
+        - in: path
+          name: seasonId
+          required: true
+          schema:
+            type: string
+          description: Season ID
+          example: "456"
+      responses:
+        "200":
+          description: Season participants count retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      seasonId:
+                        type: string
+                        example: "456"
+                      participantCount:
+                        type: integer
+                        example: 125
+                        description: Number of unique contacts participating in the season
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Forbidden - no access to account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Season not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/api/accounts/{accountId}/seasons/{seasonId}/leagues":
+    get:
+      summary: Get leagues for a specific season
+      description: Retrieve all leagues for a specific season (requires account access)
+      operationId: getSeasonLeagues
+      tags:
+        - Leagues
+        - Seasons
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: accountId
+          required: true
+          schema:
+            type: string
+          description: Account ID
+          example: "123"
+        - in: path
+          name: seasonId
+          required: true
+          schema:
+            type: string
+          description: Season ID
+          example: "456"
+        - in: query
+          name: includeTeams
+          required: false
+          schema:
+            type: string
+          description: Include team data (optional)
+        - in: query
+          name: includePlayerCounts
+          required: false
+          schema:
+            type: string
+            enum: ['true']
+          description: Include player counts for each league (optional)
+      responses:
+        "200":
+          description: Season leagues retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: Season leagues retrieved successfully
+                  data:
+                    type: object
+                    properties:
+                      leagueSeasons:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              example: "789"
+                              description: League season ID
+                            leagueId:
+                              type: string
+                              example: "456"
+                              description: League ID
+                            leagueName:
+                              type: string
+                              example: "Major League"
+                              description: League name
+                            accountId:
+                              type: string
+                              example: "123"
+                            teamCount:
+                              type: number
+                              example: 8
+                              description: Number of teams in this league
+                            playerCount:
+                              type: number
+                              example: 45
+                              description: Number of players in this league (only included if includePlayerCounts=true)
+                            divisions:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  teamCount:
+                                    type: number
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Season not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/managers":
     get:
       summary: List all managers for a team season

--- a/draco-nodejs/frontend-next/components/emails/recipients/LeagueSelectionContent.tsx
+++ b/draco-nodejs/frontend-next/components/emails/recipients/LeagueSelectionContent.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Checkbox,
+  FormControlLabel,
+  Button,
+  Stack,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { SelectAll as SelectAllIcon, ClearAll as ClearAllIcon } from '@mui/icons-material';
+
+import { League } from '../../../types/emails/recipients';
+import { createEmailRecipientService } from '../../../services/emailRecipientService';
+import { useAuth } from '../../../context/AuthContext';
+
+interface LeagueSelectionContentProps {
+  selectedLeagues: Set<string>;
+  onLeagueToggle: (leagueId: string, league?: League) => void;
+  onSelectAllLeagues: (leagues: League[]) => void;
+  onDeselectAllLeagues: () => void;
+  accountId?: string;
+  seasonId?: string;
+}
+
+/**
+ * LeagueSelectionContent - Component for selecting leagues in email recipients
+ * Provides individual league selection with select all/clear all functionality
+ */
+const LeagueSelectionContent: React.FC<LeagueSelectionContentProps> = ({
+  selectedLeagues,
+  onLeagueToggle,
+  onSelectAllLeagues,
+  onDeselectAllLeagues,
+  accountId,
+  seasonId,
+}) => {
+  const { token } = useAuth();
+  const [leagues, setLeagues] = useState<League[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create email recipient service
+  const emailRecipientService = useMemo(() => createEmailRecipientService(), []);
+
+  // Fetch leagues when component mounts or dependencies change
+  useEffect(() => {
+    const fetchLeagues = async () => {
+      if (!accountId || !seasonId || !token) {
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const result = await emailRecipientService.fetchLeagues(accountId, token, seasonId, true);
+
+        if (result.success) {
+          setLeagues(result.data);
+        } else {
+          setError('Failed to load leagues. Please try again.');
+          console.error('Failed to fetch leagues:', result.error);
+        }
+      } catch (err) {
+        setError('An unexpected error occurred while loading leagues.');
+        console.error('Error fetching leagues:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLeagues();
+  }, [accountId, seasonId, token, emailRecipientService]);
+
+  // Calculate selection statistics
+  const selectionStats = useMemo(() => {
+    const selectedCount = selectedLeagues.size;
+    const totalCount = leagues.length;
+    const totalTeams = leagues.reduce((sum, league) => sum + league.teamCount, 0);
+    const totalPlayers = leagues.reduce((sum, league) => sum + league.totalPlayers, 0);
+    const selectedTeams = leagues
+      .filter((league) => selectedLeagues.has(league.id))
+      .reduce((sum, league) => sum + league.teamCount, 0);
+    const selectedPlayers = leagues
+      .filter((league) => selectedLeagues.has(league.id))
+      .reduce((sum, league) => sum + league.totalPlayers, 0);
+
+    return {
+      selectedCount,
+      totalCount,
+      totalTeams,
+      totalPlayers,
+      selectedTeams,
+      selectedPlayers,
+      allSelected: selectedCount === totalCount && totalCount > 0,
+      noneSelected: selectedCount === 0,
+    };
+  }, [selectedLeagues, leagues]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 3 }}>
+        <CircularProgress size={24} sx={{ mr: 1 }} />
+        <Typography variant="body2">Loading leagues...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error" sx={{ mt: 1 }}>
+        {error}
+      </Alert>
+    );
+  }
+
+  if (leagues.length === 0) {
+    return (
+      <Alert severity="info" sx={{ mt: 1 }}>
+        No leagues found for this season.
+      </Alert>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Selection Controls */}
+      <Box sx={{ mb: 2 }}>
+        <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<SelectAllIcon />}
+            onClick={() => onSelectAllLeagues(leagues)}
+            disabled={selectionStats.allSelected}
+          >
+            Select All
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<ClearAllIcon />}
+            onClick={onDeselectAllLeagues}
+            disabled={selectionStats.noneSelected}
+          >
+            Clear All
+          </Button>
+        </Stack>
+
+        {/* Selection Summary */}
+        <Typography variant="body2" color="text.secondary">
+          {selectionStats.selectedCount} of {selectionStats.totalCount} leagues selected
+          {selectionStats.selectedTeams > 0 && ` (${selectionStats.selectedTeams} teams`}
+          {selectionStats.selectedPlayers > 0 && `, ${selectionStats.selectedPlayers} players`}
+          {(selectionStats.selectedTeams > 0 || selectionStats.selectedPlayers > 0) && `)`}
+        </Typography>
+      </Box>
+
+      {/* League List */}
+      <Stack spacing={1}>
+        {leagues.map((league) => {
+          const isSelected = selectedLeagues.has(league.id);
+
+          // Build label similar to season participants format
+          let label = league.name;
+          const details = [];
+          if (league.teamCount > 0) {
+            details.push(`${league.teamCount} teams`);
+          }
+          if (league.totalPlayers > 0) {
+            details.push(`${league.totalPlayers} players`);
+          }
+          if (details.length > 0) {
+            label += ` (${details.join(', ')})`;
+          }
+
+          return (
+            <FormControlLabel
+              key={league.id}
+              control={
+                <Checkbox checked={isSelected} onChange={() => onLeagueToggle(league.id, league)} />
+              }
+              label={label}
+            />
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+};
+
+export default LeagueSelectionContent;

--- a/draco-nodejs/frontend-next/services/emailRecipientService.ts
+++ b/draco-nodejs/frontend-next/services/emailRecipientService.ts
@@ -5,7 +5,7 @@
  */
 
 import { Contact, ContactRole } from '../types/users';
-import { RecipientContact, TeamGroup, RoleGroup } from '../types/emails/recipients';
+import { RecipientContact, TeamGroup, RoleGroup, League } from '../types/emails/recipients';
 import {
   transformBackendContact,
   transformBackendAutomaticRoleHolders,
@@ -836,6 +836,187 @@ export class EmailRecipientService {
       },
       {
         operation: 'fetch_team_managers',
+        additionalData: { endpoint: url },
+      },
+    );
+  }
+
+  /**
+   * Fetch leagues for a specific season
+   */
+  async fetchLeagues(
+    accountId: string,
+    token: string | null,
+    seasonId: string,
+    includePlayerCounts: boolean = false,
+  ): AsyncResult<League[]> {
+    if (!accountId || accountId.trim() === '') {
+      return {
+        success: false,
+        error: createEmailRecipientError(
+          EmailRecipientErrorCode.INVALID_DATA,
+          'Account ID is required',
+          { context: { operation: 'fetch_leagues' } },
+        ),
+      };
+    }
+
+    if (!seasonId || seasonId.trim() === '') {
+      return {
+        success: false,
+        error: createEmailRecipientError(
+          EmailRecipientErrorCode.INVALID_DATA,
+          'Season ID is required',
+          { context: { operation: 'fetch_leagues', accountId } },
+        ),
+      };
+    }
+
+    const headersResult = this.getHeaders(token);
+    if (!headersResult.success) {
+      return { success: false, error: headersResult.error };
+    }
+
+    const params = new URLSearchParams();
+    if (includePlayerCounts) {
+      params.append('includePlayerCounts', 'true');
+    }
+
+    const url = `/api/accounts/${accountId}/seasons/${seasonId}/leagues${params.toString() ? `?${params.toString()}` : ''}`;
+
+    return this.executeRequest(
+      async () => {
+        const response = await this.fetchWithTimeout(url, {
+          headers: headersResult.data,
+        });
+
+        const data = await this.handleResponse<{
+          success: boolean;
+          data: {
+            leagueSeasons: Array<{
+              id: string;
+              leagueId: string;
+              leagueName: string;
+              accountId: string;
+              teamCount?: number;
+              playerCount?: number;
+              divisions?: Array<{
+                id: string;
+                name: string;
+                teamCount: number;
+              }>;
+            }>;
+          };
+        }>(response);
+
+        if (!data.data?.leagueSeasons || !Array.isArray(data.data.leagueSeasons)) {
+          throw createEmailRecipientError(
+            EmailRecipientErrorCode.INVALID_DATA,
+            'Invalid leagues response format',
+            {
+              details: { responseData: data },
+              context: { operation: 'fetch_leagues', accountId, seasonId },
+            },
+          );
+        }
+
+        // Transform backend league seasons to frontend League format
+        const leagues: League[] = data.data.leagueSeasons.map((ls) => ({
+          id: ls.leagueId,
+          name: ls.leagueName,
+          description: undefined,
+          divisions: (ls.divisions || []).map((div) => ({
+            id: div.id,
+            name: div.name,
+            description: undefined,
+            teams: [], // Teams would need to be fetched separately if needed
+            teamCount: div.teamCount,
+            totalPlayers: 0, // Would need to be calculated from team rosters
+          })),
+          teamCount: ls.teamCount || 0,
+          totalPlayers: ls.playerCount || 0, // Use player count from API if available
+          seasonId: seasonId,
+          seasonName: '', // This would need to be fetched separately if needed
+        }));
+
+        return leagues;
+      },
+      {
+        operation: 'fetch_leagues',
+        additionalData: { endpoint: url },
+      },
+    );
+  }
+
+  /**
+   * Fetch season participants count for a specific season
+   */
+  async fetchSeasonParticipantsCount(
+    accountId: string,
+    token: string | null,
+    seasonId: string,
+  ): AsyncResult<number> {
+    if (!accountId || accountId.trim() === '') {
+      return {
+        success: false,
+        error: createEmailRecipientError(
+          EmailRecipientErrorCode.INVALID_DATA,
+          'Account ID is required',
+          { context: { operation: 'fetch_season_participants_count' } },
+        ),
+      };
+    }
+
+    if (!seasonId || seasonId.trim() === '') {
+      return {
+        success: false,
+        error: createEmailRecipientError(
+          EmailRecipientErrorCode.INVALID_DATA,
+          'Season ID is required',
+          { context: { operation: 'fetch_season_participants_count', accountId } },
+        ),
+      };
+    }
+
+    const headersResult = this.getHeaders(token);
+    if (!headersResult.success) {
+      return { success: false, error: headersResult.error };
+    }
+
+    const url = `/api/accounts/${accountId}/seasons/${seasonId}/participants/count`;
+
+    return this.executeRequest(
+      async () => {
+        const response = await this.fetchWithTimeout(url, {
+          headers: headersResult.data,
+        });
+
+        const data = await this.handleResponse<{
+          success: boolean;
+          data: {
+            seasonId: string;
+            participantCount: number;
+          };
+        }>(response);
+
+        if (
+          data.data?.participantCount === undefined ||
+          typeof data.data.participantCount !== 'number'
+        ) {
+          throw createEmailRecipientError(
+            EmailRecipientErrorCode.INVALID_DATA,
+            'Invalid season participants count response format',
+            {
+              details: { responseData: data },
+              context: { operation: 'fetch_season_participants_count', accountId, seasonId },
+            },
+          );
+        }
+
+        return data.data.participantCount;
+      },
+      {
+        operation: 'fetch_season_participants_count',
         additionalData: { endpoint: url },
       },
     );


### PR DESCRIPTION
- Add new API endpoint for season participants count with proper RBAC and account boundary enforcement
- Add new API endpoint for leagues with optional player counts (seasonId/leagues)
- Update OpenAPI documentation for both new endpoints with comprehensive schemas
- Implement LeagueSelectionContent component for league selection in email recipients
- Update NewGroupSelectionPanel to integrate league selection with proper state management
- Add league fetching and participant count services to emailRecipientService
- Include proper error handling, loading states, and participant count display

🤖 Generated with [Claude Code](https://claude.ai/code)