### PR TITLE
Add account-specific icons to page metadata

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/compose/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/compose/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import ComposeClientWrapper from './ComposeClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Compose Email"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Compose Email`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/history/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/history/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import HistoryClientWrapper from './HistoryClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Email History"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Email History`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import CommunicationsClientWrapper from './CommunicationsClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Communications"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Communications`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/[templateId]/edit/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/[templateId]/edit/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../../lib/metadataFetchers';
 import EditTemplateClientWrapper from './EditTemplateClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Edit Email Template"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Edit Email Template`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/new/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/new/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../lib/metadataFetchers';
 import CreateTemplateClientWrapper from './CreateTemplateClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Create Email Template"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Create Email Template`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/communications/templates/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import TemplatesClientWrapper from './TemplatesClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Email Templates"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Email Templates`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/home/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/home/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import AccountHomeClientWrapper from './AccountHomeClientWrapper';
 
 // Dynamically set the page title to "{Account Name} Home"
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Home`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/player-classifieds/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/player-classifieds/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import PlayerClassifiedsClientWrapper from './PlayerClassifiedsClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Player Classifieds`,
     description: `Find players and teams through classified ads for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/page.tsx
@@ -1,11 +1,12 @@
-import { getAccountName } from '@/lib/metadataFetchers';
+import { getAccountBranding } from '@/lib/metadataFetchers';
 import ScheduleClientWrapper from './ScheduleClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Schedule`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/standings/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/standings/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../lib/metadataFetchers';
 import StandingsClientWrapper from './StandingsClientWrapper';
 
 export async function generateMetadata({
@@ -7,9 +7,10 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; seasonId: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Standings`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/page.tsx
@@ -7,9 +7,10 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; seasonId: string; teamSeasonId: string }>;
 }) {
   const { accountId, seasonId, teamSeasonId } = await params;
-  const { account, league, team } = await getTeamInfo(accountId, seasonId, teamSeasonId);
+  const { account, league, team, iconUrl } = await getTeamInfo(accountId, seasonId, teamSeasonId);
   return {
     title: `${account} ${league} ${team}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/roster/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/roster/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../../../lib/metadataFetchers';
 import TeamRosterManagementClientWrapper from './TeamRosterManagementClientWrapper';
 
 export async function generateMetadata({
@@ -7,9 +7,10 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; seasonId: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Team Roster`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../lib/metadataFetchers';
 import TeamsClientWrapper from './TeamsClientWrapper';
 
 export async function generateMetadata({
@@ -7,9 +7,10 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; seasonId: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Teams`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import StatisticsClientWrapper from './StatisticsClientWrapper';
 
 export async function generateMetadata({
@@ -7,10 +7,11 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; seasonId: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Statistics`,
     description: `View detailed baseball statistics for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/users/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/users/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import UserManagementClientWrapper from './UserManagementClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `User Management - ${accountName}`,
     description: `Manage users and roles for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/verify-classified/[id]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/verify-classified/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import VerifyClassifiedClientWrapper from './VerifyClassifiedClientWrapper';
 
 export async function generateMetadata({
@@ -7,10 +7,11 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; id: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} - Verify Teams Wanted Classified`,
     description: `Verify access to your Teams Wanted classified ad for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/workouts/[workoutId]/edit/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/workouts/[workoutId]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../../lib/metadataFetchers';
 import EditWorkoutClientWrapper from './EditWorkoutClientWrapper';
 
 export async function generateMetadata({
@@ -7,10 +7,11 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; workoutId: string }>;
 }) {
   const { accountId, workoutId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `Edit Workout - ${accountName}`,
     description: `Edit workout ${workoutId} for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/workouts/[workoutId]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/workouts/[workoutId]/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import WorkoutDetailsClientWrapper from './WorkoutDetailsClientWrapper';
 
 export async function generateMetadata({
@@ -7,10 +7,11 @@ export async function generateMetadata({
   params: Promise<{ accountId: string; workoutId: string }>;
 }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `Preview Workout - ${accountName}`,
     description: `Preview how this workout will appear on the home page for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/workouts/new/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/workouts/new/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import NewWorkoutClientWrapper from './NewWorkoutClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `New Workout - ${accountName}`,
     description: `Create a new workout for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/workouts/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/workouts/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
 import WorkoutsClientWrapper from './WorkoutsClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `${accountName} Workouts`,
     description: `Manage workouts for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/workouts/sources/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/workouts/sources/page.tsx
@@ -1,12 +1,13 @@
-import { getAccountName } from '../../../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import WorkoutSourcesClientWrapper from './WorkoutSourcesClientWrapper';
 
 export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
   const { accountId } = await params;
-  const accountName = await getAccountName(accountId);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
   return {
     title: `Workout Where Heard - ${accountName}`,
     description: `Manage where-heard options for workouts at ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
   };
 }
 

--- a/draco-nodejs/frontend-next/app/login/[[...params]]/page.tsx
+++ b/draco-nodejs/frontend-next/app/login/[[...params]]/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../lib/metadataFetchers';
 import { Suspense } from 'react';
 import LoginClientWrapper from '../LoginClientWrapper';
 
@@ -10,13 +10,20 @@ export async function generateMetadata({
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   const { accountId } = (await searchParams) as any;
   let title = 'Sign In - Draco Sports Manager';
+  let icons: { icon: string } | undefined;
   if (accountId) {
-    const accountName = await getAccountName(accountId);
+    const { name: accountName, iconUrl } = await getAccountBranding(accountId);
     if (accountName) {
       title = `Sign In - ${accountName}`;
     }
+    if (iconUrl) {
+      icons = { icon: iconUrl };
+    }
   }
-  return { title };
+  return {
+    title,
+    ...(icons ? { icons } : {}),
+  };
 }
 
 export default function Page() {

--- a/draco-nodejs/frontend-next/app/reset-password/[[...params]]/page.tsx
+++ b/draco-nodejs/frontend-next/app/reset-password/[[...params]]/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../lib/metadataFetchers';
 import { Suspense } from 'react';
 import ResetPasswordClientWrapper from '../ResetPasswordClientWrapper';
 
@@ -10,13 +10,20 @@ export async function generateMetadata({
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   const { accountId } = (await searchParams) as any;
   let title = 'Password Reset - Draco Sports Manager';
+  let icons: { icon: string } | undefined;
   if (accountId) {
-    const accountName = await getAccountName(accountId);
+    const { name: accountName, iconUrl } = await getAccountBranding(accountId);
     if (accountName) {
       title = `Password Reset - ${accountName}`;
     }
+    if (iconUrl) {
+      icons = { icon: iconUrl };
+    }
   }
-  return { title };
+  return {
+    title,
+    ...(icons ? { icons } : {}),
+  };
 }
 
 export default function Page() {

--- a/draco-nodejs/frontend-next/app/signup/[[...params]]/page.tsx
+++ b/draco-nodejs/frontend-next/app/signup/[[...params]]/page.tsx
@@ -1,4 +1,4 @@
-import { getAccountName } from '../../../lib/metadataFetchers';
+import { getAccountBranding } from '../../../lib/metadataFetchers';
 import { Suspense } from 'react';
 import SignupClientWrapper from '../SignupClientWrapper';
 
@@ -10,13 +10,20 @@ export async function generateMetadata({
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   const { accountId } = (await searchParams) as any;
   let title = 'Sign Up - Draco Sports Manager';
+  let icons: { icon: string } | undefined;
   if (accountId) {
-    const accountName = await getAccountName(accountId);
+    const { name: accountName, iconUrl } = await getAccountBranding(accountId);
     if (accountName) {
       title = `Sign Up - ${accountName}`;
     }
+    if (iconUrl) {
+      icons = { icon: iconUrl };
+    }
   }
-  return { title };
+  return {
+    title,
+    ...(icons ? { icons } : {}),
+  };
 }
 
 export default function Page() {

--- a/draco-nodejs/frontend-next/lib/metadataFetchers.ts
+++ b/draco-nodejs/frontend-next/lib/metadataFetchers.ts
@@ -1,11 +1,11 @@
-// Utility functions for fetching metadata for page titles
+// Utility functions for fetching metadata for page titles and icons
 
-export async function getAccountName(accountId: string): Promise<string> {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  if (!apiUrl) {
-    throw new Error('NEXT_PUBLIC_API_URL environment variable is required for SSR');
-  }
+interface AccountBranding {
+  name: string;
+  iconUrl: string | null;
+}
 
+async function fetchAccountName(apiUrl: string, accountId: string): Promise<string> {
   try {
     const res = await fetch(`${apiUrl}/api/accounts/${accountId}/name`, {
       next: { revalidate: 60 },
@@ -22,18 +22,50 @@ export async function getAccountName(accountId: string): Promise<string> {
   return 'Account';
 }
 
+export async function getAccountBranding(accountId: string): Promise<AccountBranding> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) {
+    throw new Error('NEXT_PUBLIC_API_URL environment variable is required for SSR');
+  }
+
+  try {
+    const res = await fetch(`${apiUrl}/api/accounts/${accountId}/header`, {
+      next: { revalidate: 60 },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data?.success && data?.data?.name) {
+        return {
+          name: data.data.name,
+          iconUrl: data.data.accountLogoUrl ?? null,
+        };
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to fetch account branding:', error);
+  }
+
+  const fallbackName = await fetchAccountName(apiUrl, accountId);
+  return {
+    name: fallbackName,
+    iconUrl: null,
+  };
+}
+
+export async function getAccountName(accountId: string): Promise<string> {
+  const { name } = await getAccountBranding(accountId);
+  return name;
+}
+
 export async function getTeamInfo(
   accountId: string,
   seasonId: string,
   teamSeasonId: string,
-): Promise<{ account: string; league: string; team: string }> {
-  let account = 'Account';
+): Promise<{ account: string; league: string; team: string; iconUrl: string | null }> {
+  const { name: account, iconUrl } = await getAccountBranding(accountId);
   let league = 'League';
   let team = 'Team';
   try {
-    // Fetch account name
-    account = await getAccountName(accountId);
-    // Fetch team info
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
     if (!apiUrl) {
       throw new Error('NEXT_PUBLIC_API_URL environment variable is required for SSR');
@@ -52,7 +84,7 @@ export async function getTeamInfo(
   } catch (error) {
     console.warn('Failed to fetch team info:', error);
   }
-  return { account, league, team };
+  return { account, league, team, iconUrl };
 }
 
 export async function getLeagueName(


### PR DESCRIPTION
## Summary
- add an account branding helper that provides name and logo data for metadata generation
- include icon entries in account and authentication page `generateMetadata` implementations so favicons follow the selected account

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68d0ad4854688327b13f83c44871437a