### PR TITLE
Guard photo submission moderation updates

### DIFF
--- a/draco-nodejs/backend/src/services/__tests__/photoSubmissionService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/photoSubmissionService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 
 vi.mock('@draco/shared-schemas', () => ({}));
 vi.mock('../../utils/customErrors.js', () => {
@@ -33,19 +33,31 @@ import {
 } from '../../types/photoSubmissions.js';
 
 class PhotoSubmissionRepositoryMock implements IPhotoSubmissionRepository {
-  createSubmissionMock = vi.fn<[dbCreatePhotoSubmissionInput], Promise<dbPhotoSubmission>>();
-  findSubmissionByIdMock = vi.fn<[bigint], Promise<dbPhotoSubmission | null>>();
-  findSubmissionForAccountMock = vi.fn<[bigint, bigint], Promise<dbPhotoSubmission | null>>();
-  findSubmissionWithRelationsMock = vi.fn<
+  createSubmissionMock: Mock<
+    [dbCreatePhotoSubmissionInput],
+    Promise<dbPhotoSubmission>
+  > = vi.fn();
+  findSubmissionByIdMock: Mock<[bigint], Promise<dbPhotoSubmission | null>> = vi.fn();
+  findSubmissionForAccountMock: Mock<
+    [bigint, bigint],
+    Promise<dbPhotoSubmission | null>
+  > = vi.fn();
+  findSubmissionWithRelationsMock: Mock<
     [bigint],
     Promise<dbPhotoSubmissionWithRelations | null>
-  >();
-  findAlbumForAccountMock = vi.fn<[bigint, bigint], Promise<dbPhotoGalleryAlbum | null>>();
-  approveSubmissionMock = vi.fn<
+  > = vi.fn();
+  findAlbumForAccountMock: Mock<
+    [bigint, bigint],
+    Promise<dbPhotoGalleryAlbum | null>
+  > = vi.fn();
+  approveSubmissionMock: Mock<
     [bigint, dbApprovePhotoSubmissionInput],
     Promise<dbPhotoSubmission>
-  >();
-  denySubmissionMock = vi.fn<[bigint, dbDenyPhotoSubmissionInput], Promise<dbPhotoSubmission>>();
+  > = vi.fn();
+  denySubmissionMock: Mock<
+    [bigint, dbDenyPhotoSubmissionInput],
+    Promise<dbPhotoSubmission>
+  > = vi.fn();
 
   createSubmission(data: dbCreatePhotoSubmissionInput): Promise<dbPhotoSubmission> {
     return this.createSubmissionMock(data);


### PR DESCRIPTION
## Summary
- add Prisma-backed repository and interface helpers for photo submissions with album lookup and moderation updates
- implement photo submission service with validation, storage path generation, and factory wiring
- cover photo submission flows with vitest and configure shared schema alias for backend tests
- guard photo submission moderation updates against concurrent races by requiring pending status inside a transaction
- type Vitest mocks in the photo submission service tests to satisfy TypeScript 5

## Testing
- npm run backend:test -- photoSubmissionService

------
https://chatgpt.com/codex/tasks/task_e_68f061bb792c8327b53c51bd2a122a51