### PR TITLE
refactor account contact creation and deletion routes

### DIFF
--- a/draco-nodejs/backend/src/services/contactDependencyService.ts
+++ b/draco-nodejs/backend/src/services/contactDependencyService.ts
@@ -9,20 +9,10 @@ import { ValidationError } from '../utils/customErrors.js';
 import { ContactPhotoService } from './contactPhotoService.js';
 import { ServiceFactory } from './serviceFactory.js';
 import { ContactService } from './contactService.js';
-
-export interface ContactDependency {
-  table: string;
-  count: number;
-  description: string;
-  riskLevel: 'critical' | 'high' | 'medium' | 'low';
-}
-
-export interface DependencyCheckResult {
-  canDelete: boolean;
-  dependencies: ContactDependency[];
-  message: string;
-  totalDependencies: number;
-}
+import {
+  ContactDependencyType,
+  ContactDependencyCheckType,
+} from '@draco/shared-schemas';
 
 /**
  * Configuration for contact dependency checks
@@ -30,7 +20,7 @@ export interface DependencyCheckResult {
  */
 const DEPENDENCY_CONFIG: Record<
   string,
-  { description: string; riskLevel: ContactDependency['riskLevel'] }
+  { description: string; riskLevel: ContactDependencyType['riskLevel'] }
 > = {
   // Critical - Core player/user data
   roster: { description: 'Player records', riskLevel: 'critical' },
@@ -71,8 +61,8 @@ export class ContactDependencyService {
   /**
    * Check all dependencies for a contact before deletion
    */
-  async checkDependencies(contactId: bigint, accountId: bigint): Promise<DependencyCheckResult> {
-    const dependencies: ContactDependency[] = [];
+  async checkDependencies(contactId: bigint, accountId: bigint): Promise<ContactDependencyCheckType> {
+    const dependencies: ContactDependencyType[] = [];
 
     // First check if this contact is the account owner - this is a blocking condition
     const isAccountOwner = await this.contactService.checkIfAccountOwner(contactId, accountId);

--- a/draco-nodejs/shared/shared-schemas/contact.ts
+++ b/draco-nodejs/shared/shared-schemas/contact.ts
@@ -150,6 +150,83 @@ export const AutomaticRoleHoldersSchema = z
     description: 'Automatic role holders',
   });
 
+const booleanQueryParam = z.preprocess((value) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+
+  return undefined;
+}, z.boolean().optional());
+
+export const ContactDeletionQuerySchema = z
+  .object({
+    force: booleanQueryParam.default(false),
+    check: booleanQueryParam.default(false),
+  })
+  .openapi({
+    title: 'ContactDeletionQuery',
+    description: 'Query parameters controlling deletion vs preview behaviour',
+  });
+
+export const ContactDependencySchema = z
+  .object({
+    table: z.string(),
+    count: z.number().int().nonnegative(),
+    description: z.string(),
+    riskLevel: z.enum(['critical', 'high', 'medium', 'low']),
+  })
+  .openapi({
+    title: 'ContactDependency',
+    description: 'Dependency record referencing related data preventing contact deletion',
+  });
+
+export const ContactDependencyCheckSchema = z
+  .object({
+    canDelete: z.boolean(),
+    dependencies: ContactDependencySchema.array(),
+    message: z.string(),
+    totalDependencies: z.number().int().nonnegative(),
+  })
+  .openapi({
+    title: 'ContactDependencyCheck',
+    description: 'Result of dependency analysis for a contact deletion request',
+  });
+
+export const ContactDeletionPreviewSchema = z
+  .object({
+    contact: BaseContactSchema,
+    dependencyCheck: ContactDependencyCheckSchema,
+  })
+  .openapi({
+    title: 'ContactDeletionPreview',
+    description: 'Preview information returned when requesting a deletion dependency check',
+  });
+
+export const ContactDeletionSummarySchema = z
+  .object({
+    deletedContact: BaseContactSchema,
+    dependenciesDeleted: z.number().int().nonnegative(),
+    wasForced: z.boolean(),
+    message: z.string().optional(),
+  })
+  .openapi({
+    title: 'ContactDeletionSummary',
+    description: 'Summary returned after a contact has been deleted',
+  });
+
+export const ContactDeletionResponseSchema = z
+  .union([ContactDeletionPreviewSchema, ContactDeletionSummarySchema])
+  .openapi({
+    title: 'ContactDeletionResponse',
+    description: 'Response returned from the contact deletion endpoint',
+  });
+
 export const ContactValidationSchema = CreateContactSchema.safeExtend({
   validationType: z.enum(['streetAddress', 'dateOfBirth']),
 })
@@ -209,6 +286,12 @@ export type PagedContactType = z.infer<typeof PagedContactSchema>;
 export type TeamWithNameType = z.infer<typeof TeamWithNameSchema>;
 export type TeamManagerWithTeamsType = z.infer<typeof TeamManagerWithTeams>;
 export type AutomaticRoleHoldersType = z.infer<typeof AutomaticRoleHoldersSchema>;
+export type ContactDeletionQueryType = z.infer<typeof ContactDeletionQuerySchema>;
+export type ContactDependencyType = z.infer<typeof ContactDependencySchema>;
+export type ContactDependencyCheckType = z.infer<typeof ContactDependencyCheckSchema>;
+export type ContactDeletionPreviewType = z.infer<typeof ContactDeletionPreviewSchema>;
+export type ContactDeletionSummaryType = z.infer<typeof ContactDeletionSummarySchema>;
+export type ContactDeletionResponseType = z.infer<typeof ContactDeletionResponseSchema>;
 export type ContactValidationType = z.infer<typeof ContactValidationSchema>;
 export type ContactValidationWithSignInType = z.infer<typeof ContactValidationWithSignInSchema>;
 export type SignInUserNameType = z.infer<typeof SignInUserNameSchema>;


### PR DESCRIPTION
## Summary
- add contact deletion query/response schemas so backend and SDK share dependency-check contracts
- refactor contact service/dependency service to handle contact creation and deletion flows under the new architecture
- update account contact routes and OpenAPI documentation to validate with shared schemas and surface the new responses

## Testing
- `npm run lint -w @draco/backend`

------
https://chatgpt.com/codex/tasks/task_e_68d225f9321083279693b4e95c6007a5