### PR TITLE
Refactor schedule deletion dialog to use internal hook

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/ScheduleManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/ScheduleManagement.tsx
@@ -124,7 +124,7 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
     setEditDialogOpen,
     setDeleteDialogOpen,
     setGameResultsDialogOpen,
-    handleDeleteGame,
+    handleDeleteSuccess,
     handleSaveGameResults,
     setSelectedGame,
     setSelectedGameForResults,
@@ -454,10 +454,12 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
 
         <DeleteGameDialog
           open={deleteDialogOpen}
-          onClose={() => setDeleteDialogOpen(false)}
           selectedGame={selectedGame}
-          onConfirm={handleDeleteGame}
+          onClose={() => setDeleteDialogOpen(false)}
+          onSuccess={handleDeleteSuccess}
+          onError={setError}
           getTeamName={getTeamName}
+          accountId={accountId}
         />
 
         <GameResultsDialog

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useGameDeletion.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useGameDeletion.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from 'react';
+import { deleteGame } from '@draco/shared-api-client';
+import { useApiClient } from '../../../hooks/useApiClient';
+import { unwrapApiResult } from '../../../utils/apiResult';
+import type { Game } from '@/types/schedule';
+
+export interface UseGameDeletionOptions {
+  accountId: string;
+}
+
+export interface DeleteGameResult {
+  message: string;
+  gameId: string;
+}
+
+interface UseGameDeletionReturn {
+  deleteGame: (game: Game) => Promise<DeleteGameResult>;
+  loading: boolean;
+  error: string | null;
+  resetError: () => void;
+}
+
+export const useGameDeletion = ({ accountId }: UseGameDeletionOptions): UseGameDeletionReturn => {
+  const apiClient = useApiClient();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteSelectedGame = useCallback(
+    async (game: Game): Promise<DeleteGameResult> => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const result = await deleteGame({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: game.season.id,
+            gameId: game.id,
+          },
+          throwOnError: false,
+        });
+
+        unwrapApiResult(result, 'Failed to delete game');
+
+        return {
+          message: 'Game deleted successfully',
+          gameId: game.id,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to delete game';
+        setError(message);
+        throw err instanceof Error ? err : new Error(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [accountId, apiClient],
+  );
+
+  const resetError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    deleteGame: deleteSelectedGame,
+    loading,
+    error,
+    resetError,
+  };
+};

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useGameManagement.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useGameManagement.ts
@@ -1,9 +1,10 @@
 import { useState, useCallback } from 'react';
 import { useApiClient } from '../../../hooks/useApiClient';
 import { Game } from '@/types/schedule';
-import { deleteGame, updateGameResults } from '@draco/shared-api-client';
+import { updateGameResults } from '@draco/shared-api-client';
 import { unwrapApiResult } from '../../../utils/apiResult';
 import { getGameStatusShortText, getGameStatusText } from '../../../utils/gameUtils';
+import type { DeleteGameResult } from './useGameDeletion';
 
 interface UseGameManagementProps {
   accountId: string;
@@ -29,7 +30,7 @@ interface UseGameManagementReturn {
   setSelectedGame: (game: Game | null) => void;
   setSelectedGameForResults: (game: Game | null) => void;
 
-  handleDeleteGame: () => Promise<void>;
+  handleDeleteSuccess: (result: DeleteGameResult) => void;
   handleSaveGameResults: (gameResultData: GameResultData) => Promise<void>;
 
   openCreateDialog: () => void;
@@ -64,44 +65,26 @@ export const useGameManagement = ({
 
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [selectedGameForResults, setSelectedGameForResults] = useState<Game | null>(null);
-  const handleDeleteGame = useCallback(async () => {
-    try {
-      if (!selectedGame) return;
-
-      const result = await deleteGame({
-        client: apiClient,
-        path: {
-          accountId,
-          seasonId: selectedGame.season.id,
-          gameId: selectedGame.id,
-        },
-        throwOnError: false,
-      });
-
-      unwrapApiResult(result, 'Failed to delete game');
-
-      setSuccess('Game deleted successfully');
+  const handleDeleteSuccess = useCallback(
+    ({ message, gameId }: DeleteGameResult) => {
+      setSuccess(message);
+      setError(null);
       setEditDialogOpen(false);
       setDeleteDialogOpen(false);
-      setSelectedGame(null);
-      if (selectedGameForResults?.id === selectedGame.id) {
+
+      if (selectedGame?.id === gameId) {
+        setSelectedGame(null);
+      }
+
+      if (selectedGameForResults?.id === gameId) {
         setGameResultsDialogOpen(false);
         setSelectedGameForResults(null);
       }
-      removeGameFromCache(selectedGame.id);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete game');
-      setDeleteDialogOpen(false);
-    }
-  }, [
-    selectedGame,
-    selectedGameForResults,
-    accountId,
-    apiClient,
-    removeGameFromCache,
-    setSuccess,
-    setError,
-  ]);
+
+      removeGameFromCache(gameId);
+    },
+    [removeGameFromCache, selectedGame, selectedGameForResults, setSuccess, setError],
+  );
 
   const handleSaveGameResults = useCallback(
     async (gameResultData: GameResultData) => {
@@ -187,7 +170,7 @@ export const useGameManagement = ({
     setSelectedGame,
     setSelectedGameForResults,
 
-    handleDeleteGame,
+    handleDeleteSuccess,
     handleSaveGameResults,
 
     openCreateDialog,

--- a/draco-nodejs/frontend-next/components/schedule/index.ts
+++ b/draco-nodejs/frontend-next/components/schedule/index.ts
@@ -2,6 +2,8 @@
 export { useScheduleData } from './hooks/useScheduleData';
 export { useScheduleFilters } from './hooks/useScheduleFilters';
 export { useGameManagement } from './hooks/useGameManagement';
+export { useGameDeletion } from './hooks/useGameDeletion';
+export type { DeleteGameResult } from './hooks/useGameDeletion';
 
 // Views
 export { default as ViewFactory } from './views/ViewFactory';


### PR DESCRIPTION
## Summary
- add a dedicated schedule service hook for deleting games with loading and error state
- update the DeleteGameDialog to call the hook directly and surface a typed success result
- adjust schedule management state handling to consume the dialog result and export the new hook

## Testing
- npm run lint -w @draco/frontend-next

------
https://chatgpt.com/codex/tasks/task_e_68eb311651648327863eda6645796334