### PR TITLE
Remove password reset test mode

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -18574,9 +18574,6 @@
                   "email": {
                     "type": "string",
                     "minLength": 1
-                  },
-                  "testMode": {
-                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -18588,7 +18585,7 @@
         },
         "responses": {
           "200": {
-            "description": "Password reset token generated (email is sent or test token returned).",
+            "description": "Password reset token generated and email sent when the account exists.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18612,25 +18609,6 @@
                       "required": [
                         "success",
                         "message"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "token": {
-                          "type": "string"
-                        },
-                        "userId": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "token",
-                        "userId",
-                        "email"
                       ]
                     }
                   ]

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -12727,14 +12727,12 @@ paths:
                 email:
                   type: string
                   minLength: 1
-                testMode:
-                  type: boolean
               required:
                 - email
       responses:
         "200":
-          description: Password reset token generated (email is sent or test token
-            returned).
+          description: Password reset token generated and email sent when the account
+            exists.
           content:
             application/json:
               schema:
@@ -12751,18 +12749,6 @@ paths:
                     required:
                       - success
                       - message
-                  - type: object
-                    properties:
-                      token:
-                        type: string
-                      userId:
-                        type: string
-                      email:
-                        type: string
-                    required:
-                      - token
-                      - userId
-                      - email
         "400":
           description: Invalid request payload.
           content:

--- a/draco-nodejs/backend/src/openapi/paths/password-reset/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/password-reset/index.ts
@@ -10,7 +10,6 @@ export const registerPasswordResetEndpoints = ({ registry, schemaRefs, z }: Regi
 
   const passwordResetRequestBodySchema = z.object({
     email: z.string().trim().min(1),
-    testMode: z.boolean().optional(),
   });
 
   const passwordResetRequestResponseSchema = z.union([
@@ -18,11 +17,6 @@ export const registerPasswordResetEndpoints = ({ registry, schemaRefs, z }: Regi
     z.object({
       success: z.boolean(),
       message: z.string(),
-    }),
-    z.object({
-      token: z.string(),
-      userId: z.string(),
-      email: z.string(),
     }),
   ]);
 
@@ -45,7 +39,7 @@ export const registerPasswordResetEndpoints = ({ registry, schemaRefs, z }: Regi
     },
     responses: {
       200: {
-        description: 'Password reset token generated (email is sent or test token returned).',
+        description: 'Password reset token generated and email sent when the account exists.',
         content: {
           'application/json': {
             schema: passwordResetRequestResponseSchema,

--- a/draco-nodejs/backend/src/responseFormatters/userResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/userResponseFormatter.ts
@@ -1,24 +1,10 @@
-import { RegisteredUserSchema, RegisteredUserType } from '@draco/shared-schemas';
-import { dbPasswordResetToken, dbUser } from '../repositories/index.js';
-import { InternalServerError } from '../utils/customErrors.js';
+import { dbPasswordResetToken } from '../repositories/index.js';
 
 export interface PasswordResetVerificationResponse {
   valid: boolean;
 }
 
 export class UserResponseFormatter {
-  static formatRegisteredUserWithToken(user: dbUser, token: string): RegisteredUserType {
-    if (!user.username) {
-      throw new InternalServerError('User record is missing a username');
-    }
-
-    return RegisteredUserSchema.parse({
-      userId: user.id,
-      userName: user.username,
-      token,
-    });
-  }
-
   static formatPasswordResetVerification(
     token: dbPasswordResetToken | null,
   ): PasswordResetVerificationResponse {

--- a/draco-nodejs/backend/src/routes/passwordReset.ts
+++ b/draco-nodejs/backend/src/routes/passwordReset.ts
@@ -16,18 +16,6 @@ const userService = ServiceFactory.getUserService();
 const PASSWORD_RESET_ACKNOWLEDGEMENT =
   'If an account with that email exists, a password reset link has been sent.';
 
-function parseTestModeFlag(value: unknown): boolean {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    return value.toLowerCase() === 'true';
-  }
-
-  return false;
-}
-
 /**
  * Request password reset
  * POST /api/password-reset/request
@@ -42,11 +30,9 @@ router.post(
     }
 
     const parsedEmail = SignInUserNameSchema.parse(email);
-    const testMode = parseTestModeFlag(req.body?.testMode);
 
     const result = await userService.requestPasswordReset({
       email: parsedEmail,
-      testMode,
     });
 
     if (result.kind === 'user-not-found') {
@@ -54,11 +40,6 @@ router.post(
         success: true,
         message: PASSWORD_RESET_ACKNOWLEDGEMENT,
       });
-      return;
-    }
-
-    if (result.kind === 'test-token') {
-      res.status(200).json(result.user);
       return;
     }
 

--- a/draco-nodejs/backend/src/services/userService.ts
+++ b/draco-nodejs/backend/src/services/userService.ts
@@ -1,4 +1,4 @@
-import { RegisteredUserType, SignInUserNameType } from '@draco/shared-schemas';
+import { SignInUserNameType } from '@draco/shared-schemas';
 import bcrypt from 'bcrypt';
 import { randomBytes } from 'node:crypto';
 import {
@@ -26,10 +26,7 @@ interface UserServiceDependencies {
   tokenExpiryHours?: number;
 }
 
-export type PasswordResetRequestResult =
-  | { kind: 'user-not-found' }
-  | { kind: 'test-token'; user: RegisteredUserType }
-  | { kind: 'email-sent' };
+export type PasswordResetRequestResult = { kind: 'user-not-found' } | { kind: 'email-sent' };
 
 export class UserService {
   private readonly userRepository: IUserRepository;
@@ -51,10 +48,8 @@ export class UserService {
 
   async requestPasswordReset({
     email,
-    testMode = false,
   }: {
     email: SignInUserNameType;
-    testMode?: boolean;
   }): Promise<PasswordResetRequestResult> {
     const normalizedEmail = email.trim().toLowerCase();
     const user = await this.userRepository.findByUsername(normalizedEmail);
@@ -66,11 +61,6 @@ export class UserService {
     const resetToken = this.generateResetToken();
     await this.invalidateExistingTokens(user.id);
     await this.createResetToken(user.id, resetToken);
-
-    if (testMode) {
-      const formattedUser = UserResponseFormatter.formatRegisteredUserWithToken(user, resetToken);
-      return { kind: 'test-token', user: formattedUser };
-    }
 
     const emailSent = await this.emailService.sendPasswordResetEmail(
       normalizedEmail,

--- a/draco-nodejs/frontend-next/app/reset-password/PasswordReset.tsx
+++ b/draco-nodejs/frontend-next/app/reset-password/PasswordReset.tsx
@@ -60,7 +60,6 @@ const PasswordReset: React.FC<PasswordResetProps> = ({ onResetSuccess, accountId
         client: apiClient,
         body: {
           email: trimmedEmail,
-          testMode: true,
         },
         throwOnError: false,
       });
@@ -69,14 +68,6 @@ const PasswordReset: React.FC<PasswordResetProps> = ({ onResetSuccess, accountId
 
       if (data === true) {
         setSuccess('If an account with that email exists, a password reset link has been sent.');
-        setActiveStep(1);
-        return;
-      }
-
-      if (typeof data === 'object' && data !== null && 'token' in data) {
-        const tokenData = data as { token: string; userId?: string; email?: string };
-        setSuccess(`Password reset token generated (TEST MODE): ${tokenData.token}`);
-        setToken(tokenData.token);
         setActiveStep(1);
         return;
       }


### PR DESCRIPTION
## Summary
- remove the password reset dialog test mode flag so the frontend no longer shows inline tokens
- drop backend support for the password reset test mode response and always send reset emails
- regenerate the OpenAPI spec and client to reflect the updated contract

## Testing
- npm run backend:test

------
https://chatgpt.com/codex/tasks/task_e_68e5d494f5288327b0561eaea6da7ccc