### PR TITLE
Add proprietary license file and update build packaging docs

### DIFF
--- a/LICENSES/PROPRIETARY_LICENSE.txt
+++ b/LICENSES/PROPRIETARY_LICENSE.txt
@@ -1,0 +1,85 @@
+PROPRIETARY SOFTWARE LICENSE AGREEMENT
+=====================================
+
+IMPORTANT: READ THIS LICENSE CAREFULLY BEFORE INSTALLING OR USING THE SOFTWARE.
+
+This Proprietary Software License Agreement ("Agreement") governs use of the
+Draco software, related components, and any accompanying documentation
+(collectively, the "Software") provided by Draco Labs, Inc. ("Licensor"). By
+installing, copying, or otherwise using the Software, you ("Licensee") agree to
+be bound by the terms of this Agreement. If you do not agree to the terms of
+this Agreement, do not install or use the Software.
+
+1. GRANT OF LICENSE
+   Licensor grants Licensee a non-exclusive, non-transferable, revocable license
+   to install and use the Software solely for Licensee's internal business
+   purposes in accordance with the documentation provided by Licensor.
+
+2. RESTRICTIONS
+   Licensee shall not, and shall not permit any third party to: (a) copy,
+   distribute, or sublicense the Software, except as expressly permitted in this
+   Agreement; (b) modify, translate, adapt, or create derivative works of the
+   Software; (c) reverse engineer, decompile, disassemble, or otherwise attempt
+   to derive the source code of the Software; (d) remove or obscure any
+   proprietary notices or labels on the Software; or (e) use the Software in any
+   manner that violates applicable laws or regulations.
+
+3. OWNERSHIP
+   The Software is licensed, not sold. Licensor retains all rights, title, and
+   interest in and to the Software, including all intellectual property rights.
+   This Agreement does not convey to Licensee any ownership rights in the
+   Software.
+
+4. TERM AND TERMINATION
+   This Agreement is effective until terminated. Licensee may terminate this
+   Agreement at any time by uninstalling and destroying all copies of the
+   Software. Licensor may terminate this Agreement immediately if Licensee fails
+   to comply with any term of this Agreement. Upon termination, Licensee shall
+   cease all use of the Software and destroy all copies in Licensee's possession
+   or control.
+
+5. CONFIDENTIALITY
+   Licensee acknowledges that the Software contains trade secrets and other
+   proprietary information of Licensor. Licensee agrees to maintain the
+   confidentiality of the Software and not disclose the Software or any
+   proprietary information to any third party without Licensor's prior written
+   consent.
+
+6. WARRANTY DISCLAIMER
+   THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. LICENSOR
+   DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+   AND NON-INFRINGEMENT. LICENSOR DOES NOT WARRANT THAT THE SOFTWARE WILL MEET
+   LICENSEE'S REQUIREMENTS OR THAT THE OPERATION OF THE SOFTWARE WILL BE
+   UNINTERRUPTED OR ERROR-FREE.
+
+7. LIMITATION OF LIABILITY
+   TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR SHALL NOT BE LIABLE FOR ANY
+   INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY
+   LOSS OF PROFITS OR REVENUE, ARISING OUT OF OR IN CONNECTION WITH THIS
+   AGREEMENT OR THE USE OF THE SOFTWARE, EVEN IF LICENSOR HAS BEEN ADVISED OF
+   THE POSSIBILITY OF SUCH DAMAGES. LICENSOR'S TOTAL LIABILITY UNDER THIS
+   AGREEMENT SHALL NOT EXCEED THE AMOUNT PAID BY LICENSEE FOR THE SOFTWARE.
+
+8. INDEMNIFICATION
+   Licensee agrees to indemnify, defend, and hold harmless Licensor from and
+   against any claims, liabilities, damages, losses, or expenses, including
+   reasonable attorneys' fees, arising out of or in connection with Licensee's
+   use of the Software or breach of this Agreement.
+
+9. GOVERNING LAW AND JURISDICTION
+   This Agreement shall be governed by and construed in accordance with the laws
+   of the State of California, without regard to its conflict of law principles.
+   The parties consent to the exclusive jurisdiction of the state and federal
+   courts located in San Francisco County, California for the resolution of any
+   disputes arising out of or relating to this Agreement.
+
+10. ENTIRE AGREEMENT
+    This Agreement constitutes the entire agreement between the parties with
+    respect to the Software and supersedes all prior or contemporaneous
+    understandings regarding the Software. Any amendments or modifications must
+    be in writing and signed by both parties.
+
+By installing or using the Software, Licensee acknowledges that Licensee has
+read this Agreement, understands it, and agrees to be bound by its terms and
+conditions.

--- a/docs/build_integration.md
+++ b/docs/build_integration.md
@@ -1,0 +1,35 @@
+# Build Integration Checklist
+
+This guide outlines the required artifacts and packaging steps for distributing
+Draco product builds.
+
+## Required Artifacts
+
+- Compiled application binaries or container images for the target environment.
+- Environment-specific configuration files (for example, `.env.production`).
+- Database migration bundles generated from the `dbMigration` workspace when
+  applicable.
+- Proprietary end-user license agreement located at
+  `LICENSES/PROPRIETARY_LICENSE.txt`.
+
+## Packaging Steps
+
+1. Run the workspace build command appropriate for the release target.
+2. Collect the generated build artifacts alongside the required configuration
+   files listed above.
+3. Copy `LICENSES/PROPRIETARY_LICENSE.txt` into the root of the distribution
+   package so the installer or release bundle ships with the EULA.
+4. Update any installer scripts to display or link to the EULA during the
+   installation flow.
+5. Archive the final distribution package and confirm checksum and signing steps
+   per the release checklist.
+
+## Verification
+
+Before shipping a build:
+
+- Validate that the package includes the proprietary license file in the
+  expected path.
+- Smoke test the installation to ensure the EULA is presented to the user during
+  setup.
+- Record the build ID, checksum, and license version in the release notes.


### PR DESCRIPTION
## Summary
- add a proprietary end-user license agreement template under `LICENSES/PROPRIETARY_LICENSE.txt`
- document the requirement to bundle the proprietary license with release artifacts in `docs/build_integration.md`

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2ce5637f883279f3eccb933336ca4