### PR TITLE
refine default sports favicon handling

### DIFF
--- a/draco-nodejs/.gitignore
+++ b/draco-nodejs/.gitignore
@@ -71,6 +71,11 @@ dist
 # Gatsby files
 .cache/
 public
+!frontend-next/public/
+frontend-next/public/*
+!frontend-next/public/branding/
+frontend-next/public/branding/*
+!frontend-next/public/branding/default-sports-favicon.svg
 
 # Storybook build outputs
 .out

--- a/draco-nodejs/frontend-next/lib/metadataFetchers.ts
+++ b/draco-nodejs/frontend-next/lib/metadataFetchers.ts
@@ -5,6 +5,30 @@ interface AccountBranding {
   iconUrl: string | null;
 }
 
+const DEFAULT_ACCOUNT_FAVICON_PATH = '/branding/default-sports-favicon.svg' as const;
+
+function resolveAccountFavicon(accountHeaderData: unknown): string {
+  if (typeof accountHeaderData !== 'object' || !accountHeaderData) {
+    return DEFAULT_ACCOUNT_FAVICON_PATH;
+  }
+
+  const branding = (accountHeaderData as { branding?: unknown }).branding;
+  if (typeof branding === 'object' && branding) {
+    const { faviconUrl, tabIconUrl } = branding as {
+      faviconUrl?: string | null;
+      tabIconUrl?: string | null;
+    };
+    if (faviconUrl) {
+      return faviconUrl;
+    }
+    if (tabIconUrl) {
+      return tabIconUrl;
+    }
+  }
+
+  return DEFAULT_ACCOUNT_FAVICON_PATH;
+}
+
 async function fetchAccountName(apiUrl: string, accountId: string): Promise<string> {
   try {
     const res = await fetch(`${apiUrl}/api/accounts/${accountId}/name`, {
@@ -39,7 +63,7 @@ export async function getAccountBranding(accountId: string): Promise<AccountBran
       if (data?.success && data?.data?.name) {
         return {
           name: data.data.name,
-          iconUrl: data.data.accountLogoUrl ?? null,
+          iconUrl: resolveAccountFavicon(data.data),
         };
       }
     }
@@ -50,7 +74,7 @@ export async function getAccountBranding(accountId: string): Promise<AccountBran
   const fallbackName = await fetchAccountName(apiUrl, accountId);
   return {
     name: fallbackName,
-    iconUrl: null,
+    iconUrl: DEFAULT_ACCOUNT_FAVICON_PATH,
   };
 }
 

--- a/draco-nodejs/frontend-next/public/branding/default-sports-favicon.svg
+++ b/draco-nodejs/frontend-next/public/branding/default-sports-favicon.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="shieldGradient" x1="12%" y1="8%" x2="88%" y2="92%" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0052CC" />
+      <stop offset="100%" stop-color="#06C167" />
+    </linearGradient>
+    <linearGradient id="ballGradient" x1="30%" y1="20%" x2="80%" y2="70%" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0.4" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="16" fill="url(#shieldGradient)" />
+  <path
+    d="M12 28c7 2.5 14 3.8 20 3.8s13-1.3 20-3.8"
+    fill="none"
+    stroke="#042A5E"
+    stroke-width="3.5"
+    stroke-linecap="round"
+  />
+  <path
+    d="M12 40c7-2.5 14-3.8 20-3.8s13 1.3 20 3.8"
+    fill="none"
+    stroke="#042A5E"
+    stroke-width="3.5"
+    stroke-linecap="round"
+  />
+  <path
+    d="M26 10c4.8 5 7.2 12.5 7.2 22s-2.4 17-7.2 22"
+    fill="none"
+    stroke="#042A5E"
+    stroke-width="3.5"
+    stroke-linecap="round"
+  />
+  <path
+    d="M38 10c-4.8 5-7.2 12.5-7.2 22s2.4 17 7.2 22"
+    fill="none"
+    stroke="#042A5E"
+    stroke-width="3.5"
+    stroke-linecap="round"
+  />
+  <circle cx="40" cy="24" r="11" fill="#F9F9F9" stroke="#042A5E" stroke-width="2" />
+  <circle cx="40" cy="24" r="9" fill="url(#ballGradient)" />
+  <path
+    d="M33.8 19.2c2.4 2 6.8 2 9.2 0"
+    fill="none"
+    stroke="#DD3345"
+    stroke-width="1.6"
+    stroke-linecap="round"
+  />
+  <path
+    d="M33.4 28.6c2-1.4 6.6-1.4 8.6 0"
+    fill="none"
+    stroke="#DD3345"
+    stroke-width="1.6"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- narrow the gitignore override so only the default sports favicon asset is tracked under the frontend public folder
- resolve account branding metadata to prefer any future favicon-specific URLs while defaulting to the bundled sports favicon
- redesign the default sports favicon graphic with a shield-and-ball motif that better communicates the sports theme

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68d1a6b199188327ac5ee1036ba95876