### PR TITLE
Add useSeasonLeagueTeams hook and tests

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -23,6 +23,7 @@ import {
   ScheduleLayout,
   useScheduleFilters,
   useTeamScheduleData,
+  useSeasonLeagueTeams,
   Game,
   FilterType,
   ViewMode,
@@ -135,6 +136,15 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     filterDate,
     onError: setError,
   });
+
+  const { leagues: seasonLeagues, leagueTeamsCache: seasonLeagueTeamsCache } = useSeasonLeagueTeams(
+    {
+      accountId,
+      seasonId,
+      accountType,
+      onError: setError,
+    },
+  );
 
   const updateFilterDate = (date: Date) => {
     setFilterDate(date);
@@ -314,9 +324,9 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
         accountId={accountId}
         timeZone={timeZone}
         selectedGame={selectedGame}
-        leagues={[]}
+        leagues={seasonLeagues}
         locations={locations}
-        leagueTeamsCache={new Map()}
+        leagueTeamsCache={seasonLeagueTeamsCache}
         canEditSchedule={false}
         onClose={handleViewDialogClose}
         onSuccess={() => {}}

--- a/draco-nodejs/frontend-next/components/GameCard.tsx
+++ b/draco-nodejs/frontend-next/components/GameCard.tsx
@@ -429,6 +429,7 @@ const GameCard: React.FC<GameCardProps> = ({
 
   return (
     <Card
+      data-testid="game-card"
       variant="outlined"
       sx={{
         mb: layout === 'vertical' ? 2 : 0,

--- a/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
@@ -272,6 +272,7 @@ async function loadTeams({
   accountId,
   seasonId,
   apiClient,
+  signal,
 }: LoadTeamsParams): Promise<LoadTeamsResult> {
   const result = await listSeasonLeagueSeasons({
     client: apiClient,
@@ -280,6 +281,7 @@ async function loadTeams({
       includeTeams: true,
       includeUnassignedTeams: false,
     },
+    signal,
     throwOnError: false,
   });
 

--- a/draco-nodejs/frontend-next/components/schedule/adapters/golfAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/adapters/golfAdapter.ts
@@ -218,6 +218,7 @@ async function loadTeams({
   accountId,
   seasonId,
   apiClient,
+  signal,
 }: LoadTeamsParams): Promise<LoadTeamsResult> {
   const result = await listSeasonLeagueSeasons({
     client: apiClient,
@@ -226,6 +227,7 @@ async function loadTeams({
       includeTeams: true,
       includeUnassignedTeams: true,
     },
+    signal,
     throwOnError: false,
   });
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useSeasonLeagueTeams.test.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useSeasonLeagueTeams.test.ts
@@ -1,0 +1,193 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TeamSeasonType } from '@draco/shared-schemas';
+
+const { loadTeamsMock, getSportAdapterMock, stableApiClient } = vi.hoisted(() => {
+  const loadTeamsMock = vi.fn();
+  const getSportAdapterMock = vi.fn();
+  const stableApiClient = { key: 'test-client' };
+  return { loadTeamsMock, getSportAdapterMock, stableApiClient };
+});
+
+vi.mock('../../../../context/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ loading: false, user: null })),
+}));
+
+vi.mock('../../../../hooks/useApiClient', () => ({
+  useApiClient: vi.fn(() => stableApiClient),
+}));
+
+vi.mock('../../adapters', () => ({
+  getSportAdapter: getSportAdapterMock,
+}));
+
+const makeAdapter = (overrides: Partial<{ loadTeams: typeof loadTeamsMock }> = {}) => ({
+  sportType: 'baseball',
+  locationLabel: 'Field',
+  hasOfficials: true,
+  officialLabel: 'Umpire',
+  loadLocations: vi.fn(async () => []),
+  loadGames: vi.fn(async () => []),
+  createGame: vi.fn(),
+  updateGame: vi.fn(),
+  deleteGame: vi.fn(),
+  GameDialog: () => null,
+  ScoreEntryDialog: () => null,
+  loadTeams: loadTeamsMock,
+  ...overrides,
+});
+
+const buildTeam = (id: string, name: string): TeamSeasonType =>
+  ({
+    id,
+    name,
+  }) as TeamSeasonType;
+
+describe('useSeasonLeagueTeams', () => {
+  beforeEach(() => {
+    loadTeamsMock.mockReset();
+    getSportAdapterMock.mockReset();
+    getSportAdapterMock.mockReturnValue(makeAdapter());
+  });
+
+  it('calls adapter.loadTeams with the provided seasonId (not current season)', async () => {
+    loadTeamsMock.mockResolvedValue({ leagues: [], leagueTeamsCache: new Map() });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    renderHook(() =>
+      useSeasonLeagueTeams({ accountId: '1', seasonId: '65', accountType: 'baseball' }),
+    );
+
+    await waitFor(() => {
+      expect(loadTeamsMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(loadTeamsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: '1',
+        seasonId: '65',
+      }),
+    );
+  });
+
+  it('populates leagues and leagueTeamsCache from the adapter response', async () => {
+    const teamA = buildTeam('t-a', 'Alpha');
+    const teamB = buildTeam('t-b', 'Beta');
+    const cache = new Map<string, TeamSeasonType[]>([['ls-1', [teamA, teamB]]]);
+    loadTeamsMock.mockResolvedValue({
+      leagues: [{ id: 'ls-1', name: 'A League' }],
+      leagueTeamsCache: cache,
+    });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    const { result } = renderHook(() => useSeasonLeagueTeams({ accountId: '1', seasonId: '65' }));
+
+    await waitFor(() => {
+      expect(result.current.leagues).toEqual([{ id: 'ls-1', name: 'A League' }]);
+    });
+
+    expect(result.current.leagueTeamsCache.get('ls-1')).toEqual([teamA, teamB]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('threads an AbortSignal into adapter.loadTeams', async () => {
+    loadTeamsMock.mockResolvedValue({ leagues: [], leagueTeamsCache: new Map() });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    renderHook(() => useSeasonLeagueTeams({ accountId: '1', seasonId: '65' }));
+
+    await waitFor(() => {
+      expect(loadTeamsMock).toHaveBeenCalled();
+    });
+
+    const signal = loadTeamsMock.mock.calls[0][0].signal as AbortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('aborts the in-flight request when the hook unmounts', async () => {
+    loadTeamsMock.mockResolvedValue({ leagues: [], leagueTeamsCache: new Map() });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    const { unmount } = renderHook(() => useSeasonLeagueTeams({ accountId: '1', seasonId: '65' }));
+
+    await waitFor(() => {
+      expect(loadTeamsMock).toHaveBeenCalled();
+    });
+
+    const signal = loadTeamsMock.mock.calls[0][0].signal as AbortSignal;
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('refetches when seasonId changes', async () => {
+    loadTeamsMock.mockResolvedValue({ leagues: [], leagueTeamsCache: new Map() });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    const { rerender } = renderHook(
+      ({ seasonId }: { seasonId: string }) => useSeasonLeagueTeams({ accountId: '1', seasonId }),
+      { initialProps: { seasonId: '65' } },
+    );
+
+    await waitFor(() => {
+      expect(loadTeamsMock).toHaveBeenCalledTimes(1);
+    });
+    expect(loadTeamsMock.mock.calls[0][0].seasonId).toBe('65');
+
+    rerender({ seasonId: '70' });
+
+    await waitFor(() => {
+      expect(loadTeamsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(loadTeamsMock.mock.calls[1][0].seasonId).toBe('70');
+  });
+
+  it('reports errors via onError and leaves the cache empty', async () => {
+    loadTeamsMock.mockRejectedValue(new Error('boom'));
+    const onError = vi.fn();
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    const { result } = renderHook(() =>
+      useSeasonLeagueTeams({ accountId: '1', seasonId: '65', onError }),
+    );
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining('Unable to load team data'));
+    });
+
+    expect(result.current.leagues).toEqual([]);
+    expect(result.current.leagueTeamsCache.size).toBe(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not fetch when the adapter has no loadTeams implementation', async () => {
+    getSportAdapterMock.mockReturnValue({
+      ...makeAdapter(),
+      loadTeams: undefined,
+    });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    const { result } = renderHook(() =>
+      useSeasonLeagueTeams({ accountId: '1', seasonId: '65', accountType: 'unknown' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(loadTeamsMock).not.toHaveBeenCalled();
+    expect(result.current.leagues).toEqual([]);
+    expect(result.current.leagueTeamsCache.size).toBe(0);
+  });
+
+  it('does not fetch when accountId or seasonId is missing', async () => {
+    loadTeamsMock.mockResolvedValue({ leagues: [], leagueTeamsCache: new Map() });
+
+    const { useSeasonLeagueTeams } = await import('../useSeasonLeagueTeams');
+    renderHook(() => useSeasonLeagueTeams({ accountId: '', seasonId: '65' }));
+    renderHook(() => useSeasonLeagueTeams({ accountId: '1', seasonId: '' }));
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(loadTeamsMock).not.toHaveBeenCalled();
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
@@ -18,8 +18,6 @@ interface UseSeasonLeagueTeamsReturn {
   loading: boolean;
 }
 
-const EMPTY_CACHE: Map<string, TeamSeasonType[]> = new Map();
-
 export const useSeasonLeagueTeams = ({
   accountId,
   seasonId,
@@ -34,8 +32,9 @@ export const useSeasonLeagueTeams = ({
   onErrorRef.current = onError;
 
   const [leagues, setLeagues] = useState<League[]>([]);
-  const [leagueTeamsCache, setLeagueTeamsCache] =
-    useState<Map<string, TeamSeasonType[]>>(EMPTY_CACHE);
+  const [leagueTeamsCache, setLeagueTeamsCache] = useState<Map<string, TeamSeasonType[]>>(
+    () => new Map(),
+  );
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -45,7 +44,7 @@ export const useSeasonLeagueTeams = ({
 
     if (!adapter.loadTeams) {
       setLeagues([]);
-      setLeagueTeamsCache(EMPTY_CACHE);
+      setLeagueTeamsCache(new Map());
       setLoading(false);
       return;
     }
@@ -70,7 +69,7 @@ export const useSeasonLeagueTeams = ({
         if (err instanceof DOMException && err.name === 'AbortError') return;
         console.warn('Failed to load season league teams:', err);
         setLeagues([]);
-        setLeagueTeamsCache(EMPTY_CACHE);
+        setLeagueTeamsCache(new Map());
         onErrorRef.current?.('Unable to load team data for this season.');
       } finally {
         if (!controller.signal.aborted) {

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../../../context/AuthContext';
+import { useApiClient } from '../../../hooks/useApiClient';
+import { League } from '@/types/schedule';
+import { TeamSeasonType } from '@draco/shared-schemas';
+import { getSportAdapter } from '../adapters';
+
+interface UseSeasonLeagueTeamsProps {
+  accountId: string;
+  seasonId: string;
+  accountType?: string;
+  onError?: (message: string) => void;
+}
+
+interface UseSeasonLeagueTeamsReturn {
+  leagues: League[];
+  leagueTeamsCache: Map<string, TeamSeasonType[]>;
+  loading: boolean;
+}
+
+const EMPTY_CACHE: Map<string, TeamSeasonType[]> = new Map();
+
+export const useSeasonLeagueTeams = ({
+  accountId,
+  seasonId,
+  accountType,
+  onError,
+}: UseSeasonLeagueTeamsProps): UseSeasonLeagueTeamsReturn => {
+  const { loading: authLoading } = useAuth();
+  const apiClient = useApiClient();
+  const adapter = getSportAdapter(accountType);
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const [leagues, setLeagues] = useState<League[]>([]);
+  const [leagueTeamsCache, setLeagueTeamsCache] =
+    useState<Map<string, TeamSeasonType[]>>(EMPTY_CACHE);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (authLoading || !accountId || !seasonId) {
+      return;
+    }
+
+    if (!adapter.loadTeams) {
+      setLeagues([]);
+      setLeagueTeamsCache(EMPTY_CACHE);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      try {
+        setLoading(true);
+        const { leagues: loadedLeagues, leagueTeamsCache: loadedCache } = await adapter.loadTeams!({
+          accountId,
+          seasonId,
+          apiClient,
+          signal: controller.signal,
+        });
+
+        if (controller.signal.aborted) return;
+        setLeagues(loadedLeagues);
+        setLeagueTeamsCache(loadedCache);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.warn('Failed to load season league teams:', err);
+        setLeagues([]);
+        setLeagueTeamsCache(EMPTY_CACHE);
+        onErrorRef.current?.('Unable to load team data for this season.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [authLoading, accountId, seasonId, apiClient, adapter]);
+
+  return {
+    leagues,
+    leagueTeamsCache,
+    loading,
+  };
+};

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useSeasonLeagueTeams.ts
@@ -39,6 +39,9 @@ export const useSeasonLeagueTeams = ({
 
   useEffect(() => {
     if (authLoading || !accountId || !seasonId) {
+      setLeagues([]);
+      setLeagueTeamsCache(new Map());
+      setLoading(false);
       return;
     }
 

--- a/draco-nodejs/frontend-next/components/schedule/index.ts
+++ b/draco-nodejs/frontend-next/components/schedule/index.ts
@@ -1,6 +1,7 @@
 // Hooks
 export { useScheduleData } from './hooks/useScheduleData';
 export { useTeamScheduleData } from './hooks/useTeamScheduleData';
+export { useSeasonLeagueTeams } from './hooks/useSeasonLeagueTeams';
 export { useScheduleFilters } from './hooks/useScheduleFilters';
 export { useGameManagement } from './hooks/useGameManagement';
 

--- a/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
@@ -69,6 +69,7 @@ export interface LoadTeamsParams {
   accountId: string;
   seasonId: string;
   apiClient: Client;
+  signal?: AbortSignal;
 }
 
 export interface LoadTeamsResult {

--- a/draco-nodejs/frontend-next/e2e/pages/team-schedule.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/team-schedule.page.ts
@@ -1,0 +1,47 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class TeamSchedulePage {
+  readonly page: Page;
+  readonly mainContent: Locator;
+  readonly scheduleBreadcrumb: Locator;
+  readonly monthButton: Locator;
+  readonly weekButton: Locator;
+  readonly prevButton: Locator;
+  readonly nextButton: Locator;
+  readonly gameCards: Locator;
+  readonly gameDialog: Locator;
+  readonly gameDialogTitle: Locator;
+  readonly unassignedTeamsWarning: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mainContent = page.getByRole('main');
+    this.scheduleBreadcrumb = page.getByRole('navigation', { name: /breadcrumb/i });
+    this.monthButton = page.getByRole('button', { name: /^month$/i });
+    this.weekButton = page.getByRole('button', { name: /^week$/i });
+    this.prevButton = page.getByRole('button', { name: /previous period/i });
+    this.nextButton = page.getByRole('button', { name: /next period/i });
+    this.gameCards = page.getByTestId('game-card');
+    this.gameDialog = page.getByRole('dialog');
+    this.gameDialogTitle = this.gameDialog.getByRole('heading', { name: /game details/i });
+    this.unassignedTeamsWarning = this.gameDialog.getByText(
+      /teams that are no longer assigned to a division/i,
+    );
+  }
+
+  async goto(accountId: string, seasonId: string, teamSeasonId: string) {
+    await this.page.goto(
+      `/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`,
+    );
+    await this.mainContent.waitFor({ timeout: 15_000 });
+    await this.scheduleBreadcrumb.waitFor({ timeout: 15_000 });
+  }
+
+  homeTeamField(): Locator {
+    return this.gameDialog.getByLabel(/home team/i);
+  }
+
+  visitorTeamField(): Locator {
+    return this.gameDialog.getByLabel(/visitor team/i);
+  }
+}

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -24,14 +24,20 @@ test.describe('Team Schedule - Game Details Dialog', () => {
   test('clicking a game opens the Game Details dialog with real team names', async ({ page }) => {
     test.setTimeout(45_000);
 
-    await teamSchedulePage.monthButton.click().catch(() => {});
+    const monthButtonCount = await teamSchedulePage.monthButton.count();
+    if (monthButtonCount > 0) {
+      await expect(teamSchedulePage.monthButton).toBeVisible();
+      await expect(teamSchedulePage.monthButton).toBeEnabled();
+      await teamSchedulePage.monthButton.click();
+    }
 
     const firstCard = teamSchedulePage.gameCards.first();
     const noGamesText = page.getByText(/no games found/i).first();
-    await Promise.race([
-      firstCard.waitFor({ state: 'visible', timeout: 15_000 }),
-      noGamesText.waitFor({ state: 'visible', timeout: 15_000 }),
-    ]).catch(() => {});
+    await expect(async () => {
+      const hasVisibleCard = await firstCard.isVisible().catch(() => false);
+      const hasVisibleEmptyState = await noGamesText.isVisible().catch(() => false);
+      expect(hasVisibleCard || hasVisibleEmptyState).toBe(true);
+    }).toPass({ timeout: 15_000 });
 
     const cardCount = await teamSchedulePage.gameCards.count();
     test.skip(cardCount === 0, 'No games visible for this team/season');

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../../fixtures/base-fixtures';
+import { TeamSchedulePage } from '../../pages/team-schedule.page';
+
+test.describe('Team Schedule - Game Details Dialog', () => {
+  test.beforeEach(({ seasonId, teamSeasonId }, testInfo) => {
+    if (!seasonId || !teamSeasonId) {
+      testInfo.skip(true, 'E2E_SEASON_ID or E2E_TEAM_SEASON_ID not set');
+    }
+  });
+
+  let teamSchedulePage: TeamSchedulePage;
+
+  test.beforeEach(async ({ page, accountId, seasonId, teamSeasonId }) => {
+    if (!seasonId || !teamSeasonId) return;
+    teamSchedulePage = new TeamSchedulePage(page);
+    await teamSchedulePage.goto(accountId, seasonId, teamSeasonId);
+  });
+
+  test('schedule page loads', async () => {
+    await expect(teamSchedulePage.mainContent).toBeVisible();
+    await expect(teamSchedulePage.scheduleBreadcrumb).toBeVisible();
+  });
+
+  test('clicking a game opens the Game Details dialog with real team names', async ({ page }) => {
+    test.setTimeout(45_000);
+
+    await teamSchedulePage.monthButton.click().catch(() => {});
+
+    const firstCard = teamSchedulePage.gameCards.first();
+    const noGamesText = page.getByText(/no games found/i).first();
+    await Promise.race([
+      firstCard.waitFor({ state: 'visible', timeout: 15_000 }),
+      noGamesText.waitFor({ state: 'visible', timeout: 15_000 }),
+    ]).catch(() => {});
+
+    const cardCount = await teamSchedulePage.gameCards.count();
+    test.skip(cardCount === 0, 'No games visible for this team/season');
+
+    await firstCard.scrollIntoViewIfNeeded();
+    await firstCard.click();
+
+    await expect(teamSchedulePage.gameDialog).toBeVisible({ timeout: 10_000 });
+    await expect(teamSchedulePage.gameDialogTitle).toBeVisible();
+
+    const homeTeam = teamSchedulePage.homeTeamField();
+    const visitorTeam = teamSchedulePage.visitorTeamField();
+
+    await expect(homeTeam).toBeVisible();
+    await expect(visitorTeam).toBeVisible();
+
+    const homeValue = await homeTeam.inputValue();
+    const visitorValue = await visitorTeam.inputValue();
+
+    expect(homeValue.trim()).not.toBe('');
+    expect(visitorValue.trim()).not.toBe('');
+    expect(homeValue).not.toBe('Unknown Team');
+    expect(visitorValue).not.toBe('Unknown Team');
+
+    await expect(teamSchedulePage.unassignedTeamsWarning).toHaveCount(0);
+
+    await page.keyboard.press('Escape');
+  });
+});


### PR DESCRIPTION
Introduce useSeasonLeagueTeams hook to load season leagues and team caches (with AbortSignal support) and export it from the schedule index. Update sport adapter types to accept an optional signal and thread that signal through baseball and golf adapters' loadTeams calls. Integrate the hook into TeamSchedulePage so schedules receive real leagues and leagueTeamsCache. Add data-testid to GameCard for e2e selection and add a Playwright page object plus an E2E test that verifies the Game Details dialog shows real team names. Include unit tests covering loading, aborting, error handling, and refetch behavior.