### PR TITLE
Fix My Teams logos on account home

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -628,6 +628,7 @@ const BaseballAccountHome: React.FC = () => {
           leagueName: team.league?.name ?? 'Unknown League',
           divisionName: team.division?.name ?? undefined,
           teamId: team.team?.id,
+          logoUrl: team.team?.logoUrl ?? undefined,
         }));
 
         setUserTeams(teams);


### PR DESCRIPTION
## Summary
- include each team season's logo URL when mapping `getAccountUserTeams` results on the Baseball account home page so the Your Teams widget can render the real team badges instead of the placeholder

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9fb60fe08327ae3dc62e4095de33)