### PR TITLE
Simplify login error messaging

### DIFF
--- a/draco-nodejs/frontend-next/context/AuthContext.tsx
+++ b/draco-nodejs/frontend-next/context/AuthContext.tsx
@@ -3,6 +3,9 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import axios from 'axios';
 import { SignInCredentialsType } from '@draco/shared-schemas';
 
+const LOGIN_ERROR_MESSAGE =
+  'Invalid username or password. If you forgot your password, click the "Forgot your password?" link to reset it.';
+
 interface User {
   id: string;
   username: string;
@@ -75,12 +78,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setLoading(false);
         return true;
       } else {
-        setError(response.data?.message || 'Sign in failed');
+        setError(LOGIN_ERROR_MESSAGE);
         setLoading(false);
         return false;
       }
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Sign in failed');
+      setError(LOGIN_ERROR_MESSAGE);
       setLoading(false);
       return false;
     }


### PR DESCRIPTION
## Summary
- replace detailed login failure errors with a consistent, user-friendly message and reset guidance

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68d332fbc4dc8327a94d30d3d49ee5f7