### PR TITLE
Use 'Team Overview' and reorder breadcrumbs

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/sponsors/manage/TeamSponsorManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/sponsors/manage/TeamSponsorManagement.tsx
@@ -233,7 +233,7 @@ const TeamSponsorManagement: React.FC<TeamSponsorManagementProps> = ({
             color="inherit"
             href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}`}
           >
-            Team Page
+            Team Overview
           </MuiLink>
           <Typography color="text.primary">Sponsor Management</Typography>
         </Breadcrumbs>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/stat-entry/TeamStatEntryPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/stat-entry/TeamStatEntryPage.tsx
@@ -1433,7 +1433,7 @@ const TeamStatEntryPage: React.FC<TeamStatEntryPageProps> = ({
               color="inherit"
               sx={{ fontWeight: 500, ml: 3 }}
             >
-              {teamHeaderData?.teamName ?? 'Team'}
+              Team Overview
             </MuiLink>
             <Typography color="text.primary" sx={{ fontWeight: 500 }}>
               Statistics

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -148,10 +148,10 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
         </AccountPageHeader>
 
         <Container maxWidth={false} sx={{ py: 4 }}>
-          {breadcrumbs}
           <Box sx={{ mb: 3 }}>
             <AdPlacement />
           </Box>
+          {breadcrumbs}
 
           {summaryContent}
 


### PR DESCRIPTION
Standardize breadcrumb labeling and adjust layout: replace the 'Team Page' / dynamic team name breadcrumb with a static 'Team Overview' label in TeamSponsorManagement.tsx and TeamStatEntryPage.tsx for consistency. In ScheduleLayout.tsx, move the breadcrumbs rendering below the AdPlacement block so the ad is shown above the breadcrumbs and the page layout is more consistent. Files changed: TeamSponsorManagement.tsx, TeamStatEntryPage.tsx, ScheduleLayout.tsx.