### PR TITLE
Document OpenAPI client usage in frontend docs

### DIFF
--- a/draco-nodejs/frontend-next/AGENTS.md
+++ b/draco-nodejs/frontend-next/AGENTS.md
@@ -15,3 +15,8 @@
 - `types` and `utils` — Shared types and helpers sourced from `@draco/shared-schemas`.
 
 Refer back to the architecture guide for component patterns, data flow, and integration examples.
+
+## OpenAPI Client Usage
+- Always create the generated OpenAPI client with `useApiClient()`.
+- Every call to a generated operation **must** include `client: apiClient` in the options object (see `useRosterDataManager` for examples).
+- Omitting the client causes the helper to throw because it lacks the HTTP transport configuration.

--- a/draco-nodejs/frontend-next/FRONTEND_ARCHITECTURE.md
+++ b/draco-nodejs/frontend-next/FRONTEND_ARCHITECTURE.md
@@ -186,6 +186,22 @@ export function useServiceHook(accountId: string) {
 }
 ```
 
+### OpenAPI Client Integration
+
+Generated operations from `@draco/shared-api-client` expect a configured HTTP client. Always hydrate them with the shared instance returned from `useApiClient`, which wraps `createClient`/`createConfig` and injects the active auth token.
+
+```typescript
+const apiClient = useApiClient();
+
+const result = await apiGetContactRoster({
+  path: { accountId, contactId },
+  client: apiClient,
+  throwOnError: false,
+});
+```
+
+Leaving out the `client` parameter causes the generated helper to throw because it has no transport configuration. Keep the `client: apiClient` field in every OpenAPI call (for example `apiUpdateRosterMember({...})` in `useRosterDataManager`) so requests inherit the authenticated base configuration.
+
 ### State Management Pattern
 
 Use consistent state management patterns throughout the application.


### PR DESCRIPTION
## Summary
- document the requirement to hydrate generated OpenAPI calls with the shared api client in the frontend architecture guide
- update the frontend agent guide with the same instruction so contributors consistently include `client: apiClient`

## Testing
- npm run lint:fix --workspaces

------
https://chatgpt.com/codex/tasks/task_e_68d17d7782bc8327bcc9638c3ed0ed08