### PR TITLE
Add metadata for season and account settings pages

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/SeasonManagementClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/SeasonManagementClientWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import SeasonManagement from './SeasonManagement';
+import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
+
+export default function SeasonManagementClientWrapper() {
+  return (
+    <ProtectedRoute requiredRole="AccountAdmin" checkAccountBoundary={true}>
+      <SeasonManagement />
+    </ProtectedRoute>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/page.tsx
@@ -1,11 +1,16 @@
-'use client';
-import SeasonManagement from './SeasonManagement';
-import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
+import { getAccountBranding } from '@/lib/metadataFetchers';
+import SeasonManagementClientWrapper from './SeasonManagementClientWrapper';
+
+export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
+  const { accountId } = await params;
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
+  return {
+    title: `Season Management - ${accountName}`,
+    description: `Manage seasons and league assignments for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
+  };
+}
 
 export default function Page() {
-  return (
-    <ProtectedRoute requiredRole="AccountAdmin" checkAccountBoundary={true}>
-      <SeasonManagement />
-    </ProtectedRoute>
-  );
+  return <SeasonManagementClientWrapper />;
 }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/settings/AccountSettingsClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/settings/AccountSettingsClientWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import AccountSettings from './AccountSettings';
+import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
+
+export default function AccountSettingsClientWrapper() {
+  return (
+    <ProtectedRoute requiredRole="AccountAdmin" checkAccountBoundary={true}>
+      <AccountSettings />
+    </ProtectedRoute>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/settings/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/settings/page.tsx
@@ -1,11 +1,16 @@
-'use client';
-import AccountSettings from './AccountSettings';
-import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
+import { getAccountBranding } from '@/lib/metadataFetchers';
+import AccountSettingsClientWrapper from './AccountSettingsClientWrapper';
+
+export async function generateMetadata({ params }: { params: Promise<{ accountId: string }> }) {
+  const { accountId } = await params;
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
+  return {
+    title: `Account Settings - ${accountName}`,
+    description: `Manage account configuration details for ${accountName}`,
+    ...(iconUrl ? { icons: { icon: iconUrl } } : {}),
+  };
+}
 
 export default function Page() {
-  return (
-    <ProtectedRoute requiredRole="AccountAdmin" checkAccountBoundary={true}>
-      <AccountSettings />
-    </ProtectedRoute>
-  );
+  return <AccountSettingsClientWrapper />;
 }


### PR DESCRIPTION
## Summary
- add ClientWrapper components and dynamic metadata for the season management route
- add ClientWrapper component and dynamic metadata for the account settings route

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68d1a90f20dc8327bb6f5d71f9693dcd