### PR TITLE
Debug photo upload serializer not called

### DIFF
--- a/draco-nodejs/frontend-next/services/rosterOperationsService.ts
+++ b/draco-nodejs/frontend-next/services/rosterOperationsService.ts
@@ -12,11 +12,11 @@ interface ErrorDetail {
   location?: string;
 }
 
-// Backend contact input format (updated to use middleName)
+// Backend contact input format (uses lowercase backend field names)
 interface ContactInputData {
   firstname?: string;
   lastname?: string;
-  middleName?: string; // ✅ Updated to use middleName instead of middlename
+  middlename?: string; // ✅ Uses lowercase middlename to match backend validation
   email?: string;
   phone1?: string;
   phone2?: string;
@@ -541,7 +541,7 @@ export class RosterOperationsService {
       if (contactData.firstName) contactInputData.firstname = contactData.firstName;
       if (contactData.lastName) contactInputData.lastname = contactData.lastName;
       if (contactData.middleName !== undefined)
-        contactInputData.middleName = contactData.middleName;
+        contactInputData.middlename = contactData.middleName;
       if (contactData.email !== undefined) contactInputData.email = contactData.email;
       if (contactData.phone1 !== undefined) contactInputData.phone1 = contactData.phone1;
       if (contactData.phone2 !== undefined) contactInputData.phone2 = contactData.phone2;

--- a/draco-nodejs/frontend-next/services/userManagementService.ts
+++ b/draco-nodejs/frontend-next/services/userManagementService.ts
@@ -380,7 +380,7 @@ export class UserManagementService {
       backendData.lastname = contactData.lastName.trim();
     }
     if (contactData.middleName !== undefined) {
-      backendData.middleName = contactData.middleName;
+      backendData.middlename = contactData.middleName;
     }
     if (contactData.email && contactData.email.trim()) {
       backendData.email = contactData.email.trim();
@@ -516,7 +516,7 @@ export class UserManagementService {
       backendData.lastname = contactData.lastName;
     }
     if (contactData.middleName !== undefined) {
-      backendData.middleName = contactData.middleName;
+      backendData.middlename = contactData.middleName;
     }
     if (contactData.email !== undefined) {
       backendData.email = contactData.email;


### PR DESCRIPTION
Fix `middleName` field name mismatch in frontend services to align with backend `middlename` validation.

The frontend was sending `middleName` (camelCase) in FormData and JSON bodies, while the backend validation expected `middlename` (lowercase). This mismatch caused photo + data uploads to fail silently. This PR ensures consistent lowercase field naming for backend API communication.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcdda1b1-361f-4c2d-b4bb-699435f002e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fcdda1b1-361f-4c2d-b4bb-699435f002e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

