### PR TITLE
remove view all workouts button from join league dashboard

### DIFF
--- a/draco-nodejs/frontend-next/components/join-league/JoinLeagueDashboard.tsx
+++ b/draco-nodejs/frontend-next/components/join-league/JoinLeagueDashboard.tsx
@@ -11,6 +11,8 @@ interface JoinLeagueDashboardProps {
   account: AccountType;
   workouts: WorkoutSummary[];
   token?: string;
+  showViewAllWorkoutsButton?: boolean;
+  onViewAllWorkouts?: () => void;
 }
 
 const JoinLeagueDashboard: React.FC<JoinLeagueDashboardProps> = ({
@@ -18,6 +20,8 @@ const JoinLeagueDashboard: React.FC<JoinLeagueDashboardProps> = ({
   account,
   workouts,
   token,
+  showViewAllWorkoutsButton,
+  onViewAllWorkouts,
 }) => {
   const hasAnyContent = workouts.length > 0;
 
@@ -78,7 +82,13 @@ const JoinLeagueDashboard: React.FC<JoinLeagueDashboardProps> = ({
             },
           }}
         >
-          <TrainingSection workouts={workouts} accountId={accountId} token={token} />
+          <TrainingSection
+            workouts={workouts}
+            accountId={accountId}
+            token={token}
+            showViewAllWorkoutsButton={showViewAllWorkoutsButton}
+            onViewAllWorkouts={onViewAllWorkouts}
+          />
         </Box>
 
         {/* Players Wanted Section */}

--- a/draco-nodejs/frontend-next/components/join-league/TrainingSection.tsx
+++ b/draco-nodejs/frontend-next/components/join-league/TrainingSection.tsx
@@ -10,9 +10,17 @@ interface TrainingSectionProps {
   workouts: WorkoutSummary[];
   accountId: string;
   token?: string;
+  showViewAllWorkoutsButton?: boolean;
+  onViewAllWorkouts?: () => void;
 }
 
-const TrainingSection: React.FC<TrainingSectionProps> = ({ workouts, accountId, token }) => {
+const TrainingSection: React.FC<TrainingSectionProps> = ({
+  workouts,
+  accountId,
+  token,
+  showViewAllWorkoutsButton = false,
+  onViewAllWorkouts,
+}) => {
   if (workouts.length === 0) {
     return null;
   }
@@ -23,6 +31,11 @@ const TrainingSection: React.FC<TrainingSectionProps> = ({ workouts, accountId, 
         icon={<FitnessCenter />}
         title="Training & Tryouts"
         description="Register for upcoming workouts and training sessions"
+        actionButton={
+          showViewAllWorkoutsButton && onViewAllWorkouts
+            ? { label: 'View All Workouts', onClick: onViewAllWorkouts }
+            : undefined
+        }
       />
       <Box
         sx={{


### PR DESCRIPTION
## Summary
- allow the join-league training section to opt into its view-all control
- default the training section to render without the view-all workouts button so the baseball account home no longer exposes it

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68d1cdf487d48327bad2b299302b49d1