### PR TITLE
Add Playwright E2E fixtures, helpers & scripts

### DIFF
--- a/draco-nodejs/frontend-next/AGENTS.md
+++ b/draco-nodejs/frontend-next/AGENTS.md
@@ -298,6 +298,15 @@ const MyComponent = () => {
 
 **Reference implementations:** `components/ThemeSwitcher.tsx`, `theme.ts`
 
+## E2E Test Fixtures
+
+Two test accounts are used to isolate read-only seed data from write-heavy fixture data:
+
+- `E2E_ACCOUNT_ID=1` — Shared read-only seed account. Tests that only read data (smoke tests, photo gallery, hall of fame, social hub) run against this account. **Do not mutate it.**
+- `E2E_TEST_ACCOUNT_ID=29` — Per-worker write-fixture account. Write-heavy tests create a fresh league, season, and team under this account each Playwright worker, then delete them in teardown.
+
+The admin user in `.env.e2e` holds `AccountAdmin` role on both accounts. Worker fixtures follow the `golf-substitute-fixtures.ts` pattern with `{ scope: 'worker' }`, a unique `suffix` derived from `workerIndex + Date.now()`, and cleanup logged via `e2e/helpers/cleanupLog.ts`.
+
 ---
 
 # Frontend Architecture

--- a/draco-nodejs/frontend-next/e2e/README.md
+++ b/draco-nodejs/frontend-next/e2e/README.md
@@ -1,0 +1,138 @@
+# E2E Tests
+
+Playwright-based end-to-end suite. Targets a locally running dev stack (`pnpm dev` from repo root) and a local Postgres database.
+
+## Running
+
+From the repo root:
+
+```bash
+pnpm frontend:e2e                    # full suite
+pnpm frontend:e2e:last-failed        # rerun only the last-failed tests
+pnpm frontend:e2e:reap               # delete orphaned E2E-* rows older than 24h (localhost only)
+pnpm frontend:e2e -- <spec> --project=chromium --workers=4   # scope to one file or project
+```
+
+`pnpm frontend:e2e` wraps `dotenv -e .env.local -e .env.e2e -- playwright test` — do **not** call `playwright test` directly, or env vars will be missing.
+
+## Test accounts
+
+Two accounts are used in the dev DB:
+
+| Env var | Account | Mutable? | Purpose |
+| --- | --- | --- | --- |
+| `E2E_ACCOUNT_ID=1` | "Detroit MSBL" seed | **Read-only** | Smoke, public-page, hall-of-fame, social-hub, photo-gallery — tests that rely on stable seed content. |
+| `E2E_TEST_ACCOUNT_ID=29` | "E2E Test Account" | Write-heavy | Worker fixtures create fresh leagues / seasons / teams / contacts here and clean them up on worker teardown. |
+
+The admin user (`.env.e2e` `E2E_ADMIN_EMAIL`) has `AccountAdmin` on both.
+
+## Layout
+
+```
+e2e/
+├── fixtures/                # Worker-scoped test data fixtures
+│   ├── base-fixtures.ts     # Shared options (accountId, seasonId, etc.) from env
+│   ├── account-scoped-fixtures.ts
+│   ├── team-scoped-fixtures.ts
+│   ├── contact-scoped-fixtures.ts
+│   └── golf-*.ts            # Golf-specific write fixtures
+├── helpers/
+│   ├── api.ts               # Typed ApiHelper wrapping the generated SDK
+│   ├── auth.ts              # getJwtToken, BASE_URL
+│   ├── cleanupLog.ts        # Log-not-throw cleanup error recorder
+│   └── date.ts
+├── pages/                   # Page-object classes
+├── scripts/
+│   └── reap-e2e-data.ts     # Safety-gated cleanup of orphan E2E rows
+├── tests/                   # *.spec.ts organized by domain
+│   ├── account/
+│   ├── community/
+│   ├── golf/
+│   ├── smoke/
+│   ├── sports/
+│   └── fixtures-smoke.spec.ts  # Smoke-tests the three worker fixtures
+├── .auth/admin.json         # Cached admin JWT (created by global-setup)
+└── global-setup.ts          # Logs in once and stores auth state
+```
+
+## Worker fixtures
+
+Use a worker fixture when your test **mutates** data and you don't want it to collide with other workers or the shared seed. Worker fixtures run once per Playwright worker, not per test.
+
+### Pick the right fixture
+
+| Fixture | Provides | Use when |
+| --- | --- | --- |
+| `accountScoped` | `accountId`, `seasonId`, `leagueId`, `leagueSeasonId`, `suffix` | You need league/season context but no team (announcements, polls, sponsors, handouts, etc.). |
+| `teamScoped` | All of above + `teamId`, `teamSeasonId`, `rosterContactIds`, `rosterMemberIds` | You need a team with roster (team pages, schedule, standings, statistics). |
+| `contactScoped` | `accountId`, 3 players + 1 manager contact | You need a pool of contacts but no team (user management, player classifieds, communications). |
+
+### Usage
+
+```ts
+import { test, expect } from '../../fixtures/account-scoped-fixtures';
+
+test('create an announcement', async ({ page, accountScoped }) => {
+  await page.goto(`/account/${accountScoped.accountId}/announcements`);
+  // ... mutate data scoped to accountScoped.leagueSeasonId, etc.
+});
+```
+
+To use multiple fixtures in one file, merge them:
+
+```ts
+import { mergeTests } from '@playwright/test';
+import { test as accountTest } from '../../fixtures/account-scoped-fixtures';
+import { test as contactTest } from '../../fixtures/contact-scoped-fixtures';
+
+const test = mergeTests(accountTest, contactTest);
+```
+
+Worker-scoped fixtures are lazy — they only instantiate when a test in the worker actually references them.
+
+### Do not
+
+- Do **not** mutate `E2E_ACCOUNT_ID=1` seed data. Use `E2E_TEST_ACCOUNT_ID=29` via a fixture instead.
+- Do **not** introduce per-test (test-scoped) data fixtures — setup cost swamps the test. Keep `{ scope: 'worker' }`.
+- Do **not** inline raw `fetch` calls inside a fixture — add the operation to `helpers/api.ts` first, then call it.
+- Do **not** throw from cleanup — accumulate errors in an array via `tryCleanup` and pass to `appendCleanupLog`. Teardown must always complete.
+- Do **not** rename existing fixture properties without auditing every consumer.
+
+## Adding a new fixture
+
+Follow the shape of `golf-substitute-fixtures.ts`:
+
+1. Create a `create<Thing>Data(baseURL, workerIndex)` function that makes a unique `suffix = \`\${Date.now() % 10_000_000}w\${workerIndex}\`` and calls `ApiHelper` methods to build the data.
+2. Create a `cleanup<Thing>Data(baseURL, data)` function that deletes in **reverse FK order** using `tryCleanup`, then calls `appendCleanupLog('<label> \${suffix}', errors)`.
+3. Export a `test` via `base.extend<object, WorkerFixtures>({ <name>: [async fn, { scope: 'worker' }] })` and re-export `expect`.
+4. If `ApiHelper` doesn't have a method you need, add it there rather than inlining fetches.
+5. Add a smoke assertion to `tests/fixtures-smoke.spec.ts` so fixture regressions are caught fast.
+
+## Waits and flake avoidance
+
+- **Never use `waitForLoadState('networkidle')`.** It is unreliable — any background fetch resets the idle timer. This was audited out of the suite in the April 2026 cleanup. Use `waitForLoadState('domcontentloaded')` when the only need is "page has started rendering," or — strongly preferred — wait on an explicit element:
+  ```ts
+  await expect(page.getByRole('heading', { name: 'Announcements' })).toBeVisible({ timeout: 15_000 });
+  ```
+- When branching on which of two UI states rendered (e.g., mobile hamburger vs desktop nav), gate the branch with `locator.or(otherLocator)`:
+  ```ts
+  const signIn = page.getByRole('button', { name: 'Sign In' });
+  const menu = page.getByRole('button', { name: 'menu' });
+  await expect(signIn.or(menu)).toBeVisible({ timeout: 15_000 });
+  if (await menu.isVisible()) { ... } else { ... }
+  ```
+- Avoid `page.waitForTimeout(...)` as a flake band-aid. If something needs extra time, wait on the real condition instead.
+- Avoid `test.skip` / `test.fixme` to bypass flake. Fix or remove the test.
+
+## Cleanup & orphan recovery
+
+- Each worker's cleanup runs in reverse FK order via `tryCleanup`, and errors are written to `e2e/.results/cleanup-errors-*.log` — check these logs if the DB accumulates `E2E` rows over time.
+- To reap stale orphans (older than 24h):
+  ```bash
+  pnpm frontend:e2e:reap
+  ```
+  The script refuses to run unless `DATABASE_URL` matches `postgresql://<user>@localhost/...` (no password, no remote host). Do **not** weaken this check.
+
+## Global auth setup
+
+`global-setup.ts` logs in as the admin once per Playwright run and stores state to `.auth/admin.json`. Every browser project depends on this project. If auth fails, all tests are skipped — check `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` in `.env.e2e` and that the dev stack is up on `http://localhost:4001`.

--- a/draco-nodejs/frontend-next/e2e/README.md
+++ b/draco-nodejs/frontend-next/e2e/README.md
@@ -9,7 +9,7 @@ From the repo root:
 ```bash
 pnpm frontend:e2e                    # full suite
 pnpm frontend:e2e:last-failed        # rerun only the last-failed tests
-pnpm frontend:e2e:reap               # delete orphaned E2E-* rows older than 24h (localhost only)
+pnpm frontend:e2e:reap               # delete orphaned E2E-* rows in E2E_TEST_ACCOUNT_ID (localhost only)
 pnpm frontend:e2e -- <spec> --project=chromium --workers=4   # scope to one file or project
 ```
 
@@ -127,11 +127,11 @@ Follow the shape of `golf-substitute-fixtures.ts`:
 ## Cleanup & orphan recovery
 
 - Each worker's cleanup runs in reverse FK order via `tryCleanup`, and errors are written to `e2e/.results/cleanup-errors-*.log` — check these logs if the DB accumulates `E2E` rows over time.
-- To reap stale orphans (older than 24h):
+- To reap orphaned E2E rows in the dedicated test account:
   ```bash
   pnpm frontend:e2e:reap
   ```
-  The script refuses to run unless `DATABASE_URL` matches `postgresql://<user>@localhost/...` (no password, no remote host). Do **not** weaken this check.
+  The script deletes every `E2E`-named row scoped to `E2E_TEST_ACCOUNT_ID` (no time cutoff), so don't run it while another E2E run is in-flight against the same account. It refuses to start unless `DATABASE_URL` matches `postgresql://<user>@localhost/...` (no password, no remote host) and `E2E_TEST_ACCOUNT_ID` is a numeric account id. Do **not** weaken these checks.
 
 ## Global auth setup
 

--- a/draco-nodejs/frontend-next/e2e/fixtures/account-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/account-scoped-fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from './base-fixtures';
+import { test as base, getRequiredE2eTestAccountId } from './base-fixtures';
 import { ApiHelper, tryCleanup } from '../helpers/api';
 import { getJwtToken, BASE_URL } from '../helpers/auth';
 import { appendCleanupLog } from '../helpers/cleanupLog';
@@ -16,7 +16,7 @@ async function createAccountScopedData(
   workerIndex: number,
 ): Promise<AccountScopedData> {
   const api = new ApiHelper(baseURL, getJwtToken());
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const accountId = getRequiredE2eTestAccountId();
   const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
 
   const league = await api.createLeague(accountId, { name: `E2E Lg ${suffix}` });

--- a/draco-nodejs/frontend-next/e2e/fixtures/account-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/account-scoped-fixtures.ts
@@ -1,0 +1,60 @@
+import { test as base } from './base-fixtures';
+import { ApiHelper, tryCleanup } from '../helpers/api';
+import { getJwtToken, BASE_URL } from '../helpers/auth';
+import { appendCleanupLog } from '../helpers/cleanupLog';
+
+export type AccountScopedData = {
+  accountId: string;
+  seasonId: string;
+  leagueSeasonId: string;
+  leagueId: string;
+  suffix: string;
+};
+
+async function createAccountScopedData(
+  baseURL: string,
+  workerIndex: number,
+): Promise<AccountScopedData> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
+
+  const league = await api.createLeague(accountId, { name: `E2E Lg ${suffix}` });
+  const currentSeason = await api.fetchCurrentSeason(accountId);
+  const leagueSeason = await api.addLeagueToSeason(accountId, currentSeason.id, league.id);
+
+  return {
+    accountId,
+    seasonId: currentSeason.id,
+    leagueSeasonId: leagueSeason.id,
+    leagueId: league.id,
+    suffix,
+  };
+}
+
+async function cleanupAccountScopedData(baseURL: string, data: AccountScopedData): Promise<void> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const errors: string[] = [];
+
+  await tryCleanup(errors, () =>
+    api.removeLeagueFromSeason(data.accountId, data.seasonId, data.leagueSeasonId),
+  );
+  await tryCleanup(errors, () => api.deleteLeague(data.accountId, data.leagueId));
+
+  appendCleanupLog(`account-scoped ${data.suffix}`, errors);
+}
+
+type WorkerFixtures = { accountScoped: AccountScopedData };
+
+export const test = base.extend<object, WorkerFixtures>({
+  accountScoped: [
+    async ({}, use, workerInfo) => {
+      const data = await createAccountScopedData(BASE_URL, workerInfo.workerIndex);
+      await use(data);
+      await cleanupAccountScopedData(BASE_URL, data);
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/draco-nodejs/frontend-next/e2e/fixtures/base-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/base-fixtures.ts
@@ -15,10 +15,15 @@ export const test = base.extend<DracoFixtures>({
 });
 
 export function getRequiredE2eTestAccountId(): string {
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID;
-  if (!accountId || accountId.trim() === '') {
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID?.trim() ?? '';
+  if (accountId === '') {
     throw new Error(
       'E2E_TEST_ACCOUNT_ID must be set to a non-empty account id for write-scoped Playwright fixtures.',
+    );
+  }
+  if (!/^\d+$/.test(accountId)) {
+    throw new Error(
+      'E2E_TEST_ACCOUNT_ID must be set to a numeric account id for write-scoped Playwright fixtures.',
     );
   }
   return accountId;

--- a/draco-nodejs/frontend-next/e2e/fixtures/base-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/base-fixtures.ts
@@ -14,4 +14,14 @@ export const test = base.extend<DracoFixtures>({
   playerId: [process.env.E2E_PLAYER_ID || '', { option: true }],
 });
 
+export function getRequiredE2eTestAccountId(): string {
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID;
+  if (!accountId || accountId.trim() === '') {
+    throw new Error(
+      'E2E_TEST_ACCOUNT_ID must be set to a non-empty account id for write-scoped Playwright fixtures.',
+    );
+  }
+  return accountId;
+}
+
 export { expect } from '@playwright/test';

--- a/draco-nodejs/frontend-next/e2e/fixtures/contact-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/contact-scoped-fixtures.ts
@@ -1,0 +1,68 @@
+import { test as base } from './base-fixtures';
+import { ApiHelper, tryCleanup } from '../helpers/api';
+import { getJwtToken, BASE_URL } from '../helpers/auth';
+import { appendCleanupLog } from '../helpers/cleanupLog';
+
+export type ContactScopedData = {
+  accountId: string;
+  suffix: string;
+  players: Array<{ id: string; firstName: string; lastName: string }>;
+  manager: { id: string; firstName: string; lastName: string };
+};
+
+async function createContactScopedData(
+  baseURL: string,
+  workerIndex: number,
+): Promise<ContactScopedData> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
+
+  const playerDefs = [
+    { firstName: 'E2E', lastName: `PlrA${suffix}` },
+    { firstName: 'E2E', lastName: `PlrB${suffix}` },
+    { firstName: 'E2E', lastName: `PlrC${suffix}` },
+  ];
+
+  const players: ContactScopedData['players'] = [];
+  for (const def of playerDefs) {
+    const contact = await api.createAccountContact(accountId, def);
+    players.push({ id: contact.id, firstName: contact.firstName, lastName: contact.lastName });
+  }
+
+  const mgr = await api.createAccountContact(accountId, {
+    firstName: 'E2E',
+    lastName: `Mgr${suffix}`,
+  });
+  const manager = { id: mgr.id, firstName: mgr.firstName, lastName: mgr.lastName };
+
+  return { accountId, suffix, players, manager };
+}
+
+async function cleanupContactScopedData(baseURL: string, data: ContactScopedData): Promise<void> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const errors: string[] = [];
+
+  await tryCleanup(errors, () => api.deleteContact(data.accountId, data.manager.id));
+
+  for (const player of [...data.players].reverse()) {
+    await tryCleanup(errors, () => api.deleteContact(data.accountId, player.id));
+  }
+
+  appendCleanupLog(`contact-scoped ${data.suffix}`, errors);
+}
+
+type WorkerFixtures = { contactScoped: ContactScopedData };
+
+export const test = base.extend<object, WorkerFixtures>({
+  contactScoped: [
+    async ({}, use, workerInfo) => {
+      const data = await createContactScopedData(BASE_URL, workerInfo.workerIndex);
+      await use(data);
+      await cleanupContactScopedData(BASE_URL, data);
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/draco-nodejs/frontend-next/e2e/fixtures/contact-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/contact-scoped-fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from './base-fixtures';
+import { test as base, getRequiredE2eTestAccountId } from './base-fixtures';
 import { ApiHelper, tryCleanup } from '../helpers/api';
 import { getJwtToken, BASE_URL } from '../helpers/auth';
 import { appendCleanupLog } from '../helpers/cleanupLog';
@@ -15,7 +15,7 @@ async function createContactScopedData(
   workerIndex: number,
 ): Promise<ContactScopedData> {
   const api = new ApiHelper(baseURL, getJwtToken());
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const accountId = getRequiredE2eTestAccountId();
   const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
 
   const playerDefs = [

--- a/draco-nodejs/frontend-next/e2e/fixtures/team-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/team-scoped-fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from './base-fixtures';
+import { test as base, getRequiredE2eTestAccountId } from './base-fixtures';
 import { ApiHelper, tryCleanup } from '../helpers/api';
 import { getJwtToken, BASE_URL } from '../helpers/auth';
 import { appendCleanupLog } from '../helpers/cleanupLog';
@@ -14,7 +14,7 @@ export type TeamScopedData = AccountScopedData & {
 
 async function createTeamScopedData(baseURL: string, workerIndex: number): Promise<TeamScopedData> {
   const api = new ApiHelper(baseURL, getJwtToken());
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const accountId = getRequiredE2eTestAccountId();
   const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
 
   const league = await api.createLeague(accountId, { name: `E2E Lg ${suffix}` });

--- a/draco-nodejs/frontend-next/e2e/fixtures/team-scoped-fixtures.ts
+++ b/draco-nodejs/frontend-next/e2e/fixtures/team-scoped-fixtures.ts
@@ -1,0 +1,117 @@
+import { test as base } from './base-fixtures';
+import { ApiHelper, tryCleanup } from '../helpers/api';
+import { getJwtToken, BASE_URL } from '../helpers/auth';
+import { appendCleanupLog } from '../helpers/cleanupLog';
+import type { AccountScopedData } from './account-scoped-fixtures';
+
+export type TeamScopedData = AccountScopedData & {
+  teamId: string;
+  teamName: string;
+  teamSeasonId: string;
+  rosterContactIds: string[];
+  rosterMemberIds: string[];
+};
+
+async function createTeamScopedData(baseURL: string, workerIndex: number): Promise<TeamScopedData> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID!;
+  const suffix = `${Date.now() % 10_000_000}w${workerIndex}`;
+
+  const league = await api.createLeague(accountId, { name: `E2E Lg ${suffix}` });
+  const currentSeason = await api.fetchCurrentSeason(accountId);
+  const leagueSeason = await api.addLeagueToSeason(accountId, currentSeason.id, league.id);
+
+  const teamName = `E2E Tm ${suffix}`;
+  const teamSeason = await api.createBaseballTeam(accountId, currentSeason.id, leagueSeason.id, {
+    name: teamName,
+  });
+
+  const contactA = await api.createAccountContact(accountId, {
+    firstName: 'E2E',
+    lastName: `PlayerA${suffix}`,
+  });
+  const contactB = await api.createAccountContact(accountId, {
+    firstName: 'E2E',
+    lastName: `PlayerB${suffix}`,
+  });
+  const contactC = await api.createAccountContact(accountId, {
+    firstName: 'E2E',
+    lastName: `PlayerC${suffix}`,
+  });
+
+  const memberA = await api.signContactToRoster(
+    accountId,
+    currentSeason.id,
+    teamSeason.id,
+    contactA.id,
+  );
+  const memberB = await api.signContactToRoster(
+    accountId,
+    currentSeason.id,
+    teamSeason.id,
+    contactB.id,
+  );
+  const memberC = await api.signContactToRoster(
+    accountId,
+    currentSeason.id,
+    teamSeason.id,
+    contactC.id,
+  );
+
+  return {
+    accountId,
+    seasonId: currentSeason.id,
+    leagueSeasonId: leagueSeason.id,
+    leagueId: league.id,
+    suffix,
+    teamId: teamSeason.team.id,
+    teamName,
+    teamSeasonId: teamSeason.id,
+    rosterContactIds: [contactA.id, contactB.id, contactC.id],
+    rosterMemberIds: [memberA.id, memberB.id, memberC.id],
+  };
+}
+
+async function cleanupTeamScopedData(baseURL: string, data: TeamScopedData): Promise<void> {
+  const api = new ApiHelper(baseURL, getJwtToken());
+  const errors: string[] = [];
+
+  for (const rosterMemberId of [...data.rosterMemberIds].reverse()) {
+    await tryCleanup(errors, () =>
+      api.deleteRosterMember(data.accountId, data.seasonId, data.teamSeasonId, rosterMemberId),
+    );
+  }
+
+  for (const contactId of [...data.rosterContactIds].reverse()) {
+    await tryCleanup(errors, () => api.deleteContact(data.accountId, contactId));
+  }
+
+  await tryCleanup(errors, () =>
+    api.deleteSeasonTeam(data.accountId, data.seasonId, data.teamSeasonId),
+  );
+
+  await tryCleanup(errors, () => api.deleteTeamDefinition(data.accountId, data.teamId));
+
+  await tryCleanup(errors, () =>
+    api.removeLeagueFromSeason(data.accountId, data.seasonId, data.leagueSeasonId),
+  );
+
+  await tryCleanup(errors, () => api.deleteLeague(data.accountId, data.leagueId));
+
+  appendCleanupLog(`team-scoped ${data.suffix}`, errors);
+}
+
+type WorkerFixtures = { teamScoped: TeamScopedData };
+
+export const test = base.extend<object, WorkerFixtures>({
+  teamScoped: [
+    async ({}, use, workerInfo) => {
+      const data = await createTeamScopedData(BASE_URL, workerInfo.workerIndex);
+      await use(data);
+      await cleanupTeamScopedData(BASE_URL, data);
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/draco-nodejs/frontend-next/e2e/helpers/api.ts
+++ b/draco-nodejs/frontend-next/e2e/helpers/api.ts
@@ -32,6 +32,11 @@ import {
   createGolfClosestToPin,
   deleteGolfClosestToPin,
   getGolfCourse,
+  createContact,
+  signPlayer,
+  deletePlayer,
+  deleteSeasonTeam,
+  deleteAccountTeam,
 } from '@draco/shared-api-client';
 import type {
   League,
@@ -53,6 +58,8 @@ import type {
   GolfClosestToPinEntry,
   CreateGolfClosestToPin,
   GolfCourseWithTees,
+  Contact,
+  RosterMember,
 } from '@draco/shared-api-client';
 
 export function createE2EApiClient(baseUrl: string, token: string) {
@@ -469,5 +476,83 @@ export class ApiHelper {
     });
     if (error || !data) throw new Error(`getCourse failed: ${JSON.stringify(error)}`);
     return data;
+  }
+
+  async createAccountContact(
+    accountId: string,
+    data: { firstName: string; lastName: string; email?: string },
+  ): Promise<Contact> {
+    const { data: contact, error } = await createContact({
+      client: this.client,
+      path: { accountId },
+      body: data,
+    });
+    if (error || !contact) throw new Error(`createContact failed: ${JSON.stringify(error)}`);
+    return contact;
+  }
+
+  async createBaseballTeam(
+    accountId: string,
+    seasonId: string,
+    leagueSeasonId: string,
+    data: { name: string },
+  ): Promise<TeamSeason> {
+    const { data: team, error } = await createLeagueSeasonTeam({
+      client: this.client,
+      path: { accountId, seasonId, leagueSeasonId },
+      body: data,
+    });
+    if (error || !team) throw new Error(`createBaseballTeam failed: ${JSON.stringify(error)}`);
+    return team;
+  }
+
+  async signContactToRoster(
+    accountId: string,
+    seasonId: string,
+    teamSeasonId: string,
+    contactId: string,
+  ): Promise<RosterMember> {
+    const { data: member, error } = await signPlayer({
+      client: this.client,
+      path: { accountId, seasonId, teamSeasonId },
+      body: {
+        player: {
+          submittedDriversLicense: false,
+          firstYear: new Date().getFullYear(),
+          contact: { id: contactId },
+        },
+      },
+    });
+    if (error || !member) throw new Error(`signContactToRoster failed: ${JSON.stringify(error)}`);
+    return member;
+  }
+
+  async deleteRosterMember(
+    accountId: string,
+    seasonId: string,
+    teamSeasonId: string,
+    rosterMemberId: string,
+  ): Promise<void> {
+    const { error, response } = await deletePlayer({
+      client: this.client,
+      path: { accountId, seasonId, teamSeasonId, rosterMemberId },
+    });
+    if (error) throw new ApiError('deleteRosterMember', response.status, error);
+  }
+
+  async deleteSeasonTeam(accountId: string, seasonId: string, teamSeasonId: string): Promise<void> {
+    const { error, response } = await deleteSeasonTeam({
+      client: this.client,
+      path: { accountId, seasonId, teamSeasonId },
+    });
+    if (error) throw new ApiError('deleteSeasonTeam', response.status, error);
+  }
+
+  async deleteTeamDefinition(accountId: string, teamId: string): Promise<void> {
+    const { error, response } = await deleteAccountTeam({
+      client: this.client,
+      path: { accountId, teamId },
+    });
+    if (error) throw new ApiError('deleteTeamDefinition', response.status, error);
   }
 }

--- a/draco-nodejs/frontend-next/e2e/helpers/cleanupLog.ts
+++ b/draco-nodejs/frontend-next/e2e/helpers/cleanupLog.ts
@@ -18,9 +18,10 @@ export function appendCleanupLog(label: string, errors: string[]): void {
       String(now.getHours()).padStart(2, '0'),
       String(now.getMinutes()).padStart(2, '0'),
       String(now.getSeconds()).padStart(2, '0'),
+      String(now.getMilliseconds()).padStart(3, '0'),
     ].join('');
 
-    const logFile = path.join(RESULTS_DIR, `cleanup-errors-${timestamp}.log`);
+    const logFile = path.join(RESULTS_DIR, `cleanup-errors-${timestamp}-pid${process.pid}.log`);
     const content = `\n=== ${label} ===\n${errors.join('\n')}\n`;
 
     fs.appendFileSync(logFile, content, 'utf-8');

--- a/draco-nodejs/frontend-next/e2e/helpers/cleanupLog.ts
+++ b/draco-nodejs/frontend-next/e2e/helpers/cleanupLog.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+
+const RESULTS_DIR = path.join(import.meta.dirname, '..', '.results');
+
+export function appendCleanupLog(label: string, errors: string[]): void {
+  if (errors.length === 0) return;
+
+  try {
+    fs.mkdirSync(RESULTS_DIR, { recursive: true });
+
+    const now = new Date();
+    const timestamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, '0'),
+      String(now.getDate()).padStart(2, '0'),
+      '-',
+      String(now.getHours()).padStart(2, '0'),
+      String(now.getMinutes()).padStart(2, '0'),
+      String(now.getSeconds()).padStart(2, '0'),
+    ].join('');
+
+    const logFile = path.join(RESULTS_DIR, `cleanup-errors-${timestamp}.log`);
+    const content = `\n=== ${label} ===\n${errors.join('\n')}\n`;
+
+    fs.appendFileSync(logFile, content, 'utf-8');
+  } catch (err) {
+    console.warn('cleanupLog: failed to write cleanup log:', err);
+  }
+}

--- a/draco-nodejs/frontend-next/e2e/pages/golf-score-entry.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/golf-score-entry.page.ts
@@ -5,7 +5,7 @@ export class GolfScoreEntryPage {
 
   async goto(accountId: string) {
     await this.page.goto(`/account/${accountId}/schedule-management`);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   private gameCard(team1Name: string): Locator {
@@ -19,7 +19,6 @@ export class GolfScoreEntryPage {
     await btn.scrollIntoViewIfNeeded();
     await btn.click({ force: true });
     await this.page.getByTestId('score-entry-dialog').waitFor({ state: 'visible' });
-    await this.page.waitForLoadState('networkidle');
     await this.dialog()
       .locator('.MuiAccordion-root')
       .first()

--- a/draco-nodejs/frontend-next/e2e/pages/league-player-profile.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/league-player-profile.page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 
 export class LeaguePlayerProfilePage {
@@ -14,7 +15,8 @@ export class LeaguePlayerProfilePage {
   async goto(accountId: string, seasonId: string, contactId: string, playerName: string) {
     const url = `/account/${accountId}/seasons/${seasonId}/golf/players/${contactId}?name=${encodeURIComponent(playerName)}`;
     await this.page.goto(url);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.scoresHeading).toBeVisible({ timeout: 15_000 });
   }
 
   getScoreItems() {

--- a/draco-nodejs/frontend-next/e2e/pages/login.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/login.page.ts
@@ -23,7 +23,7 @@ export class LoginPage {
 
   async goto() {
     await this.page.goto('/login');
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async login(email: string, password: string) {

--- a/draco-nodejs/frontend-next/e2e/pages/statistics.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/statistics.page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 export class StatisticsPage {
@@ -21,6 +22,7 @@ export class StatisticsPage {
 
   async goto(accountId: string) {
     await this.page.goto(`/account/${accountId}/statistics`);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.heading).toBeVisible({ timeout: 15_000 });
   }
 }

--- a/draco-nodejs/frontend-next/e2e/pages/user-management.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/user-management.page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 export class UserManagementPage {
@@ -23,7 +24,8 @@ export class UserManagementPage {
 
   async goto(accountId: string) {
     await this.page.goto(`/account/${accountId}/users`);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.heading).toBeVisible({ timeout: 15_000 });
   }
 
   async search(term: string) {

--- a/draco-nodejs/frontend-next/e2e/scripts/reap-e2e-data.ts
+++ b/draco-nodejs/frontend-next/e2e/scripts/reap-e2e-data.ts
@@ -1,0 +1,54 @@
+import pg from 'pg';
+
+const SAFE_DB_URL = /^postgresql:\/\/[^:@\/]+@localhost(:\d+)?\//;
+
+if (!SAFE_DB_URL.test(process.env.DATABASE_URL || '')) {
+  console.error('REFUSING TO REAP: DATABASE_URL does not match localhost-no-password pattern');
+  process.exit(1);
+}
+
+const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+const { Pool } = pg;
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function reap(table: string, where: string, params: unknown[]): Promise<void> {
+  const countResult = await pool.query<{ count: string }>(
+    `SELECT COUNT(*) AS count FROM ${table} WHERE ${where}`,
+    params,
+  );
+  const count = parseInt(countResult.rows[0].count, 10);
+  if (count === 0) {
+    console.log(`${table}: 0 rows to reap`);
+    return;
+  }
+  await pool.query(`DELETE FROM ${table} WHERE ${where}`, params);
+  console.log(`${table}: reaped ${count} rows`);
+}
+
+async function main(): Promise<void> {
+  console.log(`Reaping E2E data older than ${cutoff.toISOString()}`);
+
+  await reap('contacts', "(firstname LIKE 'E2E%' OR lastname LIKE 'E2E%')", []);
+
+  await reap('teamsseason', "name LIKE 'E2E %'", []);
+
+  await reap(
+    'leagueseason',
+    "leagueseason.id IN (SELECT ls.id FROM leagueseason ls JOIN league l ON l.id = ls.leagueid WHERE l.name LIKE 'E2E %')",
+    [],
+  );
+
+  await reap('league', "name LIKE 'E2E %'", []);
+
+  await reap('season', "name LIKE 'E2E %'", []);
+
+  await pool.end();
+  console.log('Done.');
+}
+
+main().catch((err: unknown) => {
+  console.error('Reap failed:', err);
+  pool.end().catch(() => undefined);
+  process.exit(1);
+});

--- a/draco-nodejs/frontend-next/e2e/scripts/reap-e2e-data.ts
+++ b/draco-nodejs/frontend-next/e2e/scripts/reap-e2e-data.ts
@@ -7,7 +7,12 @@ if (!SAFE_DB_URL.test(process.env.DATABASE_URL || '')) {
   process.exit(1);
 }
 
-const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+const accountIdRaw = process.env.E2E_TEST_ACCOUNT_ID;
+if (!accountIdRaw || !/^\d+$/.test(accountIdRaw)) {
+  console.error('REFUSING TO REAP: E2E_TEST_ACCOUNT_ID must be set to a numeric account id');
+  process.exit(1);
+}
+const accountId = accountIdRaw;
 
 const { Pool } = pg;
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
@@ -27,21 +32,37 @@ async function reap(table: string, where: string, params: unknown[]): Promise<vo
 }
 
 async function main(): Promise<void> {
-  console.log(`Reaping E2E data older than ${cutoff.toISOString()}`);
+  console.log(`Reaping E2E data for account ${accountId}`);
 
-  await reap('contacts', "(firstname LIKE 'E2E%' OR lastname LIKE 'E2E%')", []);
+  await reap(
+    'contacts',
+    "(firstname LIKE 'E2E%' OR lastname LIKE 'E2E%') AND creatoraccountid = $1",
+    [accountId],
+  );
 
-  await reap('teamsseason', "name LIKE 'E2E %'", []);
+  await reap(
+    'teamsseason',
+    `name LIKE 'E2E %' AND leagueseasonid IN (
+       SELECT ls.id FROM leagueseason ls
+       JOIN season s ON s.id = ls.seasonid
+       WHERE s.accountid = $1
+     )`,
+    [accountId],
+  );
 
   await reap(
     'leagueseason',
-    "leagueseason.id IN (SELECT ls.id FROM leagueseason ls JOIN league l ON l.id = ls.leagueid WHERE l.name LIKE 'E2E %')",
-    [],
+    `leagueseason.id IN (
+       SELECT ls.id FROM leagueseason ls
+       JOIN league l ON l.id = ls.leagueid
+       WHERE l.name LIKE 'E2E %' AND l.accountid = $1
+     )`,
+    [accountId],
   );
 
-  await reap('league', "name LIKE 'E2E %'", []);
+  await reap('league', "name LIKE 'E2E %' AND accountid = $1", [accountId]);
 
-  await reap('season', "name LIKE 'E2E %'", []);
+  await reap('season', "name LIKE 'E2E %' AND accountid = $1", [accountId]);
 
   await pool.end();
   console.log('Done.');

--- a/draco-nodejs/frontend-next/e2e/tests/account/communications-compose-attachments.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/account/communications-compose-attachments.spec.ts
@@ -21,7 +21,10 @@ test.describe('Communications Compose - Attachments', () => {
 
     await page.goto(`/account/${accountId}/communications/compose`);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('heading', { name: /Compose Email/i })).toBeVisible({
+      timeout: 30000,
+    });
     await page.waitForTimeout(3000);
 
     const attachmentArea = page.getByText(/drag.*drop|browse.*files|attach/i);
@@ -51,7 +54,10 @@ test.describe('Communications Compose - Attachments', () => {
     });
 
     await page.goto(`/account/${accountId}/communications/compose`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('heading', { name: /Compose Email/i })).toBeVisible({
+      timeout: 30000,
+    });
     await page.waitForTimeout(2000);
 
     const fileInput = page.locator('input[type="file"]');
@@ -103,7 +109,10 @@ test.describe('Communications Compose - Attachments', () => {
     });
 
     await page.goto(`/account/${accountId}/communications/compose`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('heading', { name: /Compose Email/i })).toBeVisible({
+      timeout: 30000,
+    });
     await page.waitForTimeout(2000);
 
     const fileInput = page.locator('input[type="file"]');

--- a/draco-nodejs/frontend-next/e2e/tests/account/contact-photo-dialog-notification.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/account/contact-photo-dialog-notification.spec.ts
@@ -14,7 +14,8 @@ test.describe('ContactPhotoUploadDialog - Notification State', () => {
     teamSeasonId: string,
   ) {
     await page.goto(`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/roster`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('heading', { name: /roster/i })).toBeVisible({ timeout: 15_000 });
   }
 
   async function tryOpenPhotoDialog(page: import('@playwright/test').Page): Promise<boolean> {

--- a/draco-nodejs/frontend-next/e2e/tests/community/social-hub.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/community/social-hub.spec.ts
@@ -37,6 +37,7 @@ test.describe('Social Hub', () => {
 
   test('community messages sub-page loads', async ({ page, accountId }) => {
     await page.goto(`/account/${accountId}/social-hub/community`);
+    await expect(page.getByRole('main')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Community Messages' })).toBeVisible({
       timeout: 15_000,
     });

--- a/draco-nodejs/frontend-next/e2e/tests/fixtures-smoke.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/fixtures-smoke.spec.ts
@@ -1,0 +1,39 @@
+import { mergeTests, expect } from '@playwright/test';
+import { test as accountTest } from '../fixtures/account-scoped-fixtures';
+import { test as teamTest } from '../fixtures/team-scoped-fixtures';
+import { test as contactTest } from '../fixtures/contact-scoped-fixtures';
+
+const test = mergeTests(accountTest, teamTest, contactTest);
+
+test.describe('fixture smoke', () => {
+  test('accountScoped provides league + leagueSeason under test account', ({ accountScoped }) => {
+    expect(accountScoped.accountId).toBe(process.env.E2E_TEST_ACCOUNT_ID);
+    expect(accountScoped.seasonId).toBeTruthy();
+    expect(accountScoped.leagueId).toBeTruthy();
+    expect(accountScoped.leagueSeasonId).toBeTruthy();
+    expect(accountScoped.suffix).toMatch(/\d+w\d+/);
+  });
+
+  test('teamScoped provides team + roster', ({ teamScoped }) => {
+    expect(teamScoped.accountId).toBe(process.env.E2E_TEST_ACCOUNT_ID);
+    expect(teamScoped.teamId).toBeTruthy();
+    expect(teamScoped.teamSeasonId).toBeTruthy();
+    expect(teamScoped.teamName).toContain('E2E Tm');
+    expect(teamScoped.rosterContactIds).toHaveLength(3);
+    expect(teamScoped.rosterMemberIds).toHaveLength(3);
+    for (const id of teamScoped.rosterContactIds) expect(id).toBeTruthy();
+    for (const id of teamScoped.rosterMemberIds) expect(id).toBeTruthy();
+  });
+
+  test('contactScoped provides player pool + manager', ({ contactScoped }) => {
+    expect(contactScoped.accountId).toBe(process.env.E2E_TEST_ACCOUNT_ID);
+    expect(contactScoped.players.length).toBeGreaterThanOrEqual(3);
+    for (const p of contactScoped.players) {
+      expect(p.id).toBeTruthy();
+      expect(p.firstName).toBe('E2E');
+      expect(p.lastName).toContain('Plr');
+    }
+    expect(contactScoped.manager.id).toBeTruthy();
+    expect(contactScoped.manager.lastName).toContain('Mgr');
+  });
+});

--- a/draco-nodejs/frontend-next/e2e/tests/golf/league-player-profile.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/golf/league-player-profile.spec.ts
@@ -32,10 +32,9 @@ test.describe('Golf League Player Profile', () => {
   test('navigates back when clicking back button', async ({ page, golfData }) => {
     const leaderboardUrl = `/account/${golfData.accountId}/seasons/${golfData.seasonId}/golf`;
     await page.goto(leaderboardUrl);
-    await page.waitForLoadState('networkidle');
     const profileUrl = `/account/${golfData.accountId}/seasons/${golfData.seasonId}/golf/players/${golfData.player1ContactId}?name=${encodeURIComponent(golfData.player1Name)}`;
     await page.goto(profileUrl);
-    await page.waitForLoadState('networkidle');
+    await expect(profilePage.scoresHeading).toBeVisible({ timeout: 15_000 });
     await profilePage.backButton.click();
     await expect(page).not.toHaveURL(profileUrl, { timeout: 10_000 });
   });
@@ -43,12 +42,13 @@ test.describe('Golf League Player Profile', () => {
   test('maintains auth state after page refresh', async ({ page, golfData }) => {
     const url = `/account/${golfData.accountId}/seasons/${golfData.seasonId}/golf/players/${golfData.player1ContactId}?name=${encodeURIComponent(golfData.player1Name)}`;
     await page.goto(url);
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { name: 'League Match Scores' })).toBeVisible({
+      timeout: 15_000,
+    });
     await page.reload();
-    await page.waitForLoadState('networkidle');
     await expect(page.getByRole('button', { name: 'Sign In' })).not.toBeVisible({ timeout: 10000 });
     await expect(page.getByRole('heading', { name: 'League Match Scores' })).toBeVisible({
-      timeout: 15000,
+      timeout: 15_000,
     });
   });
 });

--- a/draco-nodejs/frontend-next/e2e/tests/golf/substitute-management.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/golf/substitute-management.spec.ts
@@ -7,7 +7,6 @@ test.describe('Golf Substitute Management', () => {
     await page.goto(
       `/account/${substituteData.accountId}/seasons/${substituteData.seasonId}/golf/leagues/${substituteData.leagueSeasonId}/substitutes`,
     );
-    await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
     await table.waitFor({ state: 'visible', timeout: 10000 });
@@ -25,7 +24,6 @@ test.describe('Golf Substitute Management', () => {
     await page.goto(
       `/account/${substituteData.accountId}/seasons/${substituteData.seasonId}/golf/leagues/${substituteData.leagueSeasonId}/substitutes`,
     );
-    await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
     await table.waitFor({ state: 'visible', timeout: 10000 });
@@ -94,7 +92,6 @@ test.describe('Golf Substitute Management', () => {
     await page.goto(
       `/account/${substituteData.accountId}/seasons/${substituteData.seasonId}/golf/leagues/${substituteData.leagueSeasonId}/substitutes`,
     );
-    await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
     await table.waitFor({ state: 'visible', timeout: 10000 });
@@ -179,7 +176,6 @@ test.describe('Golf Substitute Management', () => {
     await page.goto(
       `/account/${substituteData.accountId}/seasons/${substituteData.seasonId}/golf/leagues/${substituteData.leagueSeasonId}/substitutes`,
     );
-    await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
     await table.waitFor({ state: 'visible', timeout: 10000 });

--- a/draco-nodejs/frontend-next/e2e/tests/smoke/mobile-render.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/smoke/mobile-render.spec.ts
@@ -16,7 +16,7 @@ test.describe('Mobile rendering', () => {
 
     await page.goto(`/account/${accountId}`);
     await expect(page.locator('body')).toBeVisible();
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('main')).toBeVisible({ timeout: 15_000 });
 
     expect(
       consoleErrors,

--- a/draco-nodejs/frontend-next/e2e/tests/smoke/navigation.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/smoke/navigation.spec.ts
@@ -37,9 +37,9 @@ test.describe('Unauthenticated Public Page', () => {
     const context = await browser.newContext({ storageState: undefined });
     const page = await context.newPage();
     await page.goto('/account/1');
-    await page.waitForLoadState('networkidle');
     const signInButton = page.getByRole('button', { name: 'Sign In' });
     const menuButton = page.getByRole('button', { name: 'menu' });
+    await expect(signInButton.or(menuButton)).toBeVisible({ timeout: 15_000 });
     if (await menuButton.isVisible()) {
       await menuButton.click();
       await expect(page.getByText('Sign In').first()).toBeVisible({ timeout: 5_000 });

--- a/draco-nodejs/frontend-next/package.json
+++ b/draco-nodejs/frontend-next/package.json
@@ -22,7 +22,9 @@
     "e2e:debug": "dotenv -e .env.local -e .env.e2e -- playwright test --debug",
     "e2e:report": "playwright show-report e2e/.report",
     "e2e:codegen": "dotenv -e .env.local -e .env.e2e -- playwright codegen http://localhost:4001",
-    "e2e:update-snapshots": "dotenv -e .env.local -e .env.e2e -- playwright test --update-snapshots --project=chromium"
+    "e2e:update-snapshots": "dotenv -e .env.local -e .env.e2e -- playwright test --update-snapshots --project=chromium",
+    "e2e:last-failed": "dotenv -e .env.local -e .env.e2e -- playwright test --last-failed --retries=1",
+    "e2e:reap": "dotenv -e ../backend/.env -- tsx e2e/scripts/reap-e2e-data.ts"
   },
   "dependencies": {
     "@draco/shared-api-client": "workspace:*",

--- a/draco-nodejs/frontend-next/package.json
+++ b/draco-nodejs/frontend-next/package.json
@@ -24,7 +24,7 @@
     "e2e:codegen": "dotenv -e .env.local -e .env.e2e -- playwright codegen http://localhost:4001",
     "e2e:update-snapshots": "dotenv -e .env.local -e .env.e2e -- playwright test --update-snapshots --project=chromium",
     "e2e:last-failed": "dotenv -e .env.local -e .env.e2e -- playwright test --last-failed --retries=1",
-    "e2e:reap": "dotenv -e ../backend/.env -- tsx e2e/scripts/reap-e2e-data.ts"
+    "e2e:reap": "dotenv -e ../backend/.env -e .env.e2e -- tsx e2e/scripts/reap-e2e-data.ts"
   },
   "dependencies": {
     "@draco/shared-api-client": "workspace:*",
@@ -85,6 +85,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/leaflet": "^1.9.21",
+    "@types/pg": "^8.11.11",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/validator": "^13.15.10",
@@ -96,7 +97,9 @@
     "eslint-config-next": "16.2.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^27.4.0",
+    "pg": "^8.20.0",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "frontend:type-check": "pnpm --filter @draco/frontend-next type-check",
     "frontend:e2e": "pnpm --filter @draco/frontend-next e2e",
     "frontend:e2e:ui": "pnpm --filter @draco/frontend-next e2e:ui",
+    "frontend:e2e:last-failed": "pnpm --filter @draco/frontend-next e2e:last-failed",
+    "frontend:e2e:reap": "pnpm --filter @draco/frontend-next e2e:reap",
     "dev": "concurrently \"pnpm --filter @draco/backend dev\" \"pnpm --filter @draco/frontend-next dev\"",
     "dev:debug": "concurrently \"pnpm --filter @draco/backend dev:debug\" \"pnpm --filter @draco/frontend-next dev\"",
     "build": "pnpm --filter @draco/shared-schemas build && pnpm run sync:api && pnpm --filter @draco/backend build && pnpm --filter @draco/frontend-next build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,9 @@ importers:
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.11.11
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -579,9 +582,15 @@ importers:
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@1.8.0)
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -13236,8 +13245,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -13263,7 +13272,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -13274,21 +13283,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13299,7 +13308,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Introduce a full Playwright E2E suite: add e2e/README, worker-scoped fixtures (account/team/contact), a fixture smoke test, and page-object updates. Extend ApiHelper with contact/team/roster create/delete operations used by fixtures. Add cleanupLog helper and a safety-gated reap script (only runs against localhost DB) to remove orphan E2E data. Replace unreliable waitForLoadState('networkidle') with domcontentloaded + explicit expects to reduce flakiness. Update frontend and root package.json scripts to expose new e2e commands and wiring. Update AGENTS.md with E2E account guidance.