### PR TITLE
fix: resolve email content race condition by sharing editor ref

### DIFF
--- a/draco-nodejs/frontend-next/types/emails/compose.ts
+++ b/draco-nodejs/frontend-next/types/emails/compose.ts
@@ -157,6 +157,11 @@ export interface EmailComposeProviderProps {
   onSendComplete?: (emailId: string) => void;
   onDraftSaved?: (draftId: string) => void;
   onError?: (error: Error) => void;
+  editorRef?: React.RefObject<{
+    getCurrentContent: () => string;
+    getTextContent: () => string;
+    insertText: (text: string) => void;
+  } | null>;
 }
 
 /**


### PR DESCRIPTION
- Share editor ref between EmailComposePage and EmailComposeProvider
- Fix race condition where email content state wasn't synced when sending
- Extract contact IDs from selected groups for email sending
- Ensure latest editor content is used instead of potentially stale state

🤖 Generated with [Claude Code](https://claude.ai/code)