### PR TITLE
Use service factory to wire account creation log dependencies

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -15674,12 +15674,50 @@
                               "attachmentCount"
                             ]
                           }
+                        },
+                        "recentCreations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accountId": {
+                                "type": "string",
+                                "example": "42"
+                              },
+                              "accountName": {
+                                "type": "string",
+                                "example": "Springfield Tigers"
+                              },
+                              "ownerUserId": {
+                                "type": "string",
+                                "example": "user-123"
+                              },
+                              "ownerUserName": {
+                                "type": "string",
+                                "example": "alex.coach"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2024-01-01T00:00:00.000Z"
+                              }
+                            },
+                            "required": [
+                              "accountId",
+                              "accountName",
+                              "ownerUserId",
+                              "ownerUserName",
+                              "createdAt"
+                            ]
+                          },
+                          "description": "Account registrations recorded within the past 90 days."
                         }
                       },
                       "required": [
                         "total",
                         "withEmailActivity",
-                        "topStorageAccounts"
+                        "topStorageAccounts",
+                        "recentCreations"
                       ]
                     },
                     "storage": {

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -11168,10 +11168,39 @@ paths:
                             - accountName
                             - attachmentBytes
                             - attachmentCount
+                      recentCreations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            accountId:
+                              type: string
+                              example: "42"
+                            accountName:
+                              type: string
+                              example: Springfield Tigers
+                            ownerUserId:
+                              type: string
+                              example: user-123
+                            ownerUserName:
+                              type: string
+                              example: alex.coach
+                            createdAt:
+                              type: string
+                              format: date-time
+                              example: 2024-01-01T00:00:00.000Z
+                          required:
+                            - accountId
+                            - accountName
+                            - ownerUserId
+                            - ownerUserName
+                            - createdAt
+                        description: Account registrations recorded within the past 90 days.
                     required:
                       - total
                       - withEmailActivity
                       - topStorageAccounts
+                      - recentCreations
                   storage:
                     type: object
                     properties:

--- a/draco-nodejs/backend/src/openapi/paths/admin/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/admin/index.ts
@@ -24,6 +24,14 @@ const registerAdminAnalyticsEndpoints = ({ registry, z }: RegisterContext) => {
     clickRate: z.number().min(0).max(100).openapi({ example: 28.1 }),
   });
 
+  const accountCreationLogEntrySchema = z.object({
+    accountId: z.string().openapi({ example: '42' }),
+    accountName: z.string().openapi({ example: 'Springfield Tigers' }),
+    ownerUserId: z.string().openapi({ example: 'user-123' }),
+    ownerUserName: z.string().openapi({ example: 'alex.coach' }),
+    createdAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00.000Z' }),
+  });
+
   const monitoringHealthSchema = z.object({
     status: z.enum(['healthy', 'warning', 'critical']),
     timestamp: z.string().openapi({ format: 'date-time' }),
@@ -143,6 +151,9 @@ const registerAdminAnalyticsEndpoints = ({ registry, z }: RegisterContext) => {
       total: z.number().int().nonnegative(),
       withEmailActivity: z.number().int().nonnegative(),
       topStorageAccounts: accountStorageMetricSchema.array(),
+      recentCreations: accountCreationLogEntrySchema
+        .array()
+        .openapi({ description: 'Account registrations recorded within the past 90 days.' }),
     }),
     storage: z.object({
       totalAttachmentBytes: z.number().nonnegative(),

--- a/draco-nodejs/backend/src/services/accountCreationLogService.ts
+++ b/draco-nodejs/backend/src/services/accountCreationLogService.ts
@@ -1,0 +1,102 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DEFAULT_LOG_RELATIVE_PATH = path.join('storage', 'admin', 'account-creations.log');
+const RETENTION_DAYS = 90;
+
+export interface AccountCreationLogEntry {
+  accountId: string;
+  accountName: string;
+  ownerUserId: string;
+  ownerUserName: string;
+  createdAt: string;
+}
+
+export class AccountCreationLogService {
+  private readonly logFilePath: string;
+
+  constructor(logFilePath?: string) {
+    this.logFilePath = logFilePath ?? path.resolve(process.cwd(), DEFAULT_LOG_RELATIVE_PATH);
+  }
+
+  async recordEntry(
+    entry: Omit<AccountCreationLogEntry, 'createdAt'> & { createdAt?: string },
+  ): Promise<void> {
+    const timestamp = entry.createdAt ?? new Date().toISOString();
+    const retainedEntries = await this.loadEntriesWithinRetention();
+    retainedEntries.push({
+      accountId: entry.accountId,
+      accountName: entry.accountName,
+      ownerUserId: entry.ownerUserId,
+      ownerUserName: entry.ownerUserName,
+      createdAt: timestamp,
+    });
+
+    await this.persistEntries(retainedEntries);
+  }
+
+  async getRecentEntries(limit = 50): Promise<AccountCreationLogEntry[]> {
+    const retainedEntries = await this.loadEntriesWithinRetention();
+    return retainedEntries
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, limit);
+  }
+
+  private async loadEntriesWithinRetention(): Promise<AccountCreationLogEntry[]> {
+    const allEntries = await this.readEntriesFromDisk();
+    const retentionCutoff = this.calculateRetentionCutoff();
+
+    return allEntries.filter((entry) => {
+      const createdAt = new Date(entry.createdAt).getTime();
+      return Number.isFinite(createdAt) && createdAt >= retentionCutoff;
+    });
+  }
+
+  private calculateRetentionCutoff(): number {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
+    return cutoff.getTime();
+  }
+
+  private async readEntriesFromDisk(): Promise<AccountCreationLogEntry[]> {
+    try {
+      const content = await fs.readFile(this.logFilePath, 'utf8');
+      return content
+        .split('\n')
+        .filter((line) => line.trim().length > 0)
+        .map((line) => {
+          try {
+            const parsed = JSON.parse(line) as AccountCreationLogEntry;
+            return parsed;
+          } catch (_error) {
+            return null;
+          }
+        })
+        .filter((entry): entry is AccountCreationLogEntry => entry !== null);
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        return [];
+      }
+
+      throw error;
+    }
+  }
+
+  private async persistEntries(entries: AccountCreationLogEntry[]): Promise<void> {
+    const directory = path.dirname(this.logFilePath);
+    await fs.mkdir(directory, { recursive: true });
+
+    const sortedEntries = entries.sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+    const serialized = sortedEntries.map((entry) => JSON.stringify(entry)).join('\n');
+    const content = serialized.length > 0 ? `${serialized}\n` : '';
+
+    await fs.writeFile(this.logFilePath, content, 'utf8');
+  }
+}

--- a/draco-nodejs/backend/src/services/accountsService.ts
+++ b/draco-nodejs/backend/src/services/accountsService.ts
@@ -40,6 +40,8 @@ import { ROLE_IDS } from '../config/roles.js';
 import { RoleNamesType } from '../types/roles.js';
 import { getAccountLogoUrl } from '../config/logo.js';
 import { DateUtils } from '../utils/dateUtils.js';
+import { AccountCreationLogService } from './accountCreationLogService.js';
+import { ServiceFactory } from './serviceFactory.js';
 
 type OwnerSummary = AccountOwnerSummary;
 
@@ -51,6 +53,7 @@ export class AccountsService {
   private readonly userRepository: IUserRepository;
   private readonly roleRepository: IRoleRepository;
   private readonly seasonRepository: ISeasonsRepository;
+  private readonly accountCreationLogService: AccountCreationLogService;
 
   constructor() {
     this.accountRepository = RepositoryFactory.getAccountRepository();
@@ -58,6 +61,7 @@ export class AccountsService {
     this.userRepository = RepositoryFactory.getUserRepository();
     this.roleRepository = RepositoryFactory.getRoleRepository();
     this.seasonRepository = RepositoryFactory.getSeasonsRepository();
+    this.accountCreationLogService = ServiceFactory.getAccountCreationLogService();
   }
 
   async getAccountsForUser(userId: string): Promise<AccountType[]> {
@@ -302,6 +306,13 @@ export class AccountsService {
       ownerContact: ownerContactRecord,
       ownerUser,
     } = await this.loadAccountContext(accountRecord.id);
+
+    await this.accountCreationLogService.recordEntry({
+      accountId: accountRecord.id.toString(),
+      accountName: accountRecord.name ?? payload.name ?? 'Unknown account',
+      ownerUserId: accountOwnerUserId,
+      ownerUserName: accountOwnerUserName,
+    });
 
     return AccountResponseFormatter.formatAccount(
       account,

--- a/draco-nodejs/backend/src/services/serviceFactory.ts
+++ b/draco-nodejs/backend/src/services/serviceFactory.ts
@@ -43,6 +43,7 @@ import { SeasonService } from './seasonService.js';
 import { TurnstileService } from './turnstileService.js';
 import { HandoutService } from './handoutService.js';
 import { AdminAnalyticsService } from './adminAnalyticsService.js';
+import { AccountCreationLogService } from './accountCreationLogService.js';
 import { PhotoSubmissionService } from './photoSubmissionService.js';
 import { PhotoGalleryService } from './photoGalleryService.js';
 import { PhotoGalleryAdminService } from './photoGalleryAdminService.js';
@@ -103,6 +104,7 @@ export class ServiceFactory {
   private static photoSubmissionModerationService: PhotoSubmissionModerationService;
   private static photoSubmissionAssetService: PhotoSubmissionAssetService;
   private static photoSubmissionNotificationService: PhotoSubmissionNotificationService;
+  private static accountCreationLogService: AccountCreationLogService;
 
   static getRoleService(): IRoleService {
     if (!this.roleService) {
@@ -357,8 +359,7 @@ export class ServiceFactory {
 
   static getAdminAnalyticsService(): AdminAnalyticsService {
     if (!this.adminAnalyticsService) {
-      const monitoringService = this.getMonitoringService();
-      this.adminAnalyticsService = new AdminAnalyticsService(monitoringService);
+      this.adminAnalyticsService = new AdminAnalyticsService();
     }
 
     return this.adminAnalyticsService;
@@ -413,6 +414,14 @@ export class ServiceFactory {
     }
 
     return this.photoSubmissionNotificationService;
+  }
+
+  static getAccountCreationLogService(): AccountCreationLogService {
+    if (!this.accountCreationLogService) {
+      this.accountCreationLogService = new AccountCreationLogService();
+    }
+
+    return this.accountCreationLogService;
   }
 
   static getPhotoSubmissionModerationService(): PhotoSubmissionModerationService {

--- a/draco-nodejs/frontend-next/app/admin/AdminDashboard.tsx
+++ b/draco-nodejs/frontend-next/app/admin/AdminDashboard.tsx
@@ -177,6 +177,7 @@ const AdminDashboard: React.FC = () => {
 
   const topStorageAccounts = useMemo(() => summary?.accounts.topStorageAccounts ?? [], [summary]);
   const emailAccounts = useMemo(() => summary?.email.perAccount ?? [], [summary]);
+  const accountCreationLog = useMemo(() => summary?.accounts.recentCreations ?? [], [summary]);
   const photoCounters = summary?.photos.counters ?? {
     submissionFailures: 0,
     quotaViolations: 0,
@@ -399,6 +400,42 @@ const AdminDashboard: React.FC = () => {
               )}
             </Paper>
           </Stack>
+
+          <Paper sx={{ p: 3 }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+              <GroupsIcon fontSize="small" />
+              <Typography variant="h6">Recent account registrations</Typography>
+            </Stack>
+            {accountCreationLog.length > 0 ? (
+              <Table size="small" aria-label="Recent account registrations">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Created</TableCell>
+                    <TableCell>Account</TableCell>
+                    <TableCell>Owner username</TableCell>
+                    <TableCell>Owner user ID</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {accountCreationLog.map((entry) => (
+                    <TableRow key={`${entry.accountId}-${entry.createdAt}`} hover>
+                      <TableCell>{formatDateTime(entry.createdAt)}</TableCell>
+                      <TableCell sx={{ fontWeight: 500 }}>{entry.accountName}</TableCell>
+                      <TableCell>{entry.ownerUserName}</TableCell>
+                      <TableCell>{entry.ownerUserId}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No accounts have been created in the last 90 days.
+              </Typography>
+            )}
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+              Entries older than 90 days are automatically removed from the log.
+            </Typography>
+          </Paper>
 
           <Paper sx={{ p: 3 }}>
             <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>

--- a/draco-nodejs/frontend-next/app/admin/__tests__/AdminDashboard.test.tsx
+++ b/draco-nodejs/frontend-next/app/admin/__tests__/AdminDashboard.test.tsx
@@ -40,6 +40,15 @@ const createSummary = (): AdminAnalyticsSummary => ({
         attachmentCount: 12,
       },
     ],
+    recentCreations: [
+      {
+        accountId: '42',
+        accountName: 'Springfield Tigers',
+        ownerUserId: 'user-1',
+        ownerUserName: 'admin',
+        createdAt: '2024-01-01T10:00:00.000Z',
+      },
+    ],
   },
   storage: {
     totalAttachmentBytes: 1048576,
@@ -189,5 +198,10 @@ describe('AdminDashboard photo metrics', () => {
     expect(screen.getByText('Failures 2 • Quota 1 • Email 1')).toBeInTheDocument();
     expect(screen.getByText('Submission failure')).toBeInTheDocument();
     expect(screen.getByText('Stage "team-create" failed: Storage unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Recent account registrations')).toBeInTheDocument();
+    expect(screen.getByText('Springfield Tigers')).toBeInTheDocument();
+    expect(
+      screen.getByText('Entries older than 90 days are automatically removed from the log.'),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- resolve AccountsService's account creation log dependency through ServiceFactory
- have AdminAnalyticsService request its monitoring and log dependencies from ServiceFactory
- update ServiceFactory constructors to match the new wiring

## Testing
- npm run backend:test

------
https://chatgpt.com/codex/tasks/task_e_68fe4b33cd9c8327b204650bc2b81128