### PR TITLE
Add AdSense banner to account header and ads.txt endpoint

### DIFF
--- a/draco-nodejs/frontend-next/README.md
+++ b/draco-nodejs/frontend-next/README.md
@@ -35,6 +35,11 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 ## Environment Variables
 
 - `NEXT_PUBLIC_TURNSTILE_SITE_KEY` – Cloudflare Turnstile site key used to render the human-verification challenge for account creation and new user registration. Leave unset in local environments to disable the challenge.
+- `NEXT_PUBLIC_ENABLE_ADSENSE` – Set to `true` to render Google AdSense inventory in the account header. Keep unset/`false` locally unless you need to validate ad rendering.
+- `NEXT_PUBLIC_ADSENSE_CLIENT_ID` – The `ca-pub-XXXX` publisher identifier provided by Google. Required when AdSense is enabled.
+- `NEXT_PUBLIC_ADSENSE_ACCOUNT_HEADER_SLOT` – Ad slot ID used for the Account page header placement. Pair with auto-format and responsive sizing for optimal monetization.
+- `ADSENSE_PUBLISHER_ID` – The `pub-XXXX` publisher ID used to expose `/ads.txt`. The handler strips an optional `ca-` prefix and adds `pub-` if missing so you can reuse the same identifier you provide to Google.
+- `ADSENSE_ACCOUNT_RELATIONSHIP` – Optional relationship value for `/ads.txt`; defaults to `DIRECT`. Set to `RESELLER` only if your AdSense configuration requires it.
 
 ## Learn More
 

--- a/draco-nodejs/frontend-next/app/__tests__/adsTxtRoute.test.ts
+++ b/draco-nodejs/frontend-next/app/__tests__/adsTxtRoute.test.ts
@@ -1,0 +1,42 @@
+import { GET } from '../ads.txt/route';
+
+describe('ads.txt route', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 404 when not configured', async () => {
+    delete process.env.ADSENSE_PUBLISHER_ID;
+
+    const response = GET();
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('ads.txt not configured\n');
+  });
+
+  it('returns ads.txt content when configured', async () => {
+    process.env.ADSENSE_PUBLISHER_ID = 'ca-pub-123456789';
+
+    const response = GET();
+    const content = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(content).toBe('google.com, pub-123456789, DIRECT, f08c47fec0942fa0\n');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=86400, must-revalidate');
+  });
+
+  it('honors relationship override', async () => {
+    process.env.ADSENSE_PUBLISHER_ID = 'pub-987654321';
+    process.env.ADSENSE_ACCOUNT_RELATIONSHIP = 'RESELLER';
+
+    const response = GET();
+
+    expect(await response.text()).toBe('google.com, pub-987654321, RESELLER, f08c47fec0942fa0\n');
+  });
+});

--- a/draco-nodejs/frontend-next/app/ads.txt/route.ts
+++ b/draco-nodejs/frontend-next/app/ads.txt/route.ts
@@ -1,0 +1,34 @@
+const ADSENSE_CERT_AUTHORITY_ID = 'f08c47fec0942fa0';
+
+const normalizePublisherId = (publisherId: string) => {
+  const withoutCaPrefix = publisherId.replace(/^ca-/, '');
+
+  if (withoutCaPrefix.startsWith('pub-')) {
+    return withoutCaPrefix;
+  }
+
+  return `pub-${withoutCaPrefix}`;
+};
+
+export function GET() {
+  const publisherId = process.env.ADSENSE_PUBLISHER_ID;
+  const accountRelationship = process.env.ADSENSE_ACCOUNT_RELATIONSHIP ?? 'DIRECT';
+
+  if (!publisherId) {
+    return new Response('ads.txt not configured\n', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const normalizedPublisherId = normalizePublisherId(publisherId);
+  const lines = [`google.com, ${normalizedPublisherId}, ${accountRelationship}, ${ADSENSE_CERT_AUTHORITY_ID}`];
+
+  return new Response(`${lines.join('\n')}\n`, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, must-revalidate',
+    },
+  });
+}

--- a/draco-nodejs/frontend-next/components/AccountPageHeader.tsx
+++ b/draco-nodejs/frontend-next/components/AccountPageHeader.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { useAccountHeader } from '../hooks/useAccountHeader';
+import AdSenseBanner from './ads/AdSenseBanner';
 
 interface AccountPageHeaderProps {
   accountId: string;
@@ -53,6 +54,8 @@ const AccountPageHeader: React.FC<AccountPageHeaderProps> = ({
         ...style,
       }}
     >
+      <AdSenseBanner />
+
       {/* Logo/Name Section */}
       {showLogo && (
         <Box

--- a/draco-nodejs/frontend-next/components/__tests__/AccountPageHeader.test.tsx
+++ b/draco-nodejs/frontend-next/components/__tests__/AccountPageHeader.test.tsx
@@ -36,4 +36,10 @@ describe('AccountPageHeader', () => {
     render(<AccountPageHeader accountId="test-account" />);
     expect(await screen.findByText('Test Title')).toBeInTheDocument();
   });
+
+  it('does not render ads when AdSense is disabled', () => {
+    render(<AccountPageHeader accountId="test-account" />);
+
+    expect(screen.queryByLabelText('Advertisement')).not.toBeInTheDocument();
+  });
 });

--- a/draco-nodejs/frontend-next/components/ads/AdSenseBanner.tsx
+++ b/draco-nodejs/frontend-next/components/ads/AdSenseBanner.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Script from 'next/script';
+import Box from '@mui/material/Box';
+
+const ADSENSE_CLIENT_ID = process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID;
+const ACCOUNT_HEADER_AD_SLOT = process.env.NEXT_PUBLIC_ADSENSE_ACCOUNT_HEADER_SLOT;
+const ADSENSE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_ADSENSE === 'true';
+
+declare global {
+  interface Window {
+    adsbygoogle?: Array<Record<string, unknown>>;
+  }
+}
+
+const AdSenseBanner: React.FC = () => {
+  const adUnitRef = useRef<HTMLModElement>(null);
+  const shouldRenderAd = Boolean(ADSENSE_ENABLED && ADSENSE_CLIENT_ID && ACCOUNT_HEADER_AD_SLOT);
+
+  useEffect(() => {
+    if (!shouldRenderAd || !adUnitRef.current) {
+      return;
+    }
+
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (error) {
+      console.error('Adsense error', error);
+    }
+  }, [shouldRenderAd]);
+
+  if (!shouldRenderAd) {
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        id="google-adsense-script"
+        strategy="afterInteractive"
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`}
+        async
+        crossOrigin="anonymous"
+      />
+      <Box
+        sx={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          pt: 2,
+          px: { xs: 1.5, sm: 3 },
+        }}
+      >
+        <ins
+          ref={adUnitRef}
+          className="adsbygoogle"
+          style={{ display: 'block', width: '100%', minHeight: 90 }}
+          data-ad-client={ADSENSE_CLIENT_ID}
+          data-ad-slot={ACCOUNT_HEADER_AD_SLOT}
+          data-ad-format="auto"
+          data-full-width-responsive="true"
+          aria-label="Advertisement"
+        />
+      </Box>
+    </>
+  );
+};
+
+export default AdSenseBanner;


### PR DESCRIPTION
## Summary
- add a responsive, auto-format Google AdSense banner to the account page header with env-based toggles and client/slot configuration
- document the AdSense environment variables for the frontend
- cover the disabled-ads path in the AccountPageHeader test suite
- expose a configurable `/ads.txt` app route driven by AdSense publisher and relationship env vars to satisfy Google’s ads.txt requirements

## Testing
- npm run test -w @draco/frontend-next -- app/__tests__/adsTxtRoute.test.ts components/__tests__/AccountPageHeader.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925117632ac832782f763c06c15abd1)