### PR TITLE
Allow account admins to access account management page

### DIFF
--- a/draco-nodejs/frontend-next/app/account-management/AccountManagementClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account-management/AccountManagementClientWrapper.tsx
@@ -5,7 +5,7 @@ import AccountManagement from './AccountManagement';
 
 export default function AccountManagementClientWrapper() {
   return (
-    <ProtectedRoute requiredRole="Administrator" checkAccountBoundary={false}>
+    <ProtectedRoute requiredRole={['Administrator', 'AccountAdmin']} checkAccountBoundary={false}>
       <AccountManagement />
     </ProtectedRoute>
   );


### PR DESCRIPTION
## Summary
- allow account admins to access the account management page by permitting the AccountAdmin role through the ProtectedRoute wrapper

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68e5d985f278832794f8e6bcb7ce4ac2