### PR TITLE
Add metadata generation for admin and account pages

### DIFF
--- a/draco-nodejs/frontend-next/app/account-management/AccountManagementClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account-management/AccountManagementClientWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ProtectedRoute from '../../components/auth/ProtectedRoute';
+import AccountManagement from './AccountManagement';
+
+export default function AccountManagementClientWrapper() {
+  return (
+    <ProtectedRoute requiredRole="Administrator" checkAccountBoundary={false}>
+      <AccountManagement />
+    </ProtectedRoute>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account-management/page.tsx
+++ b/draco-nodejs/frontend-next/app/account-management/page.tsx
@@ -1,11 +1,14 @@
-'use client';
-import AccountManagement from './AccountManagement';
-import ProtectedRoute from '../../components/auth/ProtectedRoute';
+import type { Metadata } from 'next';
+import AccountManagementClientWrapper from './AccountManagementClientWrapper';
+import { DEFAULT_ACCOUNT_FAVICON_PATH } from '../../lib/metadataFetchers';
+
+export function generateMetadata(): Metadata {
+  return {
+    title: 'Account Management - Draco Sports Manager',
+    icons: { icon: DEFAULT_ACCOUNT_FAVICON_PATH },
+  };
+}
 
 export default function Page() {
-  return (
-    <ProtectedRoute requiredRole="Administrator" checkAccountBoundary={false}>
-      <AccountManagement />
-    </ProtectedRoute>
-  );
+  return <AccountManagementClientWrapper />;
 }

--- a/draco-nodejs/frontend-next/app/accounts/Accounts.tsx
+++ b/draco-nodejs/frontend-next/app/accounts/Accounts.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useCallback } from 'react';
 import { Box, Typography, Paper, Button } from '@mui/material';
 import { useRouter, useParams } from 'next/navigation';

--- a/draco-nodejs/frontend-next/app/accounts/AccountsClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/accounts/AccountsClientWrapper.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import Accounts from './Accounts';
+
+export default function AccountsClientWrapper() {
+  return <Accounts />;
+}

--- a/draco-nodejs/frontend-next/app/accounts/page.tsx
+++ b/draco-nodejs/frontend-next/app/accounts/page.tsx
@@ -1,6 +1,14 @@
-'use client';
-import Accounts from './Accounts';
+import type { Metadata } from 'next';
+import AccountsClientWrapper from './AccountsClientWrapper';
+import { DEFAULT_ACCOUNT_FAVICON_PATH } from '../../lib/metadataFetchers';
+
+export function generateMetadata(): Metadata {
+  return {
+    title: 'Accounts - Draco Sports Manager',
+    icons: { icon: DEFAULT_ACCOUNT_FAVICON_PATH },
+  };
+}
 
 export default function Page() {
-  return <Accounts />;
+  return <AccountsClientWrapper />;
 }

--- a/draco-nodejs/frontend-next/app/admin/AdminDashboard.tsx
+++ b/draco-nodejs/frontend-next/app/admin/AdminDashboard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   Typography,

--- a/draco-nodejs/frontend-next/app/admin/AdminDashboardClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/admin/AdminDashboardClientWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ProtectedRoute from '../../components/auth/ProtectedRoute';
+import AdminDashboard from './AdminDashboard';
+
+export default function AdminDashboardClientWrapper() {
+  return (
+    <ProtectedRoute requiredRole="Administrator" checkAccountBoundary={false}>
+      <AdminDashboard />
+    </ProtectedRoute>
+  );
+}

--- a/draco-nodejs/frontend-next/app/admin/page.tsx
+++ b/draco-nodejs/frontend-next/app/admin/page.tsx
@@ -1,11 +1,14 @@
-'use client';
-import AdminDashboard from './AdminDashboard';
-import ProtectedRoute from '../../components/auth/ProtectedRoute';
+import type { Metadata } from 'next';
+import AdminDashboardClientWrapper from './AdminDashboardClientWrapper';
+import { DEFAULT_ACCOUNT_FAVICON_PATH } from '../../lib/metadataFetchers';
+
+export function generateMetadata(): Metadata {
+  return {
+    title: 'Administrator Dashboard - Draco Sports Manager',
+    icons: { icon: DEFAULT_ACCOUNT_FAVICON_PATH },
+  };
+}
 
 export default function Page() {
-  return (
-    <ProtectedRoute requiredRole="Administrator" checkAccountBoundary={false}>
-      <AdminDashboard />
-    </ProtectedRoute>
-  );
+  return <AdminDashboardClientWrapper />;
 }

--- a/draco-nodejs/frontend-next/lib/metadataFetchers.ts
+++ b/draco-nodejs/frontend-next/lib/metadataFetchers.ts
@@ -5,7 +5,7 @@ interface AccountBranding {
   iconUrl: string | null;
 }
 
-const DEFAULT_ACCOUNT_FAVICON_PATH = '/branding/default-sports-favicon.svg' as const;
+export const DEFAULT_ACCOUNT_FAVICON_PATH = '/branding/default-sports-favicon.svg' as const;
 
 function resolveAccountFavicon(accountHeaderData: unknown): string {
   if (typeof accountHeaderData !== 'object' || !accountHeaderData) {


### PR DESCRIPTION
## Summary
- export the shared default favicon path so it can be reused when composing metadata
- add metadata generation to the accounts, administrator dashboard, and account management routes
- mark the client-side dashboard components with the appropriate directive so metadata can be generated from the route files
- wrap the accounts, administrator dashboard, and account management routes in client wrappers to align with routing conventions

## Testing
- npm run frontend:lint

------
https://chatgpt.com/codex/tasks/task_e_68d335f7630083278485e131e9341e91