### PR TITLE
Add breadcrumbs and titleExtra to ScheduleLayout

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -2,7 +2,12 @@
 import React, { useEffect, useState } from 'react';
 import { useMediaQuery } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Container from '@mui/material/Container';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
 import { getTeamSeasonDetails as apiGetTeamSeasonDetails } from '@draco/shared-api-client';
 import type { TeamSeasonRecordType } from '@draco/shared-schemas';
 import { useAuth } from '../../../../../../../../context/AuthContext';
@@ -233,12 +238,34 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
 
   const isResolvingInitialDate = filterDate === undefined;
 
+  const teamHomeHref = `/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}`;
+
   return (
     <ScheduleLayout
       accountId={accountId}
       title={teamName ?? 'Team Schedule'}
-      subtitle="Full Season Schedule"
-      seasonName={seasonName}
+      titleExtra={
+        seasonName ? (
+          <Typography
+            variant="body1"
+            sx={{ mt: 1, textAlign: 'center', color: 'text.secondary', fontWeight: 'normal' }}
+          >
+            {seasonName} Season
+          </Typography>
+        ) : null
+      }
+      subtitle="Schedule"
+      breadcrumbs={
+        <Box sx={{ mb: 2 }}>
+          <Breadcrumbs aria-label="breadcrumb">
+            <Link component={NextLink} underline="hover" color="inherit" href={teamHomeHref}>
+              Team Overview
+            </Link>
+            <Typography color="text.primary">Schedule</Typography>
+          </Breadcrumbs>
+        </Box>
+      }
+      seasonName={null}
       filteredGames={filteredGames}
       teams={[]}
       locations={locations}

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -28,6 +28,7 @@ export interface ScheduleLayoutProps {
   accountId: string;
   title: string;
   subtitle?: string;
+  titleExtra?: React.ReactNode;
   breadcrumbs?: React.ReactNode;
   seasonName: string | null;
   filteredGames: Game[];
@@ -75,6 +76,7 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
   accountId,
   title,
   subtitle,
+  titleExtra,
   breadcrumbs,
   seasonName,
   filteredGames,
@@ -134,6 +136,7 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
           >
             {title}
           </Typography>
+          {titleExtra}
           {subtitle ? (
             <Typography
               variant="body1"
@@ -146,7 +149,9 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
 
         <Container maxWidth={false} sx={{ py: 4 }}>
           {breadcrumbs}
-          <AdPlacement />
+          <Box sx={{ mb: 3 }}>
+            <AdPlacement />
+          </Box>
 
           {summaryContent}
 


### PR DESCRIPTION
Expose a titleExtra slot and render it under the main title in ScheduleLayout, and allow breadcrumbs to be passed in. Wrap AdPlacement in a box to add bottom spacing. Update TeamSchedulePage to provide breadcrumbs and a team overview link, move the season name into the new titleExtra (displaying as “{seasonName} Season”), change the subtitle to “Schedule”, and clear the seasonName prop (now rendered via titleExtra). These changes improve page navigation and spacing for the team schedule view.