### PR TITLE
Refactor seasons routes to layered architecture

### DIFF
--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSeasonsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSeasonsRepository.ts
@@ -1,0 +1,231 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  dbCurrentSeason,
+  dbLeagueSeasonBasic,
+  dbSeason,
+  dbSeasonWithLeagues,
+} from '../types/dbTypes.js';
+import { ISeasonsRepository } from '../interfaces/ISeasonsRepository.js';
+
+export class PrismaSeasonsRepository implements ISeasonsRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findAccountSeasons(
+    accountId: bigint,
+    includeDivisions: boolean,
+  ): Promise<dbSeasonWithLeagues[]> {
+    const seasons = await this.prisma.season.findMany({
+      where: { accountid: accountId },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+        leagueseason: {
+          select: {
+            id: true,
+            leagueid: true,
+            league: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+            divisionseason: {
+              select: {
+                id: true,
+                priority: true,
+                divisiondefs: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { name: 'desc' },
+    });
+
+    return seasons.map((season) => ({
+      ...season,
+      leagueseason: season.leagueseason.map((leagueSeason) => ({
+        ...leagueSeason,
+        divisionseason: includeDivisions ? leagueSeason.divisionseason : undefined,
+      })),
+    }));
+  }
+
+  async findSeasonWithLeagues(
+    accountId: bigint,
+    seasonId: bigint,
+    includeDivisions: boolean,
+  ): Promise<dbSeasonWithLeagues | null> {
+    const season = await this.prisma.season.findFirst({
+      where: { id: seasonId, accountid: accountId },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+        leagueseason: {
+          select: {
+            id: true,
+            leagueid: true,
+            league: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+            divisionseason: {
+              select: {
+                id: true,
+                priority: true,
+                divisiondefs: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!season) {
+      return null;
+    }
+
+    return {
+      ...season,
+      leagueseason: season.leagueseason.map((leagueSeason) => ({
+        ...leagueSeason,
+        divisionseason: includeDivisions ? leagueSeason.divisionseason : undefined,
+      })),
+    };
+  }
+
+  async findSeasonById(accountId: bigint, seasonId: bigint): Promise<dbSeason | null> {
+    return this.prisma.season.findFirst({
+      where: { id: seasonId, accountid: accountId },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+      },
+    });
+  }
+
+  async findSeasonByName(
+    accountId: bigint,
+    name: string,
+    excludeSeasonId?: bigint,
+  ): Promise<dbSeason | null> {
+    return this.prisma.season.findFirst({
+      where: {
+        accountid: accountId,
+        name,
+        ...(excludeSeasonId ? { id: { not: excludeSeasonId } } : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+      },
+    });
+  }
+
+  async createSeason(data: { name: string; accountid: bigint }): Promise<dbSeason> {
+    return this.prisma.season.create({
+      data,
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+      },
+    });
+  }
+
+  async updateSeasonName(seasonId: bigint, name: string): Promise<dbSeason> {
+    return this.prisma.season.update({
+      where: { id: seasonId },
+      data: { name },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+      },
+    });
+  }
+
+  async deleteSeason(seasonId: bigint): Promise<dbSeason> {
+    return this.prisma.season.delete({
+      where: { id: seasonId },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+      },
+    });
+  }
+
+  async findCurrentSeasonRecord(accountId: bigint): Promise<dbCurrentSeason | null> {
+    return this.prisma.currentseason.findUnique({
+      where: { accountid: accountId },
+      select: {
+        accountid: true,
+        seasonid: true,
+      },
+    });
+  }
+
+  async upsertCurrentSeason(accountId: bigint, seasonId: bigint): Promise<void> {
+    await this.prisma.currentseason.upsert({
+      where: { accountid: accountId },
+      update: { seasonid: seasonId },
+      create: { accountid: accountId, seasonid: seasonId },
+    });
+  }
+
+  async createLeagueSeason(seasonId: bigint, leagueId: bigint): Promise<dbLeagueSeasonBasic> {
+    return this.prisma.leagueseason.create({
+      data: {
+        seasonid: seasonId,
+        leagueid: leagueId,
+      },
+      select: {
+        id: true,
+        seasonid: true,
+        leagueid: true,
+        league: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+  }
+
+  async countSeasonParticipants(accountId: bigint, seasonId: bigint): Promise<number> {
+    return this.prisma.contacts.count({
+      where: {
+        roster: {
+          rosterseason: {
+            some: {
+              teamsseason: {
+                leagueseason: {
+                  seasonid: seasonId,
+                },
+              },
+            },
+          },
+        },
+        creatoraccountid: accountId,
+      },
+    });
+  }
+}

--- a/draco-nodejs/backend/src/repositories/implementations/index.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/index.ts
@@ -4,6 +4,7 @@ export * from './PrismaAccountRepository.js';
 export * from './PrismaCleanupRepository.js';
 export * from './PrismaContactRepository.js';
 export * from './PrismaSeasonRepository.js';
+export * from './PrismaSeasonsRepository.js';
 export * from './PrismaRoleRepository.js';
 export * from './PrismaLeagueRepository.js';
 export * from './PrismaPollRepository.js';

--- a/draco-nodejs/backend/src/repositories/interfaces/ISeasonsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/ISeasonsRepository.ts
@@ -1,0 +1,28 @@
+import {
+  dbCurrentSeason,
+  dbLeagueSeasonBasic,
+  dbSeason,
+  dbSeasonWithLeagues,
+} from '../types/dbTypes.js';
+
+export interface ISeasonsRepository {
+  findAccountSeasons(accountId: bigint, includeDivisions: boolean): Promise<dbSeasonWithLeagues[]>;
+  findSeasonWithLeagues(
+    accountId: bigint,
+    seasonId: bigint,
+    includeDivisions: boolean,
+  ): Promise<dbSeasonWithLeagues | null>;
+  findSeasonById(accountId: bigint, seasonId: bigint): Promise<dbSeason | null>;
+  findSeasonByName(
+    accountId: bigint,
+    name: string,
+    excludeSeasonId?: bigint,
+  ): Promise<dbSeason | null>;
+  createSeason(data: { name: string; accountid: bigint }): Promise<dbSeason>;
+  updateSeasonName(seasonId: bigint, name: string): Promise<dbSeason>;
+  deleteSeason(seasonId: bigint): Promise<dbSeason>;
+  findCurrentSeasonRecord(accountId: bigint): Promise<dbCurrentSeason | null>;
+  upsertCurrentSeason(accountId: bigint, seasonId: bigint): Promise<void>;
+  createLeagueSeason(seasonId: bigint, leagueId: bigint): Promise<dbLeagueSeasonBasic>;
+  countSeasonParticipants(accountId: bigint, seasonId: bigint): Promise<number>;
+}

--- a/draco-nodejs/backend/src/repositories/interfaces/index.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/index.ts
@@ -4,6 +4,7 @@ export * from './ITeamRepository.js';
 export * from './IAccountRepository.js';
 export * from './IContactRepository.js';
 export * from './ISeasonRepository.js';
+export * from './ISeasonsRepository.js';
 export * from './ICleanupRepository.js';
 export * from './IRoleRepository.js';
 export * from './ILeagueRepository.js';

--- a/draco-nodejs/backend/src/repositories/repositoryFactory.ts
+++ b/draco-nodejs/backend/src/repositories/repositoryFactory.ts
@@ -5,6 +5,7 @@ import {
   IContactRepository,
   IRoleRepository,
   ISeasonRepository,
+  ISeasonsRepository,
   ILeagueRepository,
   ICleanupRepository,
   IPollRepository,
@@ -29,6 +30,7 @@ import {
   PrismaContactRepository,
   PrismaRoleRepository,
   PrismaSeasonRepository,
+  PrismaSeasonsRepository,
   PrismaLeagueRepository,
   PrismaCleanupRepository,
   PrismaPollRepository,
@@ -60,6 +62,7 @@ export class RepositoryFactory {
   private static contactRepository: IContactRepository;
   private static roleRepository: IRoleRepository;
   private static seasonRepository: ISeasonRepository;
+  private static seasonsRepository: ISeasonsRepository;
   private static leagueRepository: ILeagueRepository;
   private static cleanupRepository: ICleanupRepository;
   private static pollRepository: IPollRepository;
@@ -124,6 +127,13 @@ export class RepositoryFactory {
       this.seasonRepository = new PrismaSeasonRepository(prisma);
     }
     return this.seasonRepository;
+  }
+
+  static getSeasonsRepository(): ISeasonsRepository {
+    if (!this.seasonsRepository) {
+      this.seasonsRepository = new PrismaSeasonsRepository(prisma);
+    }
+    return this.seasonsRepository;
   }
 
   static getCleanupRepository(): ICleanupRepository {

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -171,6 +171,49 @@ export type dbSeason = Prisma.seasonGetPayload<{
   };
 }>;
 
+export interface dbSeasonWithLeagues {
+  id: bigint;
+  name: string;
+  accountid: bigint;
+  leagueseason: Array<{
+    id: bigint;
+    leagueid: bigint;
+    league: {
+      id: bigint;
+      name: string;
+    };
+    divisionseason?: Array<{
+      id: bigint;
+      priority: number | null;
+      divisiondefs: {
+        id: bigint;
+        name: string;
+      } | null;
+    }>;
+  }>;
+}
+
+export type dbLeagueSeasonBasic = Prisma.leagueseasonGetPayload<{
+  select: {
+    id: true;
+    seasonid: true;
+    leagueid: true;
+    league: {
+      select: {
+        id: true;
+        name: true;
+      };
+    };
+  };
+}>;
+
+export type dbCurrentSeason = Prisma.currentseasonGetPayload<{
+  select: {
+    accountid: true;
+    seasonid: true;
+  };
+}>;
+
 export type dbContactRoles = Prisma.contactrolesGetPayload<{
   select: {
     id: true;

--- a/draco-nodejs/backend/src/responseFormatters/index.ts
+++ b/draco-nodejs/backend/src/responseFormatters/index.ts
@@ -16,3 +16,4 @@ export * from './MonitoringResponseFormatter.js';
 export * from './userResponseFormatter.js';
 export * from './managerResponseFormatter.js';
 export * from './seasonManagerResponseFormatter.js';
+export * from './seasonResponseFormatter.js';

--- a/draco-nodejs/backend/src/responseFormatters/seasonResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/seasonResponseFormatter.ts
@@ -1,0 +1,112 @@
+import {
+  LeagueSeasonWithDivisionType,
+  SeasonParticipantCountDataType,
+  SeasonType,
+} from '@draco/shared-schemas';
+import {
+  dbLeagueSeasonBasic,
+  dbSeason,
+  dbSeasonWithLeagues,
+} from '../repositories/index.js';
+
+interface SeasonFormatOptions {
+  includeDivisions: boolean;
+  currentSeasonId?: bigint | null;
+  forceCurrent?: boolean;
+}
+
+export class SeasonResponseFormatter {
+  static formatSeasonsWithLeagues(
+    seasons: dbSeasonWithLeagues[],
+    options: SeasonFormatOptions,
+  ): LeagueSeasonWithDivisionType[] {
+    return seasons.map((season) => this.formatSeasonWithLeagues(season, options));
+  }
+
+  static formatSeasonWithLeagues(
+    season: dbSeasonWithLeagues,
+    { includeDivisions, currentSeasonId, forceCurrent }: SeasonFormatOptions,
+  ): LeagueSeasonWithDivisionType {
+    const isCurrent = forceCurrent
+      ? true
+      : currentSeasonId
+      ? season.id === currentSeasonId
+      : false;
+
+    return {
+      id: season.id.toString(),
+      name: season.name,
+      accountId: season.accountid.toString(),
+      isCurrent,
+      leagues: season.leagueseason.map((leagueSeason) => {
+        const baseLeague = {
+          id: leagueSeason.id.toString(),
+          league: {
+            id: leagueSeason.leagueid.toString(),
+            name: leagueSeason.league.name,
+          },
+        };
+
+        if (!includeDivisions || !leagueSeason.divisionseason) {
+          return baseLeague;
+        }
+
+        return {
+          ...baseLeague,
+          divisions: leagueSeason.divisionseason.map((division) => ({
+            id: division.id.toString(),
+            division: {
+              id: division.divisiondefs?.id.toString() ?? '0',
+              name: division.divisiondefs?.name ?? 'Unknown Division',
+            },
+            priority: division.priority ?? 0,
+          })),
+        };
+      }),
+    };
+  }
+
+  static formatSeason(season: dbSeason, options?: { isCurrent?: boolean }): SeasonType {
+    const result: SeasonType = {
+      id: season.id.toString(),
+      name: season.name,
+      accountId: season.accountid.toString(),
+    };
+
+    if (typeof options?.isCurrent === 'boolean') {
+      result.isCurrent = options.isCurrent;
+    }
+
+    return result;
+  }
+
+  static formatSeasonWithLeagueBasics(
+    season: dbSeason,
+    leagueSeasons: dbLeagueSeasonBasic[],
+    options?: { isCurrent?: boolean },
+  ): LeagueSeasonWithDivisionType {
+    const formattedLeagues = leagueSeasons.map((leagueSeason) => ({
+      id: leagueSeason.id.toString(),
+      league: {
+        id: leagueSeason.leagueid.toString(),
+        name: leagueSeason.league.name,
+      },
+    }));
+
+    return {
+      ...this.formatSeason(season, options),
+      isCurrent: options?.isCurrent ?? false,
+      leagues: formattedLeagues,
+    };
+  }
+
+  static formatParticipantCount(
+    seasonId: bigint,
+    participantCount: number,
+  ): SeasonParticipantCountDataType {
+    return {
+      seasonId: seasonId.toString(),
+      participantCount,
+    };
+  }
+}

--- a/draco-nodejs/backend/src/routes/seasons.ts
+++ b/draco-nodejs/backend/src/routes/seasons.ts
@@ -1,627 +1,117 @@
-// Season Management Routes for Draco Sports Manager
-// Handles season creation, copying, and current season management
-
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
+import { UpsertSeasonSchema } from '@draco/shared-schemas';
 import { authenticateToken } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
-import prisma from '../lib/prisma.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
-import { NotFoundError } from '../utils/customErrors.js';
 import { extractAccountParams, extractSeasonParams } from '../utils/paramExtraction.js';
-import {
-  LeagueSeasonWithDivisionType,
-  SeasonParticipantCountDataType,
-  SeasonType,
-} from '@draco/shared-schemas';
-
-// Type definitions for Prisma query results
-
-interface dbLeagueSeasonWithLeague {
-  id: bigint;
-  seasonid: bigint;
-  leagueid: bigint;
-  league: {
-    id: bigint;
-    name: string;
-  };
-}
-
-interface dbSeasonWithLeagues {
-  id: bigint;
-  name: string;
-  accountid: bigint;
-  leagueseason: Array<{
-    id: bigint;
-    leagueid: bigint;
-    league: {
-      id: bigint;
-      name: string;
-    };
-    divisionseason?: Array<{
-      id: bigint;
-      priority?: number;
-      leagueseasonid?: bigint;
-      divisionid?: bigint;
-      divisiondefs?: {
-        id: bigint;
-        name: string;
-      };
-    }>;
-  }>;
-}
 
 const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
+const seasonService = ServiceFactory.getSeasonService();
 
-/**
- * GET /api/accounts/:accountId/seasons
- * Lists seasons for the account, including league associations.
- */
 router.get(
   '/',
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId } = extractAccountParams(req.params);
     const includeDivisions = req.query.includeDivisions === 'true';
 
-    const seasons = await prisma.season.findMany({
-      where: {
-        accountid: accountId,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-        leagueseason: {
-          select: {
-            id: true,
-            leagueid: true,
-            league: {
-              select: {
-                id: true,
-                name: true,
-              },
-            },
-            ...(includeDivisions && {
-              divisionseason: {
-                select: {
-                  id: true,
-                  divisiondefs: {
-                    select: {
-                      id: true,
-                      name: true,
-                    },
-                  },
-                },
-              },
-            }),
-          },
-        },
-      },
-      orderBy: {
-        name: 'desc', // Most recent first
-      },
-    });
+    const seasons = await seasonService.listAccountSeasons(accountId, includeDivisions);
 
-    // Get current season for this account
-    const currentSeason = await prisma.currentseason.findUnique({
-      where: {
-        accountid: accountId,
-      },
-      select: {
-        seasonid: true,
-      },
-    });
-
-    const result: LeagueSeasonWithDivisionType[] = seasons.map((season: dbSeasonWithLeagues) => ({
-      id: season.id.toString(),
-      name: season.name,
-      accountId: season.accountid.toString(),
-      isCurrent: currentSeason?.seasonid === season.id,
-      leagues: season.leagueseason.map((ls) => ({
-        id: ls.id.toString(),
-        league: { id: ls.leagueid.toString(), name: ls.league.name },
-        ...(includeDivisions &&
-          ls.divisionseason && {
-            divisions: ls.divisionseason.map((ds) => ({
-              id: ds.id.toString(), // Use divisionSeason.id for filtering
-              division: {
-                id: ds.divisiondefs?.id.toString() || '0',
-                name: ds.divisiondefs?.name || 'Unknown Division',
-              },
-              priority: ds.priority || 0,
-            })),
-          }),
-      })),
-    }));
-
-    res.json(result);
+    res.json(seasons);
   }),
 );
 
-/**
- * GET /api/accounts/:accountId/seasons/current
- * Returns the account's current season and its league assignments.
- */
 router.get(
   '/current',
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId } = extractAccountParams(req.params);
 
-    const currentSeason = await prisma.currentseason.findUnique({
-      where: {
-        accountid: accountId,
-      },
-      select: {
-        seasonid: true,
-      },
-    });
+    const season = await seasonService.getCurrentSeason(accountId);
 
-    if (!currentSeason) {
-      throw new NotFoundError('No current season set for this account');
-    }
-
-    // Get the season details
-    const season = await prisma.season.findUnique({
-      where: {
-        id: currentSeason.seasonid,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-        leagueseason: {
-          select: {
-            id: true,
-            leagueid: true,
-            league: {
-              select: {
-                id: true,
-                name: true,
-              },
-            },
-          },
-        },
-      },
-    });
-
-    if (!season) {
-      throw new NotFoundError('Current season not found');
-    }
-
-    const result: LeagueSeasonWithDivisionType = {
-      id: season.id.toString(),
-      name: season.name,
-      accountId: season.accountid.toString(),
-      isCurrent: true,
-      leagues: season.leagueseason.map((ls) => ({
-        id: ls.id.toString(),
-        league: { id: ls.leagueid.toString(), name: ls.league.name },
-      })),
-    };
-
-    res.json(result);
+    res.json(season);
   }),
 );
 
-/**
- * GET /api/accounts/:accountId/seasons/:seasonId
- * Retrieves details for a specific season within the account context.
- */
 router.get(
   '/:seasonId',
   authenticateToken,
   routeProtection.enforceAccountBoundary(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
 
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-        leagueseason: {
-          select: {
-            id: true,
-            leagueid: true,
-            league: {
-              select: {
-                id: true,
-                name: true,
-              },
-            },
-          },
-        },
-      },
-    });
+    const season = await seasonService.getSeason(accountId, seasonId);
 
-    if (!season) {
-      res.status(404).json({
-        success: false,
-        message: 'Season not found',
-      });
-      return;
-    }
-
-    // Check if this is the current season
-    const currentSeason = await prisma.currentseason.findUnique({
-      where: {
-        accountid: accountId,
-      },
-      select: {
-        seasonid: true,
-      },
-    });
-
-    const result: LeagueSeasonWithDivisionType = {
-      id: season.id.toString(),
-      name: season.name,
-      accountId: season.accountid.toString(),
-      isCurrent: currentSeason?.seasonid === season.id,
-      leagues: season.leagueseason.map((ls) => ({
-        id: ls.id.toString(),
-        league: { id: ls.leagueid.toString(), name: ls.league.name },
-      })),
-    };
-
-    res.json(result);
+    res.json(season);
   }),
 );
 
-/**
- * POST /api/accounts/:accountId/seasons
- * Create a new season (requires AccountAdmin or Administrator)
- */
 router.post(
   '/',
   authenticateToken,
   routeProtection.requireAccountAdmin(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
-    const { name } = req.body;
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId } = extractAccountParams(req.params);
+    const seasonInput = UpsertSeasonSchema.parse(req.body);
 
-    if (!name) {
-      res.status(400).json({
-        success: false,
-        message: 'Season name is required',
-      });
-      return;
-    }
+    const season = await seasonService.createSeason(accountId, seasonInput);
 
-    // Check if season with this name already exists for this account
-    const existingSeason = await prisma.season.findFirst({
-      where: {
-        name: name,
-        accountid: accountId,
-      },
-    });
-
-    if (existingSeason) {
-      res.status(409).json({
-        success: false,
-        message: 'A season with this name already exists for this account',
-      });
-      return;
-    }
-
-    const newSeason = await prisma.season.create({
-      data: {
-        name: name,
-        accountid: accountId,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-      },
-    });
-
-    const result: LeagueSeasonWithDivisionType = {
-      id: newSeason.id.toString(),
-      name: newSeason.name,
-      accountId: newSeason.accountid.toString(),
-      isCurrent: false,
-      leagues: [],
-    };
-
-    res.status(201).json(result);
+    res.status(201).json(season);
   }),
 );
 
-/**
- * PUT /api/accounts/:accountId/seasons/:seasonId
- * Update season name (requires AccountAdmin or Administrator)
- */
 router.put(
   '/:seasonId',
   authenticateToken,
   routeProtection.requireAccountAdmin(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
-    const { name } = req.body;
+    const seasonInput = UpsertSeasonSchema.parse(req.body);
 
-    if (!name) {
-      res.status(400).json({
-        success: false,
-        message: 'Season name is required',
-      });
-      return;
-    }
+    const season = await seasonService.updateSeason(accountId, seasonId, seasonInput);
 
-    // Check if season exists and belongs to this account
-    const existingSeason = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
-
-    if (!existingSeason) {
-      res.status(404).json({
-        success: false,
-        message: 'Season not found',
-      });
-      return;
-    }
-
-    // Check if another season with this name already exists for this account
-    const duplicateSeason = await prisma.season.findFirst({
-      where: {
-        name: name,
-        accountid: accountId,
-        id: { not: seasonId },
-      },
-    });
-
-    if (duplicateSeason) {
-      res.status(409).json({
-        success: false,
-        message: 'A season with this name already exists for this account',
-      });
-      return;
-    }
-
-    const updatedSeason = await prisma.season.update({
-      where: {
-        id: seasonId,
-      },
-      data: {
-        name: name,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-      },
-    });
-
-    const result: SeasonType = {
-      id: updatedSeason.id.toString(),
-      name: updatedSeason.name,
-      accountId: updatedSeason.accountid.toString(),
-    };
-
-    res.json(result);
+    res.json(season);
   }),
 );
 
-/**
- * POST /api/accounts/:accountId/seasons/:seasonId/copy
- * Copy a season (creates new season with same name + "Copy") (requires AccountAdmin or Administrator)
- */
 router.post(
   '/:seasonId/copy',
   authenticateToken,
   routeProtection.requireAccountAdmin(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
 
-    // Get the source season
-    const sourceSeason = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-      include: {
-        leagueseason: {
-          include: {
-            league: true,
-          },
-        },
-      },
-    });
+    const season = await seasonService.copySeason(accountId, seasonId);
 
-    if (!sourceSeason) {
-      res.status(404).json({
-        success: false,
-        message: 'Source season not found',
-      });
-      return;
-    }
-
-    // Generate new season name
-    const newSeasonName = `${sourceSeason.name} Copy`;
-
-    // Check if copy name already exists
-    const existingCopy = await prisma.season.findFirst({
-      where: {
-        name: newSeasonName,
-        accountid: accountId,
-      },
-    });
-
-    if (existingCopy) {
-      res.status(409).json({
-        success: false,
-        message: 'A season with this copy name already exists',
-      });
-      return;
-    }
-
-    // Create new season
-    const newSeason = await prisma.season.create({
-      data: {
-        name: newSeasonName,
-        accountid: accountId,
-      },
-      select: {
-        id: true,
-        name: true,
-        accountid: true,
-      },
-    });
-
-    // Copy league seasons (without teams/divisions for now)
-    const copiedLeagueSeasons = [];
-    for (const leagueSeason of sourceSeason.leagueseason) {
-      const newLeagueSeason = await prisma.leagueseason.create({
-        data: {
-          seasonid: newSeason.id,
-          leagueid: leagueSeason.leagueid,
-        },
-        select: {
-          id: true,
-          seasonid: true,
-          leagueid: true,
-          league: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-      });
-      copiedLeagueSeasons.push(newLeagueSeason);
-    }
-
-    const result: LeagueSeasonWithDivisionType = {
-      id: newSeason.id.toString(),
-      name: newSeason.name,
-      accountId: newSeason.accountid.toString(),
-      isCurrent: false,
-      leagues: copiedLeagueSeasons.map((ls: dbLeagueSeasonWithLeague) => ({
-        id: ls.id.toString(),
-        league: { id: ls.leagueid.toString(), name: ls.league.name },
-      })),
-    };
-
-    res.status(201).json(result);
+    res.status(201).json(season);
   }),
 );
 
-/**
- * POST /api/accounts/:accountId/seasons/:seasonId/set-current
- * Set a season as the current season for an account (requires AccountAdmin or Administrator)
- */
 router.post(
   '/:seasonId/set-current',
   authenticateToken,
   routeProtection.requireAccountAdmin(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
 
-    // Check if season exists and belongs to this account
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
+    const season = await seasonService.setCurrentSeason(accountId, seasonId);
 
-    if (!season) {
-      res.status(404).json({
-        success: false,
-        message: 'Season not found',
-      });
-      return;
-    }
-
-    // Use upsert to either create or update the current season
-    await prisma.currentseason.upsert({
-      where: {
-        accountid: accountId,
-      },
-      update: {
-        seasonid: seasonId,
-      },
-      create: {
-        accountid: accountId,
-        seasonid: seasonId,
-      },
-    });
-
-    const result: SeasonType = {
-      id: seasonId.toString(),
-      accountId: accountId.toString(),
-      isCurrent: true,
-      name: season.name,
-    };
-
-    res.json(result);
+    res.json(season);
   }),
 );
 
-/**
- * DELETE /api/accounts/:accountId/seasons/:seasonId
- * Delete a season (requires AccountAdmin or Administrator)
- * Note: This will fail if the season has any related data
- */
 router.delete(
   '/:seasonId',
   authenticateToken,
   routeProtection.requireAccountAdmin(),
-  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
 
-    // Check if season exists and belongs to this account
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
-
-    if (!season) {
-      res.status(404).json({
-        success: false,
-        message: 'Season not found',
-      });
-      return;
-    }
-
-    // Check if this is the current season
-    const currentSeason = await prisma.currentseason.findUnique({
-      where: {
-        accountid: accountId,
-      },
-    });
-
-    if (currentSeason && currentSeason.seasonid === seasonId) {
-      res.status(400).json({
-        success: false,
-        message: 'Cannot delete the current season. Set a different season as current first.',
-      });
-      return;
-    }
-
-    // Delete the season (this will cascade to related data)
-    await prisma.season.delete({
-      where: {
-        id: seasonId,
-      },
-    });
+    await seasonService.deleteSeason(accountId, seasonId);
 
     res.json(true);
   }),
 );
 
-/**
- * GET /api/accounts/:accountId/seasons/:seasonId/participants/count
- * Get the count of participants (contacts) in a season
- */
 router.get(
   '/:seasonId/participants/count',
   authenticateToken,
@@ -630,43 +120,9 @@ router.get(
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = extractSeasonParams(req.params);
 
-    // Verify season exists and belongs to account
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
+    const participantCount = await seasonService.getSeasonParticipantCount(accountId, seasonId);
 
-    if (!season) {
-      throw new NotFoundError('Season not found');
-    }
-
-    // Count distinct participants (contacts) in the season
-    // Participants are contacts who have roster entries for teams in this season
-    const participantCount = await prisma.contacts.count({
-      where: {
-        roster: {
-          rosterseason: {
-            some: {
-              teamsseason: {
-                leagueseason: {
-                  seasonid: seasonId,
-                },
-              },
-            },
-          },
-        },
-        creatoraccountid: accountId, // Ensure account boundary
-      },
-    });
-
-    const result: SeasonParticipantCountDataType = {
-      seasonId: seasonId.toString(),
-      participantCount,
-    };
-
-    res.json(result);
+    res.json(participantCount);
   }),
 );
 

--- a/draco-nodejs/backend/src/services/seasonService.ts
+++ b/draco-nodejs/backend/src/services/seasonService.ts
@@ -1,0 +1,211 @@
+import {
+  LeagueSeasonWithDivisionType,
+  SeasonParticipantCountDataType,
+  SeasonType,
+  UpsertSeasonType,
+} from '@draco/shared-schemas';
+import {
+  ISeasonsRepository,
+  RepositoryFactory,
+  dbLeagueSeasonBasic,
+} from '../repositories/index.js';
+import { SeasonResponseFormatter } from '../responseFormatters/index.js';
+import { ConflictError, NotFoundError, ValidationError } from '../utils/customErrors.js';
+
+export class SeasonService {
+  constructor(
+    private readonly seasonsRepository: ISeasonsRepository = RepositoryFactory.getSeasonsRepository(),
+  ) {}
+
+  async listAccountSeasons(
+    accountId: bigint,
+    includeDivisions: boolean,
+  ): Promise<LeagueSeasonWithDivisionType[]> {
+    const [seasons, currentSeasonRecord] = await Promise.all([
+      this.seasonsRepository.findAccountSeasons(accountId, includeDivisions),
+      this.seasonsRepository.findCurrentSeasonRecord(accountId),
+    ]);
+
+    return SeasonResponseFormatter.formatSeasonsWithLeagues(seasons, {
+      includeDivisions,
+      currentSeasonId: currentSeasonRecord?.seasonid ?? null,
+    });
+  }
+
+  async getCurrentSeason(accountId: bigint): Promise<LeagueSeasonWithDivisionType> {
+    const currentSeasonRecord = await this.seasonsRepository.findCurrentSeasonRecord(accountId);
+
+    if (!currentSeasonRecord) {
+      throw new NotFoundError('No current season set for this account');
+    }
+
+    const season = await this.seasonsRepository.findSeasonWithLeagues(
+      accountId,
+      currentSeasonRecord.seasonid,
+      false,
+    );
+
+    if (!season) {
+      throw new NotFoundError('Current season not found');
+    }
+
+    return SeasonResponseFormatter.formatSeasonWithLeagues(season, {
+      includeDivisions: false,
+      currentSeasonId: currentSeasonRecord.seasonid,
+      forceCurrent: true,
+    });
+  }
+
+  async getSeason(
+    accountId: bigint,
+    seasonId: bigint,
+  ): Promise<LeagueSeasonWithDivisionType> {
+    const [season, currentSeasonRecord] = await Promise.all([
+      this.seasonsRepository.findSeasonWithLeagues(accountId, seasonId, false),
+      this.seasonsRepository.findCurrentSeasonRecord(accountId),
+    ]);
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    return SeasonResponseFormatter.formatSeasonWithLeagues(season, {
+      includeDivisions: false,
+      currentSeasonId: currentSeasonRecord?.seasonid ?? null,
+    });
+  }
+
+  async createSeason(
+    accountId: bigint,
+    input: UpsertSeasonType,
+  ): Promise<LeagueSeasonWithDivisionType> {
+    const name = input.name.trim();
+
+    if (!name) {
+      throw new ValidationError('Season name is required');
+    }
+
+    const existingSeason = await this.seasonsRepository.findSeasonByName(accountId, name);
+    if (existingSeason) {
+      throw new ConflictError('A season with this name already exists for this account');
+    }
+
+    const newSeason = await this.seasonsRepository.createSeason({
+      name,
+      accountid: accountId,
+    });
+
+    return SeasonResponseFormatter.formatSeasonWithLeagueBasics(newSeason, [], { isCurrent: false });
+  }
+
+  async updateSeason(
+    accountId: bigint,
+    seasonId: bigint,
+    input: UpsertSeasonType,
+  ): Promise<SeasonType> {
+    const existingSeason = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+
+    if (!existingSeason) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const name = input.name.trim();
+
+    if (!name) {
+      throw new ValidationError('Season name is required');
+    }
+
+    const duplicateSeason = await this.seasonsRepository.findSeasonByName(accountId, name, seasonId);
+    if (duplicateSeason) {
+      throw new ConflictError('A season with this name already exists for this account');
+    }
+
+    const updatedSeason = await this.seasonsRepository.updateSeasonName(seasonId, name);
+    const currentSeasonRecord = await this.seasonsRepository.findCurrentSeasonRecord(accountId);
+
+    return SeasonResponseFormatter.formatSeason(updatedSeason, {
+      isCurrent: currentSeasonRecord?.seasonid === updatedSeason.id,
+    });
+  }
+
+  async copySeason(
+    accountId: bigint,
+    seasonId: bigint,
+  ): Promise<LeagueSeasonWithDivisionType> {
+    const sourceSeason = await this.seasonsRepository.findSeasonWithLeagues(accountId, seasonId, false);
+
+    if (!sourceSeason) {
+      throw new NotFoundError('Source season not found');
+    }
+
+    const newSeasonName = `${sourceSeason.name} Copy`;
+    const existingCopy = await this.seasonsRepository.findSeasonByName(accountId, newSeasonName);
+
+    if (existingCopy) {
+      throw new ConflictError('A season with this copy name already exists');
+    }
+
+    const newSeason = await this.seasonsRepository.createSeason({
+      name: newSeasonName,
+      accountid: accountId,
+    });
+
+    const copiedLeagueSeasons: dbLeagueSeasonBasic[] = [];
+    for (const leagueSeason of sourceSeason.leagueseason) {
+      const createdLeagueSeason = await this.seasonsRepository.createLeagueSeason(
+        newSeason.id,
+        leagueSeason.leagueid,
+      );
+      copiedLeagueSeasons.push(createdLeagueSeason);
+    }
+
+    return SeasonResponseFormatter.formatSeasonWithLeagueBasics(newSeason, copiedLeagueSeasons, {
+      isCurrent: false,
+    });
+  }
+
+  async setCurrentSeason(accountId: bigint, seasonId: bigint): Promise<SeasonType> {
+    const season = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    await this.seasonsRepository.upsertCurrentSeason(accountId, seasonId);
+
+    return SeasonResponseFormatter.formatSeason(season, { isCurrent: true });
+  }
+
+  async deleteSeason(accountId: bigint, seasonId: bigint): Promise<boolean> {
+    const season = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const currentSeasonRecord = await this.seasonsRepository.findCurrentSeasonRecord(accountId);
+
+    if (currentSeasonRecord?.seasonid === seasonId) {
+      throw new ValidationError('Cannot delete the current season. Set a different season as current first.');
+    }
+
+    await this.seasonsRepository.deleteSeason(seasonId);
+
+    return true;
+  }
+
+  async getSeasonParticipantCount(
+    accountId: bigint,
+    seasonId: bigint,
+  ): Promise<SeasonParticipantCountDataType> {
+    const season = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const participantCount = await this.seasonsRepository.countSeasonParticipants(accountId, seasonId);
+
+    return SeasonResponseFormatter.formatParticipantCount(seasonId, participantCount);
+  }
+}

--- a/draco-nodejs/backend/src/services/serviceFactory.ts
+++ b/draco-nodejs/backend/src/services/serviceFactory.ts
@@ -39,6 +39,7 @@ import { LeagueService } from './LeagueService.js';
 import { MonitoringService } from './monitoringService.js';
 import { UserService } from './userService.js';
 import { RepositoryFactory } from '../repositories/repositoryFactory.js';
+import { SeasonService } from './seasonService.js';
 
 /**
  * Service factory to provide service instances without direct Prisma dependencies
@@ -54,6 +55,7 @@ export class ServiceFactory {
   private static routeProtection: RouteProtection;
   private static rosterService: RosterService;
   private static contactService: ContactService;
+  private static seasonService: SeasonService;
   private static seasonManagerService: SeasonManagerService;
   private static registrationService: RegistrationService;
   private static authService: AuthService;
@@ -140,6 +142,13 @@ export class ServiceFactory {
       this.contactService = new ContactService();
     }
     return this.contactService;
+  }
+
+  static getSeasonService(): SeasonService {
+    if (!this.seasonService) {
+      this.seasonService = new SeasonService();
+    }
+    return this.seasonService;
   }
 
   static getSeasonManagerService(): SeasonManagerService {


### PR DESCRIPTION
## Summary
- add a dedicated seasons service, repository, and formatter to orchestrate account season workflows
- wire the seasons repository and supporting db types into the factories and shared exports
- rewrite the seasons routes to validate inputs and delegate all business logic to the new service layer

## Testing
- npm run lint -w @draco/backend

------
https://chatgpt.com/codex/tasks/task_e_68e1dcd38090832780e3a621a6279f22