### PR TITLE
Fix contact search endpoint to respect role-only filter

### DIFF
--- a/draco-nodejs/backend/src/routes/accounts-contacts.ts
+++ b/draco-nodejs/backend/src/routes/accounts-contacts.ts
@@ -216,10 +216,11 @@ router.get(
   routeProtection.enforceAccountBoundary(),
   routeProtection.requirePermission('account.contacts.manage'),
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
-    const { q, roles, seasonId, contactDetails } = req.query; // search query, roles flag, and optional seasonId
+    const { q, roles, seasonId, contactDetails, onlyWithRoles } = req.query; // search query, roles flag, and optional seasonId
     const { accountId } = extractAccountParams(req.params);
     const includeRoles = roles === 'true';
     const includeContactDetails = contactDetails === 'true';
+    const filterOnlyWithRoles = onlyWithRoles === 'true';
 
     // Parse season ID if provided
     const parsedSeasonId = seasonId && typeof seasonId === 'string' ? BigInt(seasonId) : null;
@@ -230,6 +231,7 @@ router.get(
     // Use ContactService to get contacts with roles
     const result = await contactService.getContactsWithRoles(accountId, parsedSeasonId, {
       includeRoles,
+      onlyWithRoles: filterOnlyWithRoles,
       includeContactDetails,
       searchQuery: q ? q.toString() : undefined,
       pagination: paginationParams,


### PR DESCRIPTION
## Summary
- ensure the contacts search route reads the `onlyWithRoles` toggle
- forward the parsed flag to the contact service so filtering occurs on the backend

## Testing
- `npm run backend:test` *(fails: missing optional dependencies such as nodemailer and node-mocks-http in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d74b1ac74c83279eddbbde172401dc