### PR TITLE
Restart latest deployment and add tests

### DIFF
--- a/draco-nodejs/backend/src/services/__tests__/frontendRestartService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/frontendRestartService.test.ts
@@ -27,29 +27,56 @@ describe('FrontendRestartService', () => {
     vi.restoreAllMocks();
   });
 
+  const mockDeploymentLookup = (deploymentId: string | null) => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          deployments: {
+            edges: deploymentId ? [{ node: { id: deploymentId } }] : [],
+          },
+        },
+      }),
+    });
+  };
+
+  const mockRestartSuccess = () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { deploymentRestart: true } }),
+    });
+  };
+
   describe('restartFrontend', () => {
-    it('sends a GraphQL mutation with Project-Access-Token header', async () => {
-      fetchMock.mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: { serviceInstanceRestart: true } }),
-      });
+    it('fetches the latest deployment and restarts it', async () => {
+      mockDeploymentLookup('deployment-789');
+      mockRestartSuccess();
 
       const service = new FrontendRestartService();
       await service.restartFrontend();
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [url, init] = fetchMock.mock.calls[0];
-      expect(url).toBe('https://backboard.railway.com/graphql/v2');
-      expect(init.method).toBe('POST');
-      expect(init.headers['Project-Access-Token']).toBe('test-token');
-      expect(init.headers['Content-Type']).toBe('application/json');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
 
-      const body = JSON.parse(init.body);
-      expect(body.query).toContain('serviceInstanceRestart');
-      expect(body.variables).toEqual({
-        serviceId: 'service-123',
-        environmentId: 'env-456',
+      const [lookupUrl, lookupInit] = fetchMock.mock.calls[0];
+      expect(lookupUrl).toBe('https://backboard.railway.com/graphql/v2');
+      expect(lookupInit.method).toBe('POST');
+      expect(lookupInit.headers['Project-Access-Token']).toBe('test-token');
+      expect(lookupInit.headers['Content-Type']).toBe('application/json');
+
+      const lookupBody = JSON.parse(lookupInit.body);
+      expect(lookupBody.query).toContain('deployments');
+      expect(lookupBody.variables).toEqual({
+        input: {
+          serviceId: 'service-123',
+          environmentId: 'env-456',
+          status: { in: ['SUCCESS'] },
+        },
       });
+
+      const [, restartInit] = fetchMock.mock.calls[1];
+      const restartBody = JSON.parse(restartInit.body);
+      expect(restartBody.query).toContain('deploymentRestart');
+      expect(restartBody.variables).toEqual({ id: 'deployment-789' });
     });
 
     it('throws when required env vars are missing', async () => {
@@ -59,6 +86,16 @@ describe('FrontendRestartService', () => {
       await expect(service.restartFrontend()).rejects.toThrow(
         /RAILWAY_API_TOKEN.*FRONTEND_SERVICE_ID.*RAILWAY_ENVIRONMENT_ID/,
       );
+    });
+
+    it('throws when no successful deployment is found', async () => {
+      mockDeploymentLookup(null);
+
+      const service = new FrontendRestartService();
+      await expect(service.restartFrontend()).rejects.toThrow(
+        /No successful deployment found for service service-123/,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('throws when the API returns a non-OK response', async () => {
@@ -81,6 +118,18 @@ describe('FrontendRestartService', () => {
 
       const service = new FrontendRestartService();
       await expect(service.restartFrontend()).rejects.toThrow(/Service not found/);
+    });
+
+    it('throws when the restart mutation itself fails', async () => {
+      mockDeploymentLookup('deployment-789');
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ errors: [{ message: 'Deployment not restartable' }] }),
+      });
+
+      const service = new FrontendRestartService();
+      await expect(service.restartFrontend()).rejects.toThrow(/Deployment not restartable/);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -124,10 +173,8 @@ describe('FrontendRestartService', () => {
     });
 
     it('re-schedules after a successful restart', async () => {
-      fetchMock.mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: { serviceInstanceRestart: true } }),
-      });
+      mockDeploymentLookup('deployment-789');
+      mockRestartSuccess();
 
       const service = new FrontendRestartService();
       service.start();

--- a/draco-nodejs/backend/src/services/frontendRestartService.ts
+++ b/draco-nodejs/backend/src/services/frontendRestartService.ts
@@ -2,15 +2,33 @@ import { getNextBackupTime } from './backupService.js';
 
 const RAILWAY_API_ENDPOINT = 'https://backboard.railway.com/graphql/v2';
 
-const RESTART_MUTATION = `
-  mutation serviceInstanceRestart($serviceId: String!, $environmentId: String!) {
-    serviceInstanceRestart(serviceId: $serviceId, environmentId: $environmentId)
+const LATEST_DEPLOYMENT_QUERY = `
+  query LatestDeployment($input: DeploymentListInput!) {
+    deployments(input: $input, first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
   }
 `;
 
-interface RailwayGraphQLResponse {
-  data?: unknown;
+const RESTART_MUTATION = `
+  mutation RestartDeployment($id: String!) {
+    deploymentRestart(id: $id)
+  }
+`;
+
+interface RailwayGraphQLResponse<T = unknown> {
+  data?: T;
   errors?: Array<{ message: string }>;
+}
+
+interface LatestDeploymentData {
+  deployments: {
+    edges: Array<{ node: { id: string } }>;
+  };
 }
 
 export class FrontendRestartService {
@@ -55,16 +73,51 @@ export class FrontendRestartService {
 
     console.log('🔄 Triggering frontend restart via Railway API...');
 
+    const deploymentId = await this.fetchLatestDeploymentId(token, serviceId, environmentId);
+    await this.restartDeployment(token, deploymentId);
+
+    console.log('🔄 Frontend restart triggered successfully');
+  }
+
+  private async fetchLatestDeploymentId(
+    token: string,
+    serviceId: string,
+    environmentId: string,
+  ): Promise<string> {
+    const result = await this.callRailway<LatestDeploymentData>(token, LATEST_DEPLOYMENT_QUERY, {
+      input: {
+        serviceId,
+        environmentId,
+        status: { in: ['SUCCESS'] },
+      },
+    });
+
+    const deploymentId = result.data?.deployments.edges[0]?.node.id;
+    if (!deploymentId) {
+      throw new Error(
+        `No successful deployment found for service ${serviceId} in environment ${environmentId}`,
+      );
+    }
+
+    return deploymentId;
+  }
+
+  private async restartDeployment(token: string, deploymentId: string): Promise<void> {
+    await this.callRailway(token, RESTART_MUTATION, { id: deploymentId });
+  }
+
+  private async callRailway<T>(
+    token: string,
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<RailwayGraphQLResponse<T>> {
     const response = await fetch(RAILWAY_API_ENDPOINT, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Project-Access-Token': token,
       },
-      body: JSON.stringify({
-        query: RESTART_MUTATION,
-        variables: { serviceId, environmentId },
-      }),
+      body: JSON.stringify({ query, variables }),
     });
 
     if (!response.ok) {
@@ -74,7 +127,7 @@ export class FrontendRestartService {
       );
     }
 
-    const result = (await response.json()) as RailwayGraphQLResponse;
+    const result = (await response.json()) as RailwayGraphQLResponse<T>;
 
     if (result.errors && result.errors.length > 0) {
       throw new Error(
@@ -82,7 +135,7 @@ export class FrontendRestartService {
       );
     }
 
-    console.log('🔄 Frontend restart triggered successfully');
+    return result;
   }
 
   private hasRequiredConfig(): boolean {


### PR DESCRIPTION
Refactor FrontendRestartService to lookup the latest successful deployment and restart it by ID. Introduces a LATEST_DEPLOYMENT_QUERY and a generic callRailway<T> helper, plus fetchLatestDeploymentId and restartDeployment methods; updates the restart mutation to target deploymentRestart. Adds unit tests to cover the new lookup/restart flow, error cases (missing env vars, no successful deployment found, non-OK API responses, and mutation errors), and adjusts existing tests to assert two fetch calls (lookup + restart). Improves logging and typing for GraphQL responses.