### PR TITLE
Adjust join league widget placement

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -93,6 +93,7 @@ const BaseballAccountHome: React.FC = () => {
   const hasAccountContact = Boolean(isAccountMember);
   const canSubmitPhotos = Boolean(isAccountMember);
   const showSubmissionPanel = Boolean(isAccountMember);
+  const shouldShowJoinLeagueNearSponsors = Boolean(user && hasAccountContact);
 
   const canModerateAccountPhotos = useMemo(() => {
     if (!accountIdStr) {
@@ -816,6 +817,15 @@ const BaseballAccountHome: React.FC = () => {
     );
   }
 
+  const joinLeagueDashboard = (
+    <JoinLeagueDashboard
+      accountId={accountIdStr}
+      account={account}
+      token={token || undefined}
+      isAccountMember={isAccountMember}
+    />
+  );
+
   return (
     <main className="min-h-screen bg-background">
       {/* Unified Header with Logo and Page Content */}
@@ -901,12 +911,7 @@ const BaseballAccountHome: React.FC = () => {
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <JoinLeagueDashboard
-              accountId={accountIdStr}
-              account={account}
-              token={token || undefined}
-              isAccountMember={isAccountMember}
-            />
+            {shouldShowJoinLeagueNearSponsors ? null : joinLeagueDashboard}
 
             {showInformationWidget && accountIdStr ? (
               <InformationWidget
@@ -981,6 +986,8 @@ const BaseballAccountHome: React.FC = () => {
                 albumOptions={submissionAlbumOptions}
               />
             ) : null}
+
+            {shouldShowJoinLeagueNearSponsors ? joinLeagueDashboard : null}
 
             {shouldShowAccountSponsors ? (
               <SponsorCard


### PR DESCRIPTION
## Summary
- add logic that determines when the logged-in user is a contact for the account
- render the join league dashboard at the top only for non-members and relocate it above the sponsor widget for members
- reuse a single join league widget instance to keep prop handling consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9a183670832780e5c707990106ef)