### PR TITLE
replace swagger comments with jsdoc summaries

### DIFF
--- a/draco-nodejs/backend/src/routes/accounts-workouts.ts
+++ b/draco-nodejs/backend/src/routes/accounts-workouts.ts
@@ -33,39 +33,12 @@ const registrationLimiter = rateLimit({
 });
 
 /**
- * @swagger
- * tags:
- *   - name: Workouts
- *     description: Account workouts and registrations
+ * Workouts API routes for account-specific workout management and registrations.
  */
 
 /**
- * @swagger
- * /api/accounts/{accountId}/workouts:
- *   get:
- *     summary: List workouts
- *     description: Public endpoint to list workouts for an account
- *     tags: [Workouts]
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *       - in: query
- *         name: status
- *         schema:
- *           type: string
- *           enum: [upcoming, past, all]
- *       - in: query
- *         name: limit
- *         schema:
- *           type: integer
- *           minimum: 1
- *           maximum: 100
- *     responses:
- *       200:
- *         description: List of workouts
+ * GET /api/accounts/:accountId/workouts
+ * Public endpoint that lists workouts with optional status and pagination filters.
  */
 router.get(
   '/:accountId/workouts',
@@ -137,28 +110,8 @@ router.post(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/workouts/{workoutId}:
- *   get:
- *     summary: Get workout details
- *     description: Public endpoint to get a workout
- *     tags: [Workouts]
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: workoutId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Workout details
- *       404:
- *         description: Workout not found
+ * GET /api/accounts/:accountId/workouts/:workoutId
+ * Retrieves a single workout for public consumption, returning 404 when absent.
  */
 router.get(
   '/:accountId/workouts/:workoutId',
@@ -260,27 +213,8 @@ router.put(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/workouts/{workoutId}:
- *   delete:
- *     summary: Delete a workout
- *     security:
- *       - bearerAuth: []
- *     tags: [Workouts]
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: workoutId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Deleted
+ * DELETE /api/accounts/:accountId/workouts/:workoutId
+ * Deletes a workout when the caller has the workout.manage permission.
  */
 router.delete(
   '/:accountId/workouts/:workoutId',
@@ -296,27 +230,8 @@ router.delete(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/workouts/{workoutId}/registrations:
- *   get:
- *     summary: List registrations for a workout
- *     security:
- *       - bearerAuth: []
- *     tags: [Workouts]
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: workoutId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: List of registrations
+ * GET /api/accounts/:accountId/workouts/:workoutId/registrations
+ * Lists registrations for a workout (requires workout.manage permission).
  */
 router.get(
   '/:accountId/workouts/:workoutId/registrations',

--- a/draco-nodejs/backend/src/routes/leagues.ts
+++ b/draco-nodejs/backend/src/routes/leagues.ts
@@ -20,68 +20,8 @@ const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
 
 /**
- * @swagger
- * /api/accounts/{accountId}/leagues:
- *   get:
- *     summary: Get all leagues for an account
- *     description: Retrieve all leagues for a specific account (requires account access)
- *     tags: [Leagues]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *     responses:
- *       200:
- *         description: Leagues retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     leagues:
- *                       type: array
- *                       items:
- *                         type: object
- *                         properties:
- *                           id:
- *                             type: string
- *                             example: "101"
- *                           name:
- *                             type: string
- *                             example: "Major League"
- *                           accountId:
- *                             type: string
- *                             example: "123"
- *       401:
- *         description: Unauthorized
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: Forbidden - no access to account
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * GET /api/accounts/:accountId/leagues
+ * Returns all leagues for the specified account (requires authentication).
  */
 router.get(
   '/',
@@ -154,79 +94,8 @@ router.get(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/leagues/{leagueId}:
- *   get:
- *     summary: Get specific league details
- *     description: Retrieve details for a specific league (requires account access)
- *     tags: [Leagues]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *       - in: path
- *         name: leagueId
- *         required: true
- *         schema:
- *           type: string
- *         description: League ID
- *         example: "101"
- *     responses:
- *       200:
- *         description: League details retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     league:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: string
- *                           example: "101"
- *                         name:
- *                           type: string
- *                           example: "Major League"
- *                         accountId:
- *                           type: string
- *                           example: "123"
- *       401:
- *         description: Unauthorized
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: Forbidden - no access to account
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       404:
- *         description: League not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * GET /api/accounts/:accountId/leagues/:leagueId
+ * Retrieves details for a single league within the account.
  */
 router.get(
   '/:leagueId',
@@ -265,91 +134,8 @@ router.get(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/leagues:
- *   post:
- *     summary: Create a new league
- *     description: Create a new league for an account (requires AccountAdmin or Administrator)
- *     tags: [Leagues]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - name
- *             properties:
- *               name:
- *                 type: string
- *                 description: League name
- *                 example: "Minor League"
- *     responses:
- *       201:
- *         description: League created successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     league:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: string
- *                           example: "102"
- *                         name:
- *                           type: string
- *                           example: "Minor League"
- *                         accountId:
- *                           type: string
- *                           example: "123"
- *       400:
- *         description: Missing league name
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       401:
- *         description: Unauthorized
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: Forbidden - requires AccountAdmin or Administrator
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       409:
- *         description: League with this name already exists
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * POST /api/accounts/:accountId/leagues
+ * Creates a new league for the account (requires account admin privileges).
  */
 router.post(
   '/',

--- a/draco-nodejs/backend/src/routes/monitoring.ts
+++ b/draco-nodejs/backend/src/routes/monitoring.ts
@@ -7,31 +7,8 @@ import { DateUtils } from '../utils/dateUtils.js';
 const router = Router();
 
 /**
- * @swagger
- * /api/monitoring/health:
- *   get:
- *     summary: Get comprehensive system health status
- *     tags: [Monitoring]
- *     responses:
- *       200:
- *         description: System health information
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: string
- *                   enum: [healthy, warning, critical]
- *                 timestamp:
- *                   type: string
- *                   format: date-time
- *                 database:
- *                   type: object
- *                 performance:
- *                   type: object
- *                 uptime:
- *                   type: number
+ * GET /api/monitoring/health
+ * Provides aggregated health details covering database connectivity, performance, and uptime.
  */
 router.get('/health', async (req: Request, res: Response) => {
   try {
@@ -89,20 +66,8 @@ router.get('/health', async (req: Request, res: Response) => {
 });
 
 /**
- * @swagger
- * /api/monitoring/performance:
- *   get:
- *     summary: Get detailed performance metrics
- *     tags: [Monitoring]
- *     parameters:
- *       - in: query
- *         name: window
- *         schema:
- *           type: integer
- *         description: Time window in minutes (default 5)
- *     responses:
- *       200:
- *         description: Performance metrics
+ * GET /api/monitoring/performance
+ * Returns recent performance metrics, optionally scoped by a time window.
  */
 router.get('/performance', (req: Request, res: Response) => {
   try {
@@ -158,20 +123,8 @@ router.get('/performance', (req: Request, res: Response) => {
 });
 
 /**
- * @swagger
- * /api/monitoring/slow-queries:
- *   get:
- *     summary: Get recent slow queries
- *     tags: [Monitoring]
- *     parameters:
- *       - in: query
- *         name: limit
- *         schema:
- *           type: integer
- *         description: Number of queries to return (default 20)
- *     responses:
- *       200:
- *         description: List of slow queries
+ * GET /api/monitoring/slow-queries
+ * Lists recent slow database queries with optional limits.
  */
 router.get('/slow-queries', (req: Request, res: Response) => {
   try {
@@ -201,14 +154,8 @@ router.get('/slow-queries', (req: Request, res: Response) => {
 });
 
 /**
- * @swagger
- * /api/monitoring/connection-pool:
- *   get:
- *     summary: Get connection pool status
- *     tags: [Monitoring]
- *     responses:
- *       200:
- *         description: Connection pool metrics
+ * GET /api/monitoring/connection-pool
+ * Reports current database connection pool utilization and recommendations.
  */
 router.get('/connection-pool', (req: Request, res: Response) => {
   try {
@@ -266,14 +213,8 @@ function getConnectionPoolRecommendations(metrics: {
 }
 
 /**
- * @swagger
- * /api/monitoring/reset:
- *   post:
- *     summary: Reset performance monitoring data
- *     tags: [Monitoring]
- *     responses:
- *       200:
- *         description: Monitoring data reset successfully
+ * POST /api/monitoring/reset
+ * Clears collected monitoring statistics.
  */
 router.post('/reset', (req: Request, res: Response) => {
   try {
@@ -293,14 +234,8 @@ router.post('/reset', (req: Request, res: Response) => {
 });
 
 /**
- * @swagger
- * /api/monitoring/config:
- *   get:
- *     summary: Get current monitoring configuration
- *     tags: [Monitoring]
- *     responses:
- *       200:
- *         description: Current monitoring configuration
+ * GET /api/monitoring/config
+ * Returns current monitoring configuration values and system metadata.
  */
 router.get('/config', (req: Request, res: Response) => {
   try {

--- a/draco-nodejs/backend/src/routes/seasons.ts
+++ b/draco-nodejs/backend/src/routes/seasons.ts
@@ -49,85 +49,8 @@ const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
 
 /**
- * @swagger
- * /api/accounts/{accountId}/seasons:
- *   get:
- *     summary: Get all seasons for an account
- *     description: Retrieve all seasons for a specific account (requires account access)
- *     tags: [Seasons]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *     responses:
- *       200:
- *         description: Seasons retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     seasons:
- *                       type: array
- *                       items:
- *                         type: object
- *                         properties:
- *                           id:
- *                             type: string
- *                             example: "456"
- *                           name:
- *                             type: string
- *                             example: "2024 Season"
- *                           accountId:
- *                             type: string
- *                             example: "123"
- *                           isCurrent:
- *                             type: boolean
- *                             example: true
- *                           leagues:
- *                             type: array
- *                             items:
- *                               type: object
- *                               properties:
- *                                 id:
- *                                   type: string
- *                                   example: "789"
- *                                 leagueId:
- *                                   type: string
- *                                   example: "101"
- *                                 leagueName:
- *                                   type: string
- *                                   example: "Major League"
- *       401:
- *         description: Unauthorized
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: Forbidden - no access to account
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * GET /api/accounts/:accountId/seasons
+ * Lists seasons for the account, including league associations.
  */
 router.get(
   '/',
@@ -212,75 +135,8 @@ router.get(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/seasons/current:
- *   get:
- *     summary: Get current season for an account
- *     description: Retrieve the current season for a specific account
- *     tags: [Seasons]
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *     responses:
- *       200:
- *         description: Current season retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     season:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: string
- *                           example: "456"
- *                         name:
- *                           type: string
- *                           example: "2024 Season"
- *                         accountId:
- *                           type: string
- *                           example: "123"
- *                         isCurrent:
- *                           type: boolean
- *                           example: true
- *                         leagues:
- *                           type: array
- *                           items:
- *                             type: object
- *                             properties:
- *                               id:
- *                                 type: string
- *                                 example: "789"
- *                               leagueId:
- *                                 type: string
- *                                 example: "101"
- *                               leagueName:
- *                                 type: string
- *                                 example: "Major League"
- *       404:
- *         description: No current season found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * GET /api/accounts/:accountId/seasons/current
+ * Returns the account's current season and its league assignments.
  */
 router.get(
   '/current',
@@ -348,93 +204,8 @@ router.get(
 );
 
 /**
- * @swagger
- * /api/accounts/{accountId}/seasons/{seasonId}:
- *   get:
- *     summary: Get specific season details
- *     description: Retrieve details for a specific season (requires account access)
- *     tags: [Seasons]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: accountId
- *         required: true
- *         schema:
- *           type: string
- *         description: Account ID
- *         example: "123"
- *       - in: path
- *         name: seasonId
- *         required: true
- *         schema:
- *           type: string
- *         description: Season ID
- *         example: "456"
- *     responses:
- *       200:
- *         description: Season details retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 data:
- *                   type: object
- *                   properties:
- *                     season:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: string
- *                           example: "456"
- *                         name:
- *                           type: string
- *                           example: "2024 Season"
- *                         accountId:
- *                           type: string
- *                           example: "123"
- *                         leagues:
- *                           type: array
- *                           items:
- *                             type: object
- *                             properties:
- *                               id:
- *                                 type: string
- *                                 example: "789"
- *                               leagueId:
- *                                 type: string
- *                                 example: "101"
- *                               leagueName:
- *                                 type: string
- *                                 example: "Major League"
- *       401:
- *         description: Unauthorized
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       403:
- *         description: Forbidden - no access to account
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       404:
- *         description: Season not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ * GET /api/accounts/:accountId/seasons/:seasonId
+ * Retrieves details for a specific season within the account context.
  */
 router.get(
   '/:seasonId',

--- a/draco-nodejs/backend/src/routes/webhookRoutes.ts
+++ b/draco-nodejs/backend/src/routes/webhookRoutes.ts
@@ -8,106 +8,20 @@ import { asyncHandler } from '../utils/asyncHandler.js';
 const router = Router();
 
 /**
- * @swagger
- * /api/webhooks/sendgrid:
- *   post:
- *     tags: [Webhooks]
- *     summary: Handle SendGrid webhook events
- *     description: Receives and processes webhook events from SendGrid for email delivery tracking
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: array
- *             items:
- *               type: object
- *               properties:
- *                 email:
- *                   type: string
- *                 timestamp:
- *                   type: number
- *                 event:
- *                   type: string
- *                   enum: [delivered, bounce, dropped, open, click, processed, deferred]
- *                 sg_event_id:
- *                   type: string
- *                 sg_message_id:
- *                   type: string
- *     responses:
- *       200:
- *         description: Webhook processed successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 message:
- *                   type: string
- *                 processed:
- *                   type: number
- *                 total:
- *                   type: number
- *                 errors:
- *                   type: number
- *       401:
- *         description: Invalid webhook signature
- *       400:
- *         description: Invalid webhook payload
- *       500:
- *         description: Internal server error
+ * POST /api/webhooks/sendgrid
+ * Receives webhook events from SendGrid and processes delivery updates.
  */
 router.post('/sendgrid', asyncHandler(WebhookController.handleSendGridWebhook));
 
 /**
- * @swagger
- * /api/webhooks/health:
- *   get:
- *     tags: [Webhooks]
- *     summary: Webhook health check
- *     description: Health check endpoint for webhook system
- *     responses:
- *       200:
- *         description: Webhook system is healthy
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: string
- *                 timestamp:
- *                   type: string
- *                 provider:
- *                   type: string
- *                 webhooks:
- *                   type: object
+ * GET /api/webhooks/health
+ * Provides a basic health check for webhook integrations.
  */
 router.get('/health', asyncHandler(WebhookController.healthCheck));
 
 /**
- * @swagger
- * /api/webhooks/stats:
- *   get:
- *     tags: [Webhooks]
- *     summary: Get webhook statistics
- *     description: Returns statistics about webhook processing
- *     responses:
- *       200:
- *         description: Webhook statistics
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 total_events_processed:
- *                   type: number
- *                 last_event_timestamp:
- *                   type: string
- *                 provider_status:
- *                   type: object
- *       500:
- *         description: Failed to get statistics
+ * GET /api/webhooks/stats
+ * Returns aggregate statistics about processed webhook events.
  */
 router.get('/stats', asyncHandler(WebhookController.getWebhookStats));
 


### PR DESCRIPTION
## Summary
- replace the remaining Swagger docblocks in backend route files with concise JSDoc route summaries now that OpenAPI lives in openapi.yaml

## Testing
- npm run lint:fix --workspaces

------
https://chatgpt.com/codex/tasks/task_e_68d0afb892d08327a010d7093f47a8d1