### PR TITLE
Add season scheduleVisible and visibility API

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -2114,12 +2114,27 @@
           },
           "isCurrent": {
             "type": "boolean"
+          },
+          "scheduleVisible": {
+            "type": "boolean"
           }
         },
         "required": [
           "id",
           "name",
-          "accountId"
+          "accountId",
+          "scheduleVisible"
+        ]
+      },
+      "UpdateScheduleVisibility": {
+        "type": "object",
+        "properties": {
+          "scheduleVisible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "scheduleVisible"
         ]
       },
       "CurrentSeasonResponse": {
@@ -2144,12 +2159,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           {
@@ -2171,6 +2190,9 @@
                 "example": "12345"
               },
               "isCurrent": {
+                "type": "boolean"
+              },
+              "scheduleVisible": {
                 "type": "boolean"
               },
               "leagues": {
@@ -2254,6 +2276,7 @@
               "id",
               "name",
               "accountId",
+              "scheduleVisible",
               "leagues"
             ]
           }
@@ -2278,6 +2301,9 @@
             "example": "12345"
           },
           "isCurrent": {
+            "type": "boolean"
+          },
+          "scheduleVisible": {
             "type": "boolean"
           },
           "leagues": {
@@ -2361,6 +2387,7 @@
           "id",
           "name",
           "accountId",
+          "scheduleVisible",
           "leagues"
         ]
       },
@@ -2970,12 +2997,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           "league": {
@@ -3061,12 +3092,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           "team": {
@@ -3127,12 +3162,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           "team": {
@@ -9613,12 +9652,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           "league": {
@@ -14800,12 +14843,16 @@
                     },
                     "isCurrent": {
                       "type": "boolean"
+                    },
+                    "scheduleVisible": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
                     "id",
                     "name",
-                    "accountId"
+                    "accountId",
+                    "scheduleVisible"
                   ]
                 },
                 "league": {
@@ -14974,6 +15021,9 @@
           "isCurrent": {
             "type": "boolean"
           },
+          "scheduleVisible": {
+            "type": "boolean"
+          },
           "leagues": {
             "type": "array",
             "items": {
@@ -15055,6 +15105,7 @@
           "id",
           "name",
           "accountId",
+          "scheduleVisible",
           "leagues"
         ]
       },
@@ -15223,12 +15274,16 @@
                           },
                           "isCurrent": {
                             "type": "boolean"
+                          },
+                          "scheduleVisible": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
                           "id",
                           "name",
-                          "accountId"
+                          "accountId",
+                          "scheduleVisible"
                         ]
                       },
                       "league": {
@@ -15373,12 +15428,16 @@
                     },
                     "isCurrent": {
                       "type": "boolean"
+                    },
+                    "scheduleVisible": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
                     "id",
                     "name",
-                    "accountId"
+                    "accountId",
+                    "scheduleVisible"
                   ]
                 },
                 "league": {
@@ -15479,12 +15538,16 @@
               },
               "isCurrent": {
                 "type": "boolean"
+              },
+              "scheduleVisible": {
+                "type": "boolean"
               }
             },
             "required": [
               "id",
               "name",
-              "accountId"
+              "accountId",
+              "scheduleVisible"
             ]
           },
           "leagueSeasons": {
@@ -15654,12 +15717,16 @@
                                 },
                                 "isCurrent": {
                                   "type": "boolean"
+                                },
+                                "scheduleVisible": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
                                 "id",
                                 "name",
-                                "accountId"
+                                "accountId",
+                                "scheduleVisible"
                               ]
                             },
                             "league": {
@@ -15804,12 +15871,16 @@
                           },
                           "isCurrent": {
                             "type": "boolean"
+                          },
+                          "scheduleVisible": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
                           "id",
                           "name",
-                          "accountId"
+                          "accountId",
+                          "scheduleVisible"
                         ]
                       },
                       "league": {
@@ -67989,6 +68060,102 @@
           },
           "500": {
             "description": "Unexpected error while retrieving the participant count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/schedule-visibility": {
+      "patch": {
+        "operationId": "updateSeasonScheduleVisibility",
+        "summary": "Update season schedule visibility",
+        "description": "Set whether the public schedule for the season is visible to unauthenticated users.",
+        "tags": [
+          "Seasons"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleVisibility"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Schedule visibility updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateScheduleVisibility"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Season not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
             "content": {
               "application/json": {
                 "schema": {

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -1583,10 +1583,20 @@ components:
           example: "12345"
         isCurrent:
           type: boolean
+        scheduleVisible:
+          type: boolean
       required:
         - id
         - name
         - accountId
+        - scheduleVisible
+    UpdateScheduleVisibility:
+      type: object
+      properties:
+        scheduleVisible:
+          type: boolean
+      required:
+        - scheduleVisible
     CurrentSeasonResponse:
       anyOf:
         - type: object
@@ -1605,10 +1615,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         - type: object
           properties:
             id:
@@ -1624,6 +1637,8 @@ components:
               pattern: ^\d+$
               example: "12345"
             isCurrent:
+              type: boolean
+            scheduleVisible:
               type: boolean
             leagues:
               type: array
@@ -1684,6 +1699,7 @@ components:
             - id
             - name
             - accountId
+            - scheduleVisible
             - leagues
     SeasonCopyResponse:
       type: object
@@ -1701,6 +1717,8 @@ components:
           pattern: ^\d+$
           example: "12345"
         isCurrent:
+          type: boolean
+        scheduleVisible:
           type: boolean
         leagues:
           type: array
@@ -1761,6 +1779,7 @@ components:
         - id
         - name
         - accountId
+        - scheduleVisible
         - leagues
     SeasonParticipantCountData:
       type: object
@@ -2218,10 +2237,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         league:
           type: object
           properties:
@@ -2284,10 +2306,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         team:
           type: object
           properties:
@@ -2332,10 +2357,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         team:
           type: object
           properties:
@@ -7067,10 +7095,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         league:
           type: object
           properties:
@@ -11042,10 +11073,13 @@ components:
                     example: "12345"
                   isCurrent:
                     type: boolean
+                  scheduleVisible:
+                    type: boolean
                 required:
                   - id
                   - name
                   - accountId
+                  - scheduleVisible
               league:
                 type: object
                 properties:
@@ -11166,6 +11200,8 @@ components:
           example: "12345"
         isCurrent:
           type: boolean
+        scheduleVisible:
+          type: boolean
         leagues:
           type: array
           items:
@@ -11225,6 +11261,7 @@ components:
         - id
         - name
         - accountId
+        - scheduleVisible
         - leagues
     LeagueSeasonWithDivisionTeamsAndUnassigned:
       type: object
@@ -11354,10 +11391,13 @@ components:
                           example: "12345"
                         isCurrent:
                           type: boolean
+                        scheduleVisible:
+                          type: boolean
                       required:
                         - id
                         - name
                         - accountId
+                        - scheduleVisible
                     league:
                       type: object
                       properties:
@@ -11463,10 +11503,13 @@ components:
                     example: "12345"
                   isCurrent:
                     type: boolean
+                  scheduleVisible:
+                    type: boolean
                 required:
                   - id
                   - name
                   - accountId
+                  - scheduleVisible
               league:
                 type: object
                 properties:
@@ -11539,10 +11582,13 @@ components:
               example: "12345"
             isCurrent:
               type: boolean
+            scheduleVisible:
+              type: boolean
           required:
             - id
             - name
             - accountId
+            - scheduleVisible
         leagueSeasons:
           type: array
           items:
@@ -11673,10 +11719,13 @@ components:
                                 example: "12345"
                               isCurrent:
                                 type: boolean
+                              scheduleVisible:
+                                type: boolean
                             required:
                               - id
                               - name
                               - accountId
+                              - scheduleVisible
                           league:
                             type: object
                             properties:
@@ -11782,10 +11831,13 @@ components:
                           example: "12345"
                         isCurrent:
                           type: boolean
+                        scheduleVisible:
+                          type: boolean
                       required:
                         - id
                         - name
                         - accountId
+                        - scheduleVisible
                     league:
                       type: object
                       properties:
@@ -46127,6 +46179,65 @@ paths:
                 $ref: "#/components/schemas/NotFoundError"
         "500":
           description: Unexpected error while retrieving the participant count.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/schedule-visibility:
+    patch:
+      operationId: updateSeasonScheduleVisibility
+      summary: Update season schedule visibility
+      description: Set whether the public schedule for the season is visible to
+        unauthenticated users.
+      tags:
+        - Seasons
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateScheduleVisibility"
+      responses:
+        "200":
+          description: Schedule visibility updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateScheduleVisibility"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Insufficient permissions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Season not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Unexpected error.
           content:
             application/json:
               schema:

--- a/draco-nodejs/backend/prisma/migrations/20260428000000_add_season_schedule_visible/migration.sql
+++ b/draco-nodejs/backend/prisma/migrations/20260428000000_add_season_schedule_visible/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE season ADD COLUMN schedulevisible BOOLEAN NOT NULL DEFAULT true;

--- a/draco-nodejs/backend/prisma/schema.prisma
+++ b/draco-nodejs/backend/prisma/schema.prisma
@@ -1662,6 +1662,7 @@ model season {
   id                          BigInt                        @id @default(autoincrement())
   accountid                   BigInt
   name                        String                        @db.VarChar(25)
+  schedulevisible             Boolean                       @default(true)
   leagueseason                leagueseason[]
   playerseasonaffiliationdues playerseasonaffiliationdues[]
   socialfeeditems             socialfeeditems[]

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -142,6 +142,7 @@ import {
   CurrentSeasonResponseSchema,
   SeasonCopyResponseSchema,
   SeasonSchema,
+  UpdateScheduleVisibilitySchema,
   TeamManagerSchema,
   TeamRosterMembersSchema,
   TeamSeasonSchema,
@@ -454,6 +455,10 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     SeasonManagerWithLeagueSchema,
   );
   const SeasonSchemaRef = registry.register('Season', SeasonSchema);
+  const UpdateScheduleVisibilitySchemaRef = registry.register(
+    'UpdateScheduleVisibility',
+    UpdateScheduleVisibilitySchema,
+  );
   const CurrentSeasonResponseSchemaRef = registry.register(
     'CurrentSeasonResponse',
     CurrentSeasonResponseSchema,
@@ -1607,6 +1612,7 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     SeasonManagerListSchemaRef,
     SeasonManagerWithLeagueSchemaRef,
     SeasonSchemaRef,
+    UpdateScheduleVisibilitySchemaRef,
     CurrentSeasonResponseSchemaRef,
     SeasonCopyResponseSchemaRef,
     SeasonParticipantCountDataSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/seasons/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/seasons/index.ts
@@ -12,6 +12,7 @@ export const registerSeasonEndpoints = ({ registry, schemaRefs, z }: RegisterCon
     SeasonParticipantCountDataSchemaRef,
     CurrentSeasonResponseSchemaRef,
     SeasonSchemaRef,
+    UpdateScheduleVisibilitySchemaRef,
     UpsertSeasonSchemaRef,
     ValidationErrorSchemaRef,
   } = schemaRefs;
@@ -717,6 +718,91 @@ export const registerSeasonEndpoints = ({ registry, schemaRefs, z }: RegisterCon
       },
       500: {
         description: 'Unexpected error while retrieving the participant count.',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
+  /**
+   * PATCH /api/accounts/:accountId/seasons/:seasonId/schedule-visibility
+   * Toggle whether the public schedule for the season is visible.
+   */
+  registry.registerPath({
+    method: 'patch',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/schedule-visibility',
+    operationId: 'updateSeasonScheduleVisibility',
+    summary: 'Update season schedule visibility',
+    description:
+      'Set whether the public schedule for the season is visible to unauthenticated users.',
+    tags: ['Seasons'],
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+    ],
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: UpdateScheduleVisibilitySchemaRef,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Schedule visibility updated successfully.',
+        content: {
+          'application/json': {
+            schema: UpdateScheduleVisibilitySchemaRef,
+          },
+        },
+      },
+      401: {
+        description: 'Authentication required.',
+        content: {
+          'application/json': {
+            schema: AuthenticationErrorSchemaRef,
+          },
+        },
+      },
+      403: {
+        description: 'Insufficient permissions.',
+        content: {
+          'application/json': {
+            schema: AuthorizationErrorSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Season not found.',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
+          },
+        },
+      },
+      500: {
+        description: 'Unexpected error.',
         content: {
           'application/json': {
             schema: InternalServerErrorSchemaRef,

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaLeagueRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaLeagueRepository.ts
@@ -31,6 +31,7 @@ const SEASON_SELECT = {
   id: true,
   name: true,
   accountid: true,
+  schedulevisible: true,
 } as const;
 
 const DIVISION_DEF_SELECT = {

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSeasonsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSeasonsRepository.ts
@@ -21,6 +21,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
         leagueseason: {
           select: {
             id: true,
@@ -69,6 +70,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
         leagueseason: {
           select: {
             id: true,
@@ -116,6 +118,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
       },
     });
   }
@@ -135,6 +138,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
       },
     });
   }
@@ -146,6 +150,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
       },
     });
   }
@@ -158,6 +163,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
       },
     });
   }
@@ -169,6 +175,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         id: true,
         name: true,
         accountid: true,
+        schedulevisible: true,
       },
     });
   }
@@ -182,6 +189,12 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
     }
     return await this.prisma.season.findUnique({
       where: { id: currentSeason.seasonid },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+        schedulevisible: true,
+      },
     });
   }
 
@@ -452,6 +465,7 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
           id: true,
           name: true,
           accountid: true,
+          schedulevisible: true,
           leagueseason: {
             select: {
               id: true,
@@ -504,6 +518,31 @@ export class PrismaSeasonsRepository implements ISeasonsRepository {
         creatoraccountid: accountId,
       },
     });
+  }
+
+  async updateScheduleVisibility(
+    accountId: bigint,
+    seasonId: bigint,
+    scheduleVisible: boolean,
+  ): Promise<dbSeason> {
+    const { count } = await this.prisma.season.updateMany({
+      where: { id: seasonId, accountid: accountId },
+      data: { schedulevisible: scheduleVisible },
+    });
+
+    if (count === 0) {
+      throw new Error(`Season ${seasonId} not found for account ${accountId}`);
+    }
+
+    return this.prisma.season.findFirst({
+      where: { id: seasonId, accountid: accountId },
+      select: {
+        id: true,
+        name: true,
+        accountid: true,
+        schedulevisible: true,
+      },
+    }) as Promise<dbSeason>;
   }
 
   async findSeasonParticipants(accountId: bigint, seasonId: bigint): Promise<dbContactEmailOnly[]> {

--- a/draco-nodejs/backend/src/repositories/interfaces/ISeasonsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/ISeasonsRepository.ts
@@ -33,4 +33,9 @@ export interface ISeasonsRepository {
     sourceSeason: dbSeasonCopySource,
     newSeasonName: string,
   ): Promise<dbSeasonWithLeagues>;
+  updateScheduleVisibility(
+    accountId: bigint,
+    seasonId: bigint,
+    scheduleVisible: boolean,
+  ): Promise<dbSeason>;
 }

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -612,6 +612,7 @@ export type dbSeason = Prisma.seasonGetPayload<{
     id: true;
     name: true;
     accountid: true;
+    schedulevisible: true;
   };
 }>;
 
@@ -619,6 +620,7 @@ export interface dbSeasonWithLeagues {
   id: bigint;
   name: string;
   accountid: bigint;
+  schedulevisible: boolean;
   leagueseason: Array<{
     id: bigint;
     leagueid: bigint;
@@ -966,6 +968,7 @@ export type dbLeagueSeasonWithTeams = Prisma.leagueseasonGetPayload<{
         id: true;
         name: true;
         accountid: true;
+        schedulevisible: true;
       };
     };
     divisionseason: {

--- a/draco-nodejs/backend/src/responseFormatters/LeagueResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/LeagueResponseFormatter.ts
@@ -66,6 +66,7 @@ export class LeagueResponseFormatter {
           id: firstSeason.id.toString(),
           name: firstSeason.name,
           accountId: firstSeason.accountid.toString(),
+          scheduleVisible: firstSeason.schedulevisible,
         }
       : undefined;
 

--- a/draco-nodejs/backend/src/responseFormatters/seasonResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/seasonResponseFormatter.ts
@@ -2,6 +2,7 @@ import {
   LeagueSeasonWithDivisionType,
   SeasonParticipantCountDataType,
   SeasonType,
+  UpdateScheduleVisibilityType,
 } from '@draco/shared-schemas';
 import { dbLeagueSeasonBasic, dbSeason, dbSeasonWithLeagues } from '../repositories/index.js';
 
@@ -30,6 +31,7 @@ export class SeasonResponseFormatter {
       name: season.name,
       accountId: season.accountid.toString(),
       isCurrent,
+      scheduleVisible: season.schedulevisible,
       leagues: season.leagueseason.map((leagueSeason) => {
         const baseLeague = {
           id: leagueSeason.id.toString(),
@@ -63,6 +65,7 @@ export class SeasonResponseFormatter {
       id: season.id.toString(),
       name: season.name,
       accountId: season.accountid.toString(),
+      scheduleVisible: season.schedulevisible,
     };
 
     if (typeof options?.isCurrent === 'boolean') {
@@ -70,6 +73,10 @@ export class SeasonResponseFormatter {
     }
 
     return result;
+  }
+
+  static formatScheduleVisibility(season: dbSeason): UpdateScheduleVisibilityType {
+    return { scheduleVisible: season.schedulevisible };
   }
 
   static formatSeasonWithLeagueBasics(

--- a/draco-nodejs/backend/src/responseFormatters/teamResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/teamResponseFormatter.ts
@@ -123,6 +123,7 @@ export class TeamResponseFormatter {
         id: teamSeason.leagueseason?.season?.id?.toString() || 'unknown',
         name: teamSeason.leagueseason?.season?.name || 'Unknown Season',
         accountId: accountId.toString(),
+        scheduleVisible: teamSeason.leagueseason?.season?.schedulevisible ?? true,
       },
       record: {
         w: record.wins,

--- a/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
@@ -1,0 +1,325 @@
+import express, {
+  type Express,
+  type Request,
+  type Response,
+  type NextFunction,
+  type Router,
+} from 'express';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { ServiceFactory } from '../../services/serviceFactory.js';
+import { ValidationError, AuthorizationError } from '../../utils/customErrors.js';
+
+vi.mock('../../middleware/authMiddleware.js', () => ({
+  authenticateToken: (req: Request, _res: Response, next: NextFunction) => {
+    if (!req.headers.authorization) {
+      next(new AuthorizationError('Access denied'));
+      return;
+    }
+    req.user = { id: (req.headers['x-user-id'] as string) ?? 'user-1', username: 'tester' };
+    next();
+  },
+  optionalAuth: (req: Request, _res: Response, next: NextFunction) => {
+    if (req.headers.authorization) {
+      req.user = { id: (req.headers['x-user-id'] as string) ?? 'user-1', username: 'tester' };
+    }
+    next();
+  },
+}));
+
+const createRouteProtectionMock = () => {
+  const passThrough = () => (_req: Request, _res: Response, next: NextFunction) => next();
+  return {
+    enforceAccountBoundary: passThrough,
+    enforceTeamBoundary: passThrough,
+    requirePermission: () => passThrough(),
+    enforceLeagueBoundary: passThrough,
+    enforceAccountOwner: passThrough,
+  };
+};
+
+const scheduleServiceMock = {
+  listSeasonGames: vi.fn(),
+  updateGameResults: vi.fn(),
+  createGame: vi.fn(),
+  updateGame: vi.fn(),
+  deleteGame: vi.fn(),
+  getGameRecap: vi.fn(),
+  upsertGameRecap: vi.fn(),
+};
+
+const roleServiceMock = {
+  hasPermission: vi.fn(),
+};
+
+const seasonServiceMock = {
+  isScheduleHiddenForCurrentSeason: vi.fn(),
+};
+
+const ACCOUNT_ID = '10';
+const SEASON_ID = '25';
+
+const defaultGamesResponse = {
+  games: [{ id: '1', homeTeam: 'A', awayTeam: 'B' }],
+  pagination: { total: 1, page: 1, limit: 20 },
+};
+
+let app: Express;
+let router: Router;
+
+describe('GET / (season games) - visibility guard', () => {
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'test-secret'; // pragma: allowlist secret
+
+    vi.spyOn(ServiceFactory, 'getRouteProtection').mockReturnValue(
+      createRouteProtectionMock() as never,
+    );
+    vi.spyOn(ServiceFactory, 'getScheduleService').mockReturnValue(scheduleServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getRoleService').mockReturnValue(roleServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getSeasonService').mockReturnValue(seasonServiceMock as never);
+
+    const routerModule = await import('../games.js');
+    router = routerModule.default;
+
+    app = express();
+    app.use(express.json());
+    app.use(`/api/accounts/:accountId/seasons/:seasonId/games`, router);
+
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      if (err instanceof AuthorizationError) {
+        res.status(403).json({ message: err.message });
+        return;
+      }
+      if (err instanceof ValidationError) {
+        res.status(400).json({ message: err.message });
+        return;
+      }
+      res.status(500).json({ message: err.message });
+    });
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
+    roleServiceMock.hasPermission.mockResolvedValue(false);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  type RouteLayer = {
+    route?: {
+      path: string;
+      methods: Record<string, boolean>;
+      stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => unknown }>;
+    };
+  };
+
+  const runGamesRoute = async (
+    options: {
+      userId?: string;
+      hasManagePermission?: boolean;
+      isHiddenCurrentSeason?: boolean;
+      withAuth?: boolean;
+    } = {},
+  ) => {
+    const {
+      userId = 'user-1',
+      hasManagePermission = false,
+      isHiddenCurrentSeason = false,
+      withAuth = true,
+    } = options;
+
+    roleServiceMock.hasPermission.mockResolvedValue(hasManagePermission);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(isHiddenCurrentSeason);
+
+    const layer = (router.stack as RouteLayer[]).find(
+      (stackLayer) =>
+        stackLayer.route && stackLayer.route.path === '/' && stackLayer.route.methods['get'],
+    );
+
+    if (!layer?.route) {
+      throw new Error('Route GET / not found');
+    }
+
+    const handlers = layer.route.stack.map((s) => s.handle);
+
+    const headers: Record<string, string> = withAuth
+      ? { authorization: 'Bearer token', 'x-user-id': userId }
+      : {};
+
+    const reqPartial: Partial<Request> = {
+      method: 'GET',
+      params: {
+        accountId: ACCOUNT_ID,
+        seasonId: SEASON_ID,
+      },
+      query: {},
+      headers,
+      get: ((headerName: string) => headers[headerName.toLowerCase()]) as Request['get'],
+    };
+    const req = reqPartial as Request;
+
+    if (withAuth) {
+      req.user = { id: userId, username: 'tester' };
+    }
+
+    interface MockResponseExtras {
+      body?: unknown;
+    }
+    type MockResponse = Response & MockResponseExtras;
+
+    const resPartial: Partial<Response> & MockResponseExtras = {
+      statusCode: 200,
+      body: undefined,
+      status(code: number) {
+        resPartial.statusCode = code;
+        return res;
+      },
+      json(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+      send(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+    };
+    const res = resPartial as MockResponse;
+
+    let lastError: unknown = null;
+
+    for (const handler of handlers) {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+
+        const settle = (err?: unknown) => {
+          if (settled) return;
+          settled = true;
+          if (err) lastError = err;
+          resolve();
+        };
+
+        const next: NextFunction = (err?: unknown) => settle(err);
+
+        const originalJson = res.json.bind(res);
+        res.json = ((payload: unknown) => {
+          const r = originalJson(payload);
+          settle();
+          return r;
+        }) as Response['json'];
+
+        try {
+          const ret = handler(req, res, next);
+          if (ret && typeof (ret as Promise<unknown>).then === 'function') {
+            (ret as Promise<unknown>).catch((err) => settle(err));
+          }
+        } catch (err) {
+          settle(err);
+        }
+      });
+
+      if (lastError) break;
+    }
+
+    return { req, res, error: lastError };
+  };
+
+  it('returns games when season is visible (current) and caller is unauthenticated', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: false,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('returns empty games when current season is hidden and caller is unauthenticated', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: false,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(res.body).toEqual({
+      games: [],
+      pagination: { total: 0, page: 1, limit: 50 },
+    });
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+  });
+
+  it('returns empty games when current season is hidden and authenticated non-admin calls without permission', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: true,
+      hasManagePermission: false,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(res.body).toEqual({
+      games: [],
+      pagination: { total: 0, page: 1, limit: 50 },
+    });
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+  });
+
+  it('returns games when season is hidden but season is NOT current (historical access)', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: false,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('returns games when current season is hidden but AccountAdmin has account.games.manage', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: true,
+      hasManagePermission: true,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    expect(roleServiceMock.hasPermission).toHaveBeenCalledWith('user-1', 'account.games.manage', {
+      accountId: BigInt(ACCOUNT_ID),
+    });
+  });
+
+  it('skips isScheduleHiddenForCurrentSeason entirely when caller has account.games.manage', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: true,
+      hasManagePermission: true,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
+    expect(res.body).toEqual(defaultGamesResponse);
+  });
+
+  it('returns games when season is visible and authenticated admin calls', async () => {
+    const { res } = await runGamesRoute({
+      withAuth: true,
+      hasManagePermission: true,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('checks permission using the authenticated userId from req.user', async () => {
+    const customUserId = 'admin-user-42';
+    roleServiceMock.hasPermission.mockResolvedValue(true);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(true);
+
+    await runGamesRoute({ withAuth: true, userId: customUserId, hasManagePermission: true });
+
+    expect(roleServiceMock.hasPermission).toHaveBeenCalledWith(
+      customUserId,
+      'account.games.manage',
+      { accountId: BigInt(ACCOUNT_ID) },
+    );
+  });
+});

--- a/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
@@ -7,7 +7,7 @@ import express, {
 } from 'express';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { ServiceFactory } from '../../services/serviceFactory.js';
-import { ValidationError, AuthorizationError } from '../../utils/customErrors.js';
+import { ValidationError, AuthorizationError, NotFoundError } from '../../utils/customErrors.js';
 
 vi.mock('../../middleware/authMiddleware.js', () => ({
   authenticateToken: (req: Request, _res: Response, next: NextFunction) => {
@@ -52,7 +52,15 @@ const roleServiceMock = {
 };
 
 const seasonServiceMock = {
+  findSeasonById: vi.fn(),
   isScheduleHiddenForCurrentSeason: vi.fn(),
+};
+
+const defaultSeason = {
+  id: '25',
+  name: 'Test Season',
+  accountId: '10',
+  scheduleVisible: true,
 };
 
 const ACCOUNT_ID = '10';
@@ -89,6 +97,10 @@ describe('GET / (season games) - visibility guard', () => {
         res.status(403).json({ message: err.message });
         return;
       }
+      if (err instanceof NotFoundError) {
+        res.status(404).json({ message: err.message });
+        return;
+      }
       if (err instanceof ValidationError) {
         res.status(400).json({ message: err.message });
         return;
@@ -101,6 +113,7 @@ describe('GET / (season games) - visibility guard', () => {
     vi.resetAllMocks();
     scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
     roleServiceMock.hasPermission.mockResolvedValue(false);
+    seasonServiceMock.findSeasonById.mockResolvedValue(defaultSeason);
     seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
   });
 
@@ -307,6 +320,32 @@ describe('GET / (season games) - visibility guard', () => {
 
     expect(res.body).toEqual(defaultGamesResponse);
     expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('returns 404 (no games) when seasonId does not belong to accountId, regardless of permission', async () => {
+    seasonServiceMock.findSeasonById.mockResolvedValue(null);
+
+    const { res, error } = await runGamesRoute({
+      withAuth: true,
+      hasManagePermission: true,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+    expect(res.body).toBeUndefined();
+  });
+
+  it('returns 404 for unauthenticated callers when seasonId belongs to another account', async () => {
+    seasonServiceMock.findSeasonById.mockResolvedValue(null);
+
+    const { error } = await runGamesRoute({
+      withAuth: false,
+    });
+
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
   });
 
   it('checks permission using the authenticated userId from req.user', async () => {

--- a/draco-nodejs/backend/src/routes/__tests__/team-stats-schedule.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/team-stats-schedule.test.ts
@@ -1,0 +1,398 @@
+import express, {
+  type Express,
+  type Request,
+  type Response,
+  type NextFunction,
+  type Router,
+} from 'express';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { ServiceFactory } from '../../services/serviceFactory.js';
+import { ValidationError, AuthorizationError } from '../../utils/customErrors.js';
+
+vi.mock('../../middleware/authMiddleware.js', () => ({
+  authenticateToken: (req: Request, _res: Response, next: NextFunction) => {
+    if (!req.headers.authorization) {
+      next(new AuthorizationError('Access denied'));
+      return;
+    }
+    req.user = { id: (req.headers['x-user-id'] as string) ?? 'user-1', username: 'tester' };
+    next();
+  },
+  optionalAuth: (req: Request, _res: Response, next: NextFunction) => {
+    if (req.headers.authorization) {
+      req.user = { id: (req.headers['x-user-id'] as string) ?? 'user-1', username: 'tester' };
+    }
+    next();
+  },
+}));
+
+const teamServiceMock = {
+  validateTeamSeasonBasic: vi.fn(),
+  getTeamSeasonDetails: vi.fn(),
+};
+
+const scheduleServiceMock = {
+  listSeasonGames: vi.fn(),
+};
+
+const roleServiceMock = {
+  hasPermission: vi.fn(),
+};
+
+const seasonServiceMock = {
+  isScheduleHiddenForCurrentSeason: vi.fn(),
+};
+
+const teamStatsServiceMock = {
+  getTeamGames: vi.fn(),
+  getTeamBattingStats: vi.fn(),
+  getTeamPitchingStats: vi.fn(),
+};
+
+const ACCOUNT_ID = '10';
+const SEASON_ID = '25';
+const TEAM_SEASON_ID = '50';
+
+const defaultGamesResponse = {
+  games: [{ id: '1', homeTeam: 'A', awayTeam: 'B' }],
+  pagination: { total: 1, page: 1, limit: 20 },
+};
+
+let app: Express;
+let router: Router;
+
+describe('GET /:teamSeasonId/schedule - visibility guard', () => {
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'test-secret'; // pragma: allowlist secret
+
+    vi.spyOn(ServiceFactory, 'getTeamService').mockReturnValue(teamServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getScheduleService').mockReturnValue(scheduleServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getRoleService').mockReturnValue(roleServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getSeasonService').mockReturnValue(seasonServiceMock as never);
+    vi.spyOn(ServiceFactory, 'getTeamStatsService').mockReturnValue(teamStatsServiceMock as never);
+
+    const routerModule = await import('../team-stats.js');
+    router = routerModule.default;
+
+    app = express();
+    app.use(express.json());
+    app.use(`/api/accounts/:accountId/seasons/:seasonId/teams`, router);
+
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      if (err instanceof AuthorizationError) {
+        res.status(403).json({ message: err.message });
+        return;
+      }
+      if (err instanceof ValidationError) {
+        res.status(400).json({ message: err.message });
+        return;
+      }
+      res.status(500).json({ message: err.message });
+    });
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    teamServiceMock.validateTeamSeasonBasic.mockResolvedValue(undefined);
+    scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
+    roleServiceMock.hasPermission.mockResolvedValue(false);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  const runScheduleRoute = async (
+    options: {
+      userId?: string;
+      hasManagePermission?: boolean;
+      isHiddenCurrentSeason?: boolean;
+    } = {},
+  ) => {
+    const {
+      userId = 'user-1',
+      hasManagePermission = false,
+      isHiddenCurrentSeason = false,
+    } = options;
+
+    roleServiceMock.hasPermission.mockResolvedValue(hasManagePermission);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(isHiddenCurrentSeason);
+
+    const layer = (
+      router.stack as Array<{
+        route?: {
+          path: string;
+          methods: Record<string, boolean>;
+          stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => unknown }>;
+        };
+      }>
+    ).find(
+      (stackLayer) =>
+        stackLayer.route &&
+        stackLayer.route.path === '/:teamSeasonId/schedule' &&
+        stackLayer.route.methods['get'],
+    );
+
+    if (!layer?.route) {
+      throw new Error('Route GET /:teamSeasonId/schedule not found');
+    }
+
+    const handlers = layer.route.stack.map((s) => s.handle);
+
+    const reqPartial: Partial<Request> = {
+      method: 'GET',
+      params: {
+        accountId: ACCOUNT_ID,
+        seasonId: SEASON_ID,
+        teamSeasonId: TEAM_SEASON_ID,
+      },
+      query: {},
+      headers: { authorization: 'Bearer token', 'x-user-id': userId },
+      get: ((headerName: string) => {
+        const headers: Record<string, string> = {
+          authorization: 'Bearer token',
+          'x-user-id': userId,
+        };
+        return headers[headerName.toLowerCase()];
+      }) as Request['get'],
+    };
+    const req = reqPartial as Request;
+    req.user = { id: userId, username: 'tester' };
+
+    interface MockResponseExtras {
+      body?: unknown;
+    }
+    type MockResponse = Response & MockResponseExtras;
+
+    const resPartial: Partial<Response> & MockResponseExtras = {
+      statusCode: 200,
+      body: undefined,
+      status(code: number) {
+        resPartial.statusCode = code;
+        return res;
+      },
+      json(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+      send(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+    };
+    const res = resPartial as MockResponse;
+
+    let lastError: unknown = null;
+
+    for (const handler of handlers) {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+
+        const settle = (err?: unknown) => {
+          if (settled) return;
+          settled = true;
+          if (err) lastError = err;
+          resolve();
+        };
+
+        const next: NextFunction = (err?: unknown) => settle(err);
+
+        const originalJson = res.json.bind(res);
+        res.json = ((payload: unknown) => {
+          const r = originalJson(payload);
+          settle();
+          return r;
+        }) as Response['json'];
+
+        try {
+          const ret = handler(req, res, next);
+          if (ret && typeof (ret as Promise<unknown>).then === 'function') {
+            (ret as Promise<unknown>).catch((err) => settle(err));
+          }
+        } catch (err) {
+          settle(err);
+        }
+      });
+
+      if (lastError) break;
+    }
+
+    return { req, res, error: lastError };
+  };
+
+  it('returns empty schedule when season is hidden, season is current, and caller lacks manage permission', async () => {
+    const { res } = await runScheduleRoute({
+      hasManagePermission: false,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(res.body).toEqual({
+      games: [],
+      pagination: { total: 0, page: 1, limit: 50 },
+    });
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+  });
+
+  it('returns full schedule when season is hidden, season is current, but caller has account.games.manage', async () => {
+    const { res } = await runScheduleRoute({
+      hasManagePermission: true,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    expect(roleServiceMock.hasPermission).toHaveBeenCalledWith('user-1', 'account.games.manage', {
+      accountId: BigInt(ACCOUNT_ID),
+    });
+  });
+
+  it('returns full schedule when season is hidden but season is NOT current (historical access)', async () => {
+    const { res } = await runScheduleRoute({
+      hasManagePermission: false,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('returns full schedule when season is visible and is current for non-admin user', async () => {
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
+
+    const { res } = await runScheduleRoute({
+      hasManagePermission: false,
+      isHiddenCurrentSeason: false,
+    });
+
+    expect(res.body).toEqual(defaultGamesResponse);
+    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+  });
+
+  it('skips visibility check entirely when caller has account.games.manage', async () => {
+    const { res } = await runScheduleRoute({
+      hasManagePermission: true,
+      isHiddenCurrentSeason: true,
+    });
+
+    expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
+    expect(res.body).toEqual(defaultGamesResponse);
+  });
+
+  it('treats unauthenticated caller as non-admin and applies visibility guard', async () => {
+    roleServiceMock.hasPermission.mockResolvedValue(false);
+    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(true);
+
+    const layer = (
+      router.stack as Array<{
+        route?: {
+          path: string;
+          methods: Record<string, boolean>;
+          stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => unknown }>;
+        };
+      }>
+    ).find(
+      (stackLayer) =>
+        stackLayer.route &&
+        stackLayer.route.path === '/:teamSeasonId/schedule' &&
+        stackLayer.route.methods['get'],
+    );
+
+    if (!layer?.route) {
+      throw new Error('Route GET /:teamSeasonId/schedule not found');
+    }
+
+    const handlers = layer.route.stack.map((s) => s.handle);
+
+    const reqPartial: Partial<Request> = {
+      method: 'GET',
+      params: {
+        accountId: ACCOUNT_ID,
+        seasonId: SEASON_ID,
+        teamSeasonId: TEAM_SEASON_ID,
+      },
+      query: {},
+      headers: {},
+      get: ((_headerName: string) => undefined) as Request['get'],
+    };
+    const req = reqPartial as Request;
+
+    interface MockResponseExtras {
+      body?: unknown;
+    }
+    type MockResponse = Response & MockResponseExtras;
+
+    const resPartial: Partial<Response> & MockResponseExtras = {
+      statusCode: 200,
+      body: undefined,
+      status(code: number) {
+        resPartial.statusCode = code;
+        return res;
+      },
+      json(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+      send(payload: unknown) {
+        resPartial.body = payload;
+        return res;
+      },
+    };
+    const res = resPartial as MockResponse;
+
+    let lastError: unknown = null;
+
+    for (const handler of handlers) {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+
+        const settle = (err?: unknown) => {
+          if (settled) return;
+          settled = true;
+          if (err) lastError = err;
+          resolve();
+        };
+
+        const next: NextFunction = (err?: unknown) => settle(err);
+
+        const originalJson = res.json.bind(res);
+        res.json = ((payload: unknown) => {
+          const r = originalJson(payload);
+          settle();
+          return r;
+        }) as Response['json'];
+
+        try {
+          const ret = handler(req, res, next);
+          if (ret && typeof (ret as Promise<unknown>).then === 'function') {
+            (ret as Promise<unknown>).catch((err) => settle(err));
+          }
+        } catch (err) {
+          settle(err);
+        }
+      });
+
+      if (lastError) break;
+    }
+
+    expect(res.body).toEqual({
+      games: [],
+      pagination: { total: 0, page: 1, limit: 50 },
+    });
+    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+  });
+
+  it('returns empty response with correct pagination shape when schedule is hidden', async () => {
+    const { res } = await runScheduleRoute({
+      hasManagePermission: false,
+      isHiddenCurrentSeason: true,
+    });
+
+    const body = res.body as { games: unknown[]; pagination: { total: number } };
+    expect(body).toHaveProperty('games');
+    expect(body).toHaveProperty('pagination');
+    expect(Array.isArray(body.games)).toBe(true);
+    expect(body.games).toHaveLength(0);
+    expect(body.pagination.total).toBe(0);
+  });
+});

--- a/draco-nodejs/backend/src/routes/games.ts
+++ b/draco-nodejs/backend/src/routes/games.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { authenticateToken } from '../middleware/authMiddleware.js';
+import { authenticateToken, optionalAuth } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { PaginationHelper } from '../utils/pagination.js';
@@ -20,6 +20,8 @@ import {
 const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
 const scheduleService = ServiceFactory.getScheduleService();
+const roleService = ServiceFactory.getRoleService();
+const seasonService = ServiceFactory.getSeasonService();
 
 const parseSeasonParams = (params: ParamsObject) => {
   try {
@@ -75,11 +77,32 @@ router.put(
  */
 router.get(
   '/',
+  optionalAuth,
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
-    const { seasonId } = parseSeasonParams(req.params);
+    const { accountId, seasonId } = parseSeasonParams(req.params);
     const { startDate, endDate, teamId, hasRecap } = req.query;
 
     const paginationParams = PaginationHelper.parseParams(req.query);
+
+    const userId = req.user?.id;
+    const hasManagePermission = userId
+      ? await roleService.hasPermission(userId, 'account.games.manage', { accountId })
+      : false;
+
+    if (!hasManagePermission) {
+      const hidden = await seasonService.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+      if (hidden) {
+        res.json({
+          games: [],
+          pagination: {
+            total: 0,
+            page: paginationParams.page,
+            limit: paginationParams.limit,
+          },
+        });
+        return;
+      }
+    }
 
     let parsedTeamId: bigint | undefined;
     if (teamId) {

--- a/draco-nodejs/backend/src/routes/games.ts
+++ b/draco-nodejs/backend/src/routes/games.ts
@@ -10,7 +10,7 @@ import {
   extractSeasonParams,
   ParamsObject,
 } from '../utils/paramExtraction.js';
-import { ValidationError, AuthenticationError } from '../utils/customErrors.js';
+import { ValidationError, AuthenticationError, NotFoundError } from '../utils/customErrors.js';
 import {
   UpdateGameResultsSchema,
   UpsertGameRecapSchema,
@@ -83,6 +83,11 @@ router.get(
     const { startDate, endDate, teamId, hasRecap } = req.query;
 
     const paginationParams = PaginationHelper.parseParams(req.query);
+
+    const season = await seasonService.findSeasonById(accountId, seasonId);
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
 
     const userId = req.user?.id;
     const hasManagePermission = userId

--- a/draco-nodejs/backend/src/routes/seasons.ts
+++ b/draco-nodejs/backend/src/routes/seasons.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { UpsertSeasonSchema } from '@draco/shared-schemas';
+import { UpsertSeasonSchema, UpdateScheduleVisibilitySchema } from '@draco/shared-schemas';
 import { authenticateToken } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
@@ -105,6 +105,25 @@ router.post(
     const season = await seasonService.setCurrentSeason(accountId, seasonId);
 
     res.json(season);
+  }),
+);
+
+router.patch(
+  '/:seasonId/schedule-visibility',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requireAccountAdmin(),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId } = extractSeasonParams(req.params);
+    const input = UpdateScheduleVisibilitySchema.parse(req.body);
+
+    const result = await seasonService.setScheduleVisibility(
+      accountId,
+      seasonId,
+      input.scheduleVisible,
+    );
+
+    res.json(result);
   }),
 );
 

--- a/draco-nodejs/backend/src/routes/team-stats.ts
+++ b/draco-nodejs/backend/src/routes/team-stats.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { optionalAuth } from '../middleware/authMiddleware.js';
 import { extractTeamParams, ParamsObject } from '../utils/paramExtraction.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
@@ -14,6 +15,8 @@ const router = Router({ mergeParams: true });
 const teamStatsService = ServiceFactory.getTeamStatsService();
 const teamService = ServiceFactory.getTeamService();
 const scheduleService = ServiceFactory.getScheduleService();
+const roleService = ServiceFactory.getRoleService();
+const seasonService = ServiceFactory.getSeasonService();
 
 const parseTeamParams = (params: ParamsObject) => {
   try {
@@ -76,6 +79,7 @@ router.get(
  */
 router.get(
   '/:teamSeasonId/schedule',
+  optionalAuth,
   asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const { accountId, seasonId, teamSeasonId } = parseTeamParams(req.params);
     const { startDate, endDate, hasRecap } = req.query;
@@ -83,6 +87,26 @@ router.get(
     await teamService.validateTeamSeasonBasic(teamSeasonId, seasonId, accountId);
 
     const paginationParams = PaginationHelper.parseParams(req.query);
+
+    const userId = req.user?.id;
+    const hasManagePermission = userId
+      ? await roleService.hasPermission(userId, 'account.games.manage', { accountId })
+      : false;
+
+    if (!hasManagePermission) {
+      const hidden = await seasonService.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+      if (hidden) {
+        res.json({
+          games: [],
+          pagination: {
+            total: 0,
+            page: paginationParams.page,
+            limit: paginationParams.limit,
+          },
+        });
+        return;
+      }
+    }
 
     const parsedStartDate = startDate ? new Date(String(startDate)) : undefined;
     const parsedEndDate = endDate ? new Date(String(endDate)) : undefined;

--- a/draco-nodejs/backend/src/services/__tests__/golfMatchService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/golfMatchService.test.ts
@@ -94,6 +94,7 @@ function createMockFlight(overrides: Partial<GolfFlightWithDetails> = {}): GolfF
       enddate: new Date('2024-12-31'),
       isactive: true,
       iscurrent: true,
+      schedulevisible: true,
     } as season,
     ...overrides,
   } as GolfFlightWithDetails;

--- a/draco-nodejs/backend/src/services/__tests__/scheduleVisibility.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/scheduleVisibility.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SeasonService } from '../seasonService.js';
+import { ISeasonsRepository, dbSeason } from '../../repositories/index.js';
+import { NotFoundError } from '../../utils/customErrors.js';
+
+class SeasonsRepositoryStub implements ISeasonsRepository {
+  findAccountSeasons = vi.fn<ISeasonsRepository['findAccountSeasons']>();
+  findSeasonWithLeagues = vi.fn<ISeasonsRepository['findSeasonWithLeagues']>();
+  findSeasonById = vi.fn<ISeasonsRepository['findSeasonById']>();
+  findSeasonByName = vi.fn<ISeasonsRepository['findSeasonByName']>();
+  createSeason = vi.fn<ISeasonsRepository['createSeason']>();
+  updateSeasonName = vi.fn<ISeasonsRepository['updateSeasonName']>();
+  deleteSeason = vi.fn<ISeasonsRepository['deleteSeason']>();
+  findCurrentSeason = vi.fn<ISeasonsRepository['findCurrentSeason']>();
+  upsertCurrentSeason = vi.fn<ISeasonsRepository['upsertCurrentSeason']>();
+  createLeagueSeason = vi.fn<ISeasonsRepository['createLeagueSeason']>();
+  countSeasonParticipants = vi.fn<ISeasonsRepository['countSeasonParticipants']>();
+  findSeasonParticipants = vi.fn<ISeasonsRepository['findSeasonParticipants']>();
+  findSeasonForCopy = vi.fn<ISeasonsRepository['findSeasonForCopy']>();
+  copySeasonStructure = vi.fn<ISeasonsRepository['copySeasonStructure']>();
+  updateScheduleVisibility = vi.fn<ISeasonsRepository['updateScheduleVisibility']>();
+}
+
+const accountId = 10n;
+const seasonId = 25n;
+
+const makeSeason = (overrides: Partial<dbSeason> = {}): dbSeason => ({
+  id: seasonId,
+  name: 'Spring 2024',
+  accountid: accountId,
+  schedulevisible: true,
+  ...overrides,
+});
+
+describe('SeasonService.setScheduleVisibility', () => {
+  let repo: SeasonsRepositoryStub;
+  let service: SeasonService;
+
+  beforeEach(() => {
+    repo = new SeasonsRepositoryStub();
+    service = new SeasonService(repo);
+  });
+
+  it('returns updated visibility when season exists and is hidden', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: true }));
+    repo.updateScheduleVisibility.mockResolvedValue(makeSeason({ schedulevisible: false }));
+
+    const result = await service.setScheduleVisibility(accountId, seasonId, false);
+
+    expect(result).toEqual({ scheduleVisible: false });
+    expect(repo.updateScheduleVisibility).toHaveBeenCalledWith(accountId, seasonId, false);
+  });
+
+  it('returns updated visibility when season exists and is shown', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: false }));
+    repo.updateScheduleVisibility.mockResolvedValue(makeSeason({ schedulevisible: true }));
+
+    const result = await service.setScheduleVisibility(accountId, seasonId, true);
+
+    expect(result).toEqual({ scheduleVisible: true });
+    expect(repo.updateScheduleVisibility).toHaveBeenCalledWith(accountId, seasonId, true);
+  });
+
+  it('throws NotFoundError when season does not exist', async () => {
+    repo.findSeasonById.mockResolvedValue(null);
+
+    await expect(service.setScheduleVisibility(accountId, seasonId, false)).rejects.toThrow(
+      NotFoundError,
+    );
+
+    expect(repo.updateScheduleVisibility).not.toHaveBeenCalled();
+  });
+});
+
+describe('SeasonService.findSeasonById', () => {
+  let repo: SeasonsRepositoryStub;
+  let service: SeasonService;
+
+  beforeEach(() => {
+    repo = new SeasonsRepositoryStub();
+    service = new SeasonService(repo);
+  });
+
+  it('returns formatted season when found', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: false }));
+
+    const result = await service.findSeasonById(accountId, seasonId);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(seasonId.toString());
+    expect(result?.scheduleVisible).toBe(false);
+  });
+
+  it('returns null when season does not exist', async () => {
+    repo.findSeasonById.mockResolvedValue(null);
+
+    const result = await service.findSeasonById(accountId, seasonId);
+
+    expect(result).toBeNull();
+  });
+
+  it('correctly exposes scheduleVisible as true', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: true }));
+
+    const result = await service.findSeasonById(accountId, seasonId);
+
+    expect(result?.scheduleVisible).toBe(true);
+  });
+});
+
+describe('SeasonService.isScheduleHiddenForCurrentSeason', () => {
+  let repo: SeasonsRepositoryStub;
+  let service: SeasonService;
+
+  beforeEach(() => {
+    repo = new SeasonsRepositoryStub();
+    service = new SeasonService(repo);
+  });
+
+  it('returns true when season is hidden and is the current season', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: false }));
+    repo.findCurrentSeason.mockResolvedValue(makeSeason({ id: seasonId }));
+
+    const result = await service.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when season is hidden but is NOT the current season', async () => {
+    const otherSeasonId = 99n;
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: false }));
+    repo.findCurrentSeason.mockResolvedValue(makeSeason({ id: otherSeasonId }));
+
+    const result = await service.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when season is visible and is the current season', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: true }));
+    repo.findCurrentSeason.mockResolvedValue(makeSeason({ id: seasonId }));
+
+    const result = await service.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when season is hidden and there is no current season', async () => {
+    repo.findSeasonById.mockResolvedValue(makeSeason({ schedulevisible: false }));
+    repo.findCurrentSeason.mockResolvedValue(null);
+
+    const result = await service.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the season itself does not exist', async () => {
+    repo.findSeasonById.mockResolvedValue(null);
+    repo.findCurrentSeason.mockResolvedValue(makeSeason({ id: seasonId }));
+
+    const result = await service.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+
+    expect(result).toBe(false);
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
@@ -135,7 +135,13 @@ const makeAccountGame = (
       leagueid: 1n,
       seasonid: 2n,
       league: { id: 1n, accountid: 42n, name: 'Test League', active: true },
-      season: { id: 2n, name: 'Test Season', accountid: 42n, currentseason: false },
+      season: {
+        id: 2n,
+        name: 'Test Season',
+        accountid: 42n,
+        currentseason: false,
+        schedulevisible: true,
+      },
     },
   }) as dbScheduleGameForAccount;
 
@@ -162,7 +168,13 @@ const makeGameWithDetails = (id: bigint): dbScheduleGameWithDetails =>
       leagueid: 1n,
       seasonid: 2n,
       league: { id: 1n, accountid: 42n, name: 'Test League', active: true },
-      season: { id: 2n, name: 'Test Season', accountid: 42n, currentseason: false },
+      season: {
+        id: 2n,
+        name: 'Test Season',
+        accountid: 42n,
+        currentseason: false,
+        schedulevisible: true,
+      },
     },
     _count: { gamerecap: 0 },
   }) as dbScheduleGameWithDetails;

--- a/draco-nodejs/backend/src/services/__tests__/schedulerProblemSpecService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerProblemSpecService.test.ts
@@ -48,6 +48,7 @@ class SeasonsRepositoryStub implements ISeasonsRepository {
   findSeasonParticipants = vi.fn<ISeasonsRepository['findSeasonParticipants']>();
   findSeasonForCopy = vi.fn<ISeasonsRepository['findSeasonForCopy']>();
   copySeasonStructure = vi.fn<ISeasonsRepository['copySeasonStructure']>();
+  updateScheduleVisibility = vi.fn<ISeasonsRepository['updateScheduleVisibility']>();
 }
 
 class SchedulerFieldAvailabilityRulesRepositoryStub implements ISchedulerFieldAvailabilityRulesRepository {
@@ -124,6 +125,7 @@ const makeSeason = (): dbSeason => ({
   id: seasonId,
   name: 'Test Season',
   accountid: accountId,
+  schedulevisible: true,
 });
 
 const makeSeasonWindowConfig = (

--- a/draco-nodejs/backend/src/services/__tests__/seasonService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/seasonService.test.ts
@@ -36,6 +36,8 @@ class SeasonsRepositoryStub implements ISeasonsRepository {
   findSeasonForCopy = vi.fn<ISeasonsRepository['findSeasonForCopy']>();
 
   copySeasonStructure = vi.fn<ISeasonsRepository['copySeasonStructure']>();
+
+  updateScheduleVisibility = vi.fn<ISeasonsRepository['updateScheduleVisibility']>();
 }
 
 const accountId = 10n;
@@ -152,6 +154,7 @@ const createCopiedSeasonRecord = (): dbSeasonWithLeagues => ({
   id: 999n,
   name: 'Spring 2024 Copy',
   accountid: accountId,
+  schedulevisible: true,
   leagueseason: [
     {
       id: 123n,
@@ -206,6 +209,7 @@ describe('SeasonService.copySeason', () => {
       name: 'Spring 2024 Copy',
       accountId: accountId.toString(),
       isCurrent: false,
+      scheduleVisible: true,
       leagues: [
         {
           id: copiedSeasonRecord.leagueseason[0].id.toString(),
@@ -238,6 +242,7 @@ describe('SeasonService.copySeason', () => {
       id: 777n,
       name: 'Spring 2024 Copy',
       accountid: accountId,
+      schedulevisible: true,
     } satisfies dbSeason);
 
     await expect(service.copySeason(accountId, seasonId)).rejects.toBeInstanceOf(ConflictError);

--- a/draco-nodejs/backend/src/services/seasonService.ts
+++ b/draco-nodejs/backend/src/services/seasonService.ts
@@ -3,6 +3,7 @@ import {
   LeagueSeasonWithDivisionType,
   SeasonParticipantCountDataType,
   SeasonType,
+  UpdateScheduleVisibilityType,
   UpsertSeasonType,
 } from '@draco/shared-schemas';
 import { ISeasonsRepository, RepositoryFactory } from '../repositories/index.js';
@@ -199,6 +200,48 @@ export class SeasonService {
     await this.seasonsRepository.deleteSeason(seasonId);
 
     return true;
+  }
+
+  async findSeasonById(accountId: bigint, seasonId: bigint): Promise<SeasonType | null> {
+    const season = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+    if (!season) {
+      return null;
+    }
+    return SeasonResponseFormatter.formatSeason(season);
+  }
+
+  async isScheduleHiddenForCurrentSeason(accountId: bigint, seasonId: bigint): Promise<boolean> {
+    const [season, currentSeason] = await Promise.all([
+      this.seasonsRepository.findSeasonById(accountId, seasonId),
+      this.seasonsRepository.findCurrentSeason(accountId),
+    ]);
+
+    if (!season) {
+      return false;
+    }
+
+    const isCurrent = currentSeason?.id === seasonId;
+    return !season.schedulevisible && isCurrent;
+  }
+
+  async setScheduleVisibility(
+    accountId: bigint,
+    seasonId: bigint,
+    scheduleVisible: boolean,
+  ): Promise<UpdateScheduleVisibilityType> {
+    const season = await this.seasonsRepository.findSeasonById(accountId, seasonId);
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const updated = await this.seasonsRepository.updateScheduleVisibility(
+      accountId,
+      seasonId,
+      scheduleVisible,
+    );
+
+    return SeasonResponseFormatter.formatScheduleVisibility(updated);
   }
 
   async getSeasonParticipantCount(

--- a/draco-nodejs/backend/src/services/teamService.ts
+++ b/draco-nodejs/backend/src/services/teamService.ts
@@ -85,6 +85,7 @@ export class TeamService {
       id: currentSeason.id.toString(),
       name: currentSeason.name,
       accountId: accountId.toString(),
+      scheduleVisible: currentSeason.schedulevisible,
     };
 
     let formatted: TeamSeasonType[];

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
@@ -1,16 +1,19 @@
 'use client';
 import React, { useState, useEffect } from 'react';
-import { Fab } from '@mui/material';
+import { Box, Button, Fab, FormControlLabel, Switch, useMediaQuery } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
+import PrintIcon from '@mui/icons-material/Print';
 import { useRole } from '../../../../context/RoleContext';
 import { useAuth } from '../../../../context/AuthContext';
 import { useCurrentSeason } from '../../../../hooks/useCurrentSeason';
 import { useAccountTimezone, useAccount } from '../../../../context/AccountContext';
+import { useApiClient } from '../../../../hooks/useApiClient';
+import { updateSeasonScheduleVisibility } from '@draco/shared-api-client';
+import { unwrapApiResult } from '../../../../utils/apiResult';
 import { GameCardData } from '../../../../components/GameCard';
 import { getGameSummary } from '../../../../lib/utils';
 import { convertGameToGameCardData } from '../../../../utils/gameTransformers';
 import { useGameRecapFlow } from '../../../../hooks/useGameRecapFlow';
-import { useMediaQuery } from '@mui/material';
 import {
   useScheduleData,
   useScheduleFilters,
@@ -24,6 +27,10 @@ import {
 } from '../../../../components/schedule';
 import { SeasonSchedulerAdapter } from '../../../../components/scheduler/SeasonSchedulerAdapter';
 import { AdminBreadcrumbs } from '../../../../components/admin';
+import { getFilteredScheduleSummary } from '../../../../components/schedule/utils/getFilteredScheduleSummary';
+import SeasonSummaryWidget from '../../../../components/schedule/SeasonSummaryWidget';
+import usePrintAction from '../../../../components/print/usePrintAction';
+import SchedulePrintView from '../../../../components/schedule/SchedulePrintView';
 
 interface ScheduleManagementProps {
   accountId: string;
@@ -34,10 +41,18 @@ const CALENDAR_VIEW_BREAKPOINT = 900;
 const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) => {
   const { hasRole, hasRoleInAccount, hasRoleInTeam } = useRole();
   const { token } = useAuth();
-  const { currentSeasonId, currentSeasonName, fetchCurrentSeason } = useCurrentSeason(accountId);
+  const {
+    currentSeasonId,
+    currentSeasonName,
+    currentSeasonScheduleVisible,
+    fetchCurrentSeason,
+    refetchCurrentSeason,
+  } = useCurrentSeason(accountId);
   const timeZone = useAccountTimezone();
   const { currentAccount } = useAccount();
   const accountType = currentAccount?.accountType;
+  const apiClient = useApiClient();
+  const [visibilityPending, setVisibilityPending] = useState(false);
 
   useEffect(() => {
     if (accountId) {
@@ -74,6 +89,28 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       setFeedback({ severity: 'error', message });
     } else {
       setFeedback((prev) => (prev?.severity === 'error' ? null : prev));
+    }
+  };
+
+  const handleVisibilityToggle = async () => {
+    if (!currentSeasonId || visibilityPending) {
+      return;
+    }
+
+    setVisibilityPending(true);
+    try {
+      const result = await updateSeasonScheduleVisibility({
+        client: apiClient,
+        path: { accountId, seasonId: currentSeasonId },
+        body: { scheduleVisible: !currentSeasonScheduleVisible },
+        throwOnError: false,
+      });
+      unwrapApiResult(result, 'Failed to update schedule visibility');
+      await refetchCurrentSeason();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update schedule visibility');
+    } finally {
+      setVisibilityPending(false);
     }
   };
 
@@ -123,6 +160,13 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
   const leagueTeams = filterLeagueSeasonId
     ? (leagueTeamsCache.get(filterLeagueSeasonId) ?? [])
     : [];
+
+  const filteredSummary = getFilteredScheduleSummary({
+    games: filteredGames,
+    timeZone,
+    teamSeasonId: filterTeamSeasonId || undefined,
+    ready: !loadingStaticData,
+  });
 
   const {
     createDialogOpen,
@@ -263,6 +307,10 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
     onRecapSaved: handleRecapSaved,
   });
 
+  const { triggerPrint } = usePrintAction();
+
+  const printTitle = currentSeasonName ? `Schedule — ${currentSeasonName}` : 'Schedule';
+
   const handleViewModeChange = (mode: ViewMode) => {
     setManualViewMode(mode === defaultViewMode ? null : mode);
   };
@@ -273,11 +321,36 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       title="Schedule Management"
       subtitle="Create, edit, and manage game schedules for your organization."
       breadcrumbs={
-        <AdminBreadcrumbs
-          accountId={accountId}
-          category={{ name: 'Season', href: `/account/${accountId}/admin/season` }}
-          currentPage="Schedule Management"
-        />
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <AdminBreadcrumbs
+            accountId={accountId}
+            category={{ name: 'Season', href: `/account/${accountId}/admin/season` }}
+            currentPage="Schedule Management"
+          />
+          <Box
+            className="print-hidden"
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}
+          >
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={currentSeasonScheduleVisible ?? false}
+                  onChange={handleVisibilityToggle}
+                  disabled={visibilityPending || currentSeasonId === null}
+                />
+              }
+              label="Schedule visible to public"
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<PrintIcon />}
+              onClick={triggerPrint}
+            >
+              Print
+            </Button>
+          </Box>
+        </Box>
       }
       seasonName={currentSeasonName}
       filteredGames={filteredGames}
@@ -315,6 +388,15 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       onFeedbackClose={handleFeedbackClose}
       recapError={recapError}
       onRecapErrorClose={clearRecapError}
+      summaryContent={
+        <SeasonSummaryWidget
+          summary={filteredSummary}
+          loading={false}
+          ready={!loadingStaticData}
+          games={filteredGames}
+          timeZone={timeZone}
+        />
+      }
     >
       <SeasonSchedulerAdapter
         accountId={accountId}
@@ -419,6 +501,8 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       />
 
       {recapDialogs}
+
+      <SchedulePrintView games={filteredGames} title={printTitle} timeZone={timeZone} />
 
       <Fab
         color="primary"

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -18,6 +18,12 @@ import {
 } from '../../../../components/schedule';
 import { isGolfLeagueAccountType } from '../../../../utils/accountTypeUtils';
 import GolfScorecardDialog from '../../../../components/golf/GolfScorecardDialog';
+import usePrintAction from '../../../../components/print/usePrintAction';
+import SchedulePrintView from '../../../../components/schedule/SchedulePrintView';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import PrintIcon from '@mui/icons-material/Print';
 
 interface ScheduleProps {
   accountId: string;
@@ -27,7 +33,8 @@ const CALENDAR_VIEW_BREAKPOINT = 900;
 
 const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
   const { token } = useAuth();
-  const { currentSeasonName, fetchCurrentSeason } = useCurrentSeason(accountId);
+  const { currentSeasonName, currentSeasonScheduleVisible, fetchCurrentSeason } =
+    useCurrentSeason(accountId);
   const timeZone = useAccountTimezone();
   const { currentAccount } = useAccount();
   const accountType = currentAccount?.accountType;
@@ -144,6 +151,10 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
     getTeamName: (_game, teamId) => getTeamName(teamId),
   });
 
+  const { triggerPrint } = usePrintAction();
+
+  const printTitle = currentSeasonName ? `${currentSeasonName} Schedule` : 'Schedule';
+
   const handleViewModeChange = (mode: ViewMode) => {
     setManualViewMode(mode === defaultViewMode ? null : mode);
   };
@@ -166,11 +177,34 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
     setSelectedMatchId(null);
   };
 
+  const scheduleHiddenNotice =
+    !loadingGames && filteredGames.length === 0 && currentSeasonScheduleVisible === false ? (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body1" color="text.secondary">
+          The schedule has not been published yet. Please check back soon.
+        </Typography>
+      </Box>
+    ) : undefined;
+
   return (
     <ScheduleLayout
       accountId={accountId}
       title="Schedule"
       seasonName={currentSeasonName}
+      breadcrumbs={
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+          <Button
+            className="print-hidden"
+            variant="outlined"
+            size="small"
+            startIcon={<PrintIcon />}
+            onClick={triggerPrint}
+          >
+            Print
+          </Button>
+        </Box>
+      }
+      summaryContent={scheduleHiddenNotice}
       filteredGames={filteredGames}
       teams={teams}
       locations={locations}
@@ -230,6 +264,8 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
       )}
 
       {recapDialogs}
+
+      <SchedulePrintView games={filteredGames} title={printTitle} timeZone={timeZone} />
     </ScheduleLayout>
   );
 };

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/Teams.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/Teams.tsx
@@ -54,7 +54,12 @@ const Teams: React.FC<TeamsProps> = ({ accountId, seasonId, router }) => {
 
         const leagueData = unwrapApiResult(leagueResult, 'Failed to load teams data');
         const mapped = mapLeagueSetup(leagueData);
-        mapped.season = mapped.season ?? { id: seasonId, name: '', accountId };
+        mapped.season = mapped.season ?? {
+          id: seasonId,
+          name: '',
+          accountId,
+          scheduleVisible: true,
+        };
 
         setTeamsData(mapped);
       } catch (err) {

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import { useMediaQuery } from '@mui/material';
 import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Container from '@mui/material/Container';
 import Link from '@mui/material/Link';
@@ -30,7 +29,12 @@ import {
 } from '../../../../../../../../components/schedule';
 import { useTeamSeasonSummary } from '../../../../../../../../components/schedule/hooks/useTeamSeasonSummary';
 import SeasonSummaryWidget from '../../../../../../../../components/schedule/SeasonSummaryWidget';
+import usePrintAction from '../../../../../../../../components/print/usePrintAction';
+import SchedulePrintView from '../../../../../../../../components/schedule/SchedulePrintView';
+import Button from '@mui/material/Button';
+import PrintIcon from '@mui/icons-material/Print';
 import { isGolfLeagueAccountType } from '../../../../../../../../utils/accountTypeUtils';
+import Stack from '@mui/material/Stack';
 
 interface TeamSchedulePageProps {
   accountId: string;
@@ -175,7 +179,11 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     setFilterDate: updateFilterDate,
   });
 
-  const { summary: seasonSummary, loading: loadingSeasonSummary } = useTeamSeasonSummary({
+  const {
+    summary: seasonSummary,
+    loading: loadingSeasonSummary,
+    games: summaryGames,
+  } = useTeamSeasonSummary({
     accountId,
     seasonId,
     teamSeasonId,
@@ -215,6 +223,10 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     seasonId,
     fetchRecap: fetchRecapForTeam,
   });
+
+  const { triggerPrint } = usePrintAction();
+
+  const printTitle = [teamName ?? 'Team', seasonName ?? ''].filter(Boolean).join(' — ');
 
   const handleViewModeChange = (mode: ViewMode) => {
     setManualViewMode(mode === defaultViewMode ? null : mode);
@@ -266,14 +278,28 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
       }
       subtitle="Schedule"
       breadcrumbs={
-        <Box sx={{ mb: 2 }}>
+        <Stack
+          direction="row"
+          alignItems="flex-start"
+          justifyContent="space-between"
+          sx={{ mb: 2 }}
+        >
           <Breadcrumbs aria-label="breadcrumb">
             <Link component={NextLink} underline="hover" color="inherit" href={teamHomeHref}>
               Team Overview
             </Link>
             <Typography color="text.primary">Schedule</Typography>
           </Breadcrumbs>
-        </Box>
+          <Button
+            className="print-hidden"
+            variant="outlined"
+            size="small"
+            startIcon={<PrintIcon />}
+            onClick={triggerPrint}
+          >
+            Print
+          </Button>
+        </Stack>
       }
       seasonName={null}
       filteredGames={filteredGames}
@@ -315,6 +341,8 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
           summary={seasonSummary}
           loading={loadingSeasonSummary}
           ready={!loadingDateRange}
+          games={summaryGames}
+          timeZone={timeZone}
         />
       }
     >
@@ -334,6 +362,13 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
       />
 
       {recapDialogs}
+
+      <SchedulePrintView
+        games={summaryGames}
+        title={printTitle}
+        subtitle="Full Season Schedule"
+        timeZone={timeZone}
+      />
     </ScheduleLayout>
   );
 };

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/__tests__/SeasonManagement.test.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/__tests__/SeasonManagement.test.tsx
@@ -87,6 +87,7 @@ const createSeasonResponse = (name: string, id: string): LeagueSeasonWithDivisio
   name,
   accountId: '42',
   isCurrent: false,
+  scheduleVisible: true,
   leagues: [
     {
       id: `ls-${id}`,

--- a/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
+++ b/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+
+interface PrintableLayoutProps {
+  children: ReactNode;
+  title: string;
+  subtitle?: string;
+}
+
+const PrintableLayout: React.FC<PrintableLayoutProps> = ({ children, title, subtitle }) => {
+  return (
+    <>
+      <style>{`
+        @media screen {
+          .dr-print-root { display: none; }
+        }
+        @media print {
+          @page {
+            size: letter portrait;
+            margin: 0.4in;
+          }
+          body * { visibility: hidden !important; }
+          .dr-print-root, .dr-print-root * { visibility: visible !important; }
+          .dr-print-root {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+          }
+          .print-hidden { display: none !important; }
+          .dr-print-row { page-break-inside: avoid; }
+        }
+      `}</style>
+      <div className="dr-print-root">
+        <h1 style={{ margin: '0 0 4px 0', fontSize: '18px', fontWeight: 700 }}>{title}</h1>
+        {subtitle ? (
+          <p style={{ margin: '0 0 16px 0', fontSize: '13px', color: '#555' }}>{subtitle}</p>
+        ) : null}
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default PrintableLayout;

--- a/draco-nodejs/frontend-next/components/print/__tests__/usePrintAction.test.ts
+++ b/draco-nodejs/frontend-next/components/print/__tests__/usePrintAction.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockPrint = vi.fn();
+const afterprintListeners: Array<() => void> = [];
+
+const mockWindow = {
+  print: mockPrint,
+  addEventListener: vi.fn((event: string, listener: () => void) => {
+    if (event === 'afterprint') afterprintListeners.push(listener);
+  }),
+  removeEventListener: vi.fn((event: string, listener: () => void) => {
+    if (event === 'afterprint') {
+      const idx = afterprintListeners.indexOf(listener);
+      if (idx !== -1) afterprintListeners.splice(idx, 1);
+    }
+  }),
+};
+
+function fireAfterprint() {
+  const listeners = [...afterprintListeners];
+  listeners.forEach((fn) => fn());
+}
+
+describe('usePrintAction / triggerPrint', () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPrint.mockReset();
+    (mockWindow.addEventListener as ReturnType<typeof vi.fn>).mockClear();
+    (mockWindow.removeEventListener as ReturnType<typeof vi.fn>).mockClear();
+    afterprintListeners.length = 0;
+
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    Object.defineProperty(globalThis, 'window', {
+      value: mockWindow,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: { title: 'Page Title | My Site' },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: originalDocument,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('strips the " | " suffix from document.title before printing', async () => {
+    const { default: usePrintAction } = await import('../usePrintAction.js');
+    const { triggerPrint } = usePrintAction();
+
+    triggerPrint();
+
+    expect(document.title).toBe('Page Title');
+    expect(mockPrint).toHaveBeenCalledOnce();
+  });
+
+  it('restores the original title after afterprint fires', async () => {
+    const { default: usePrintAction } = await import('../usePrintAction.js');
+    const { triggerPrint } = usePrintAction();
+
+    triggerPrint();
+    expect(document.title).toBe('Page Title');
+
+    fireAfterprint();
+
+    expect(document.title).toBe('Page Title | My Site');
+  });
+
+  it('does not corrupt savedTitle on rapid double-click (idempotent)', async () => {
+    const { default: usePrintAction } = await import('../usePrintAction.js');
+    const { triggerPrint } = usePrintAction();
+
+    triggerPrint();
+    triggerPrint();
+
+    expect(mockPrint).toHaveBeenCalledTimes(2);
+    expect(mockWindow.addEventListener).toHaveBeenCalledTimes(1);
+
+    fireAfterprint();
+
+    expect(document.title).toBe('Page Title | My Site');
+  });
+
+  it('does not strip title when there is no " | " separator', async () => {
+    document.title = 'Plain Title';
+
+    const { default: usePrintAction } = await import('../usePrintAction.js');
+    const { triggerPrint } = usePrintAction();
+
+    triggerPrint();
+
+    expect(document.title).toBe('Plain Title');
+    expect(mockPrint).toHaveBeenCalledOnce();
+
+    fireAfterprint();
+
+    expect(document.title).toBe('Plain Title');
+  });
+
+  it('is SSR-safe: does not throw when window is undefined', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { default: usePrintAction } = await import('../usePrintAction.js');
+    const { triggerPrint } = usePrintAction();
+
+    expect(() => triggerPrint()).not.toThrow();
+    expect(mockPrint).not.toHaveBeenCalled();
+  });
+});

--- a/draco-nodejs/frontend-next/components/print/usePrintAction.ts
+++ b/draco-nodejs/frontend-next/components/print/usePrintAction.ts
@@ -1,0 +1,37 @@
+const stripSuffix = (title: string): string => {
+  const sep = ' | ';
+  const i = title.indexOf(sep);
+  if (i === -1) return title;
+  return title.slice(0, i).trim();
+};
+
+let savedTitle: string | null = null;
+let listenerAttached = false;
+
+const restore = () => {
+  if (typeof window === 'undefined') return;
+  if (savedTitle !== null) document.title = savedTitle;
+  savedTitle = null;
+  window.removeEventListener('afterprint', restore);
+  listenerAttached = false;
+};
+
+const triggerPrint = () => {
+  if (typeof window === 'undefined') return;
+  if (savedTitle === null) {
+    savedTitle = document.title;
+    const cleaned = stripSuffix(savedTitle);
+    if (cleaned !== savedTitle) document.title = cleaned;
+  }
+  if (!listenerAttached) {
+    window.addEventListener('afterprint', restore);
+    listenerAttached = true;
+  }
+  window.print();
+};
+
+const usePrintAction = () => {
+  return { triggerPrint };
+};
+
+export default usePrintAction;

--- a/draco-nodejs/frontend-next/components/schedule/FieldDatesDialog.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/FieldDatesDialog.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import type { Game } from '@/types/schedule';
+import { GameStatus } from '@/types/schedule';
+import { formatDateInTimezone, formatTimeInTimezone } from '../../utils/dateUtils';
+
+interface FieldDatesDialogProps {
+  open: boolean;
+  onClose: () => void;
+  fieldId: string | null;
+  fieldName: string;
+  games: Game[];
+  timeZone: string;
+}
+
+const normalizeFieldId = (value?: string | null): string | null => {
+  if (typeof value === 'string' && value.trim().length > 0) return value;
+  return null;
+};
+
+const matchesField = (game: Game, fieldId: string | null): boolean => {
+  const gameFieldId = normalizeFieldId(game.field?.id) ?? normalizeFieldId(game.fieldId) ?? null;
+  return gameFieldId === fieldId;
+};
+
+const sortByGameDate = (a: Game, b: Game): number => {
+  return new Date(a.gameDate).getTime() - new Date(b.gameDate).getTime();
+};
+
+const formatMatchup = (game: Game): string => {
+  const home = game.homeTeamName || game.homeTeamId;
+  const visitor = game.visitorTeamName || game.visitorTeamId;
+  return `${home} vs ${visitor}`;
+};
+
+const formatResult = (game: Game): string => {
+  if (game.gameStatus === GameStatus.Scheduled) {
+    return 'Upcoming';
+  }
+  return game.gameStatusText || '—';
+};
+
+const FieldDatesDialog: React.FC<FieldDatesDialogProps> = ({
+  open,
+  onClose,
+  fieldId,
+  fieldName,
+  games,
+  timeZone,
+}) => {
+  const fieldGames = games.filter((game) => matchesField(game, fieldId)).sort(sortByGameDate);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ pr: 6 }}>
+        <Box>
+          <Typography variant="h6" component="span" fontWeight={700}>
+            {fieldName}
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          {fieldGames.length} {fieldGames.length === 1 ? 'game' : 'games'} scheduled
+        </Typography>
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8, color: (theme) => theme.palette.grey[500] }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {fieldGames.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No games found for this field.
+          </Typography>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Typography variant="caption" fontWeight={700}>
+                    Date
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" fontWeight={700}>
+                    Time
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" fontWeight={700}>
+                    League
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" fontWeight={700}>
+                    Matchup
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" fontWeight={700}>
+                    Result
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {fieldGames.map((game) => (
+                <TableRow key={game.id}>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {formatDateInTimezone(game.gameDate, timeZone, {
+                        weekday: 'short',
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {formatTimeInTimezone(game.gameDate, timeZone)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{game.league?.name ?? ''}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{formatMatchup(game)}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{formatResult(game)}</Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FieldDatesDialog;

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -153,8 +153,6 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
           </Box>
           {breadcrumbs}
 
-          {summaryContent}
-
           <Paper
             elevation={1}
             sx={{
@@ -255,6 +253,8 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
               ) : null}
             </Box>
           </WidgetShell>
+
+          {summaryContent}
 
           {children}
 

--- a/draco-nodejs/frontend-next/components/schedule/SchedulePrintView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/SchedulePrintView.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import PrintableLayout from '../print/PrintableLayout';
+import {
+  getDateKeyInTimezone,
+  formatDateInTimezone,
+  formatTimeInTimezone,
+} from '../../utils/dateUtils';
+import type { Game } from '@/types/schedule';
+import { GameStatus } from '@/types/schedule';
+
+interface SchedulePrintViewProps {
+  games: Game[];
+  title: string;
+  subtitle?: string;
+  timeZone: string;
+}
+
+const PLAYED_STATUSES = new Set([
+  GameStatus.Completed,
+  GameStatus.Forfeit,
+  GameStatus.DidNotReport,
+]);
+
+const getFieldLabel = (game: Game): string => {
+  return game.field?.name || game.field?.shortName || 'TBD';
+};
+
+const getScoreSuffix = (game: Game): string => {
+  if (!PLAYED_STATUSES.has(game.gameStatus)) {
+    return '';
+  }
+  return ` · ${game.homeScore}–${game.visitorScore}`;
+};
+
+const getMatchup = (game: Game): string => {
+  const home = game.homeTeamName ?? game.homeTeamId;
+  const visitor = game.visitorTeamName ?? game.visitorTeamId;
+  return `${home} vs ${visitor}`;
+};
+
+const groupAndSortGames = (
+  games: Game[],
+  timeZone: string,
+): Array<{ dateKey: string; dateLabel: string; games: Game[] }> => {
+  const sorted = [...games].sort(
+    (a, b) => new Date(a.gameDate).getTime() - new Date(b.gameDate).getTime(),
+  );
+
+  const groups = new Map<string, { dateLabel: string; games: Game[] }>();
+
+  for (const game of sorted) {
+    const key = getDateKeyInTimezone(game.gameDate, timeZone) ?? 'unknown';
+    if (!groups.has(key)) {
+      const label = formatDateInTimezone(game.gameDate, timeZone, {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      groups.set(key, { dateLabel: label, games: [] });
+    }
+    groups.get(key)!.games.push(game);
+  }
+
+  return Array.from(groups.entries()).map(([dateKey, value]) => ({
+    dateKey,
+    ...value,
+  }));
+};
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  marginBottom: '16px',
+  fontSize: '11px',
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '4px 6px',
+  borderBottom: '2px solid #333',
+  fontWeight: 700,
+  fontSize: '10px',
+  textTransform: 'uppercase',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '3px 6px',
+  borderBottom: '1px solid #ccc',
+  verticalAlign: 'top',
+};
+
+const dateHeadingStyle: React.CSSProperties = {
+  margin: '16px 0 4px 0',
+  fontSize: '13px',
+  fontWeight: 700,
+  borderBottom: '1px solid #999',
+  paddingBottom: '2px',
+};
+
+const SchedulePrintView: React.FC<SchedulePrintViewProps> = ({
+  games,
+  title,
+  subtitle,
+  timeZone,
+}) => {
+  if (games.length === 0) {
+    return (
+      <PrintableLayout title={title} subtitle={subtitle}>
+        <p style={{ fontSize: '12px', color: '#555' }}>No games to display.</p>
+      </PrintableLayout>
+    );
+  }
+
+  const groups = groupAndSortGames(games, timeZone);
+
+  return (
+    <PrintableLayout title={title} subtitle={subtitle}>
+      {groups.map(({ dateKey, dateLabel, games: dayGames }) => (
+        <div key={dateKey}>
+          <h2 style={dateHeadingStyle}>{dateLabel}</h2>
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Time</th>
+                <th style={thStyle}>League</th>
+                <th style={thStyle}>Matchup</th>
+                <th style={thStyle}>Field</th>
+                <th style={thStyle}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {dayGames.map((game) => (
+                <tr key={game.id} className="dr-print-row">
+                  <td style={tdStyle}>{formatTimeInTimezone(game.gameDate, timeZone)}</td>
+                  <td style={tdStyle}>{game.league.name}</td>
+                  <td style={tdStyle}>{getMatchup(game)}</td>
+                  <td style={tdStyle}>{getFieldLabel(game)}</td>
+                  <td style={tdStyle}>
+                    {game.gameStatusText}
+                    {getScoreSuffix(game)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </PrintableLayout>
+  );
+};
+
+export default SchedulePrintView;

--- a/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Box,
   Divider,
+  Link,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -19,11 +20,20 @@ import type {
   DayTypeCounts,
   StartTimeSummary,
 } from './hooks/useTeamSeasonSummary';
+import type { Game } from '@/types/schedule';
+import FieldDatesDialog from './FieldDatesDialog';
+
+interface SelectedField {
+  id: string | null;
+  name: string;
+}
 
 interface SeasonSummaryWidgetProps {
   summary: SeasonSummary | null;
   loading: boolean;
   ready: boolean;
+  games?: Game[];
+  timeZone?: string;
 }
 
 const MAX_FIELD_NAME_LENGTH = 40;
@@ -145,7 +155,112 @@ const SubCard: React.FC<SubCardProps> = ({ title, children }) => {
   );
 };
 
-const renderFields = (byField: FieldSummary[]): React.ReactNode => {
+const FIELD_COL_WIDTH = 64;
+
+interface FieldCountCellProps {
+  value: number;
+  color: string;
+}
+
+const FieldCountCell: React.FC<FieldCountCellProps> = ({ value, color }) => (
+  <Typography
+    variant="body2"
+    fontWeight={700}
+    color={color}
+    component="span"
+    sx={{ width: FIELD_COL_WIDTH, textAlign: 'right', flexShrink: 0 }}
+  >
+    {value}
+  </Typography>
+);
+
+interface FieldHeaderRowProps {
+  labels: [string, string, string];
+  tooltips: [string, string, string];
+}
+
+const FieldHeaderRow: React.FC<FieldHeaderRowProps> = ({ labels, tooltips }) => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      display="flex"
+      alignItems="baseline"
+      justifyContent="space-between"
+      gap={1}
+      sx={{ pb: 0.5, mb: 0.25 }}
+    >
+      <Box sx={{ minWidth: 0, flex: 1 }} />
+      {labels.map((label, i) => (
+        <Typography
+          key={label}
+          variant="caption"
+          fontWeight={700}
+          color={theme.palette.widget.supportingText}
+          title={tooltips[i]}
+          sx={{ width: FIELD_COL_WIDTH, textAlign: 'right', flexShrink: 0 }}
+        >
+          {label}
+        </Typography>
+      ))}
+    </Box>
+  );
+};
+
+interface FieldRowProps {
+  field: FieldSummary;
+  onFieldClick?: (field: SelectedField) => void;
+}
+
+const FieldRow: React.FC<FieldRowProps> = ({ field, onFieldClick }) => {
+  const theme = useTheme();
+  const label = truncateFieldName(field.fieldName);
+
+  const nameCell = onFieldClick ? (
+    <Link
+      component="button"
+      variant="body2"
+      fontWeight={500}
+      color={theme.palette.text.primary}
+      underline="hover"
+      onClick={() => onFieldClick({ id: field.fieldId, name: field.fieldName })}
+      title={field.fieldName}
+      sx={{ textAlign: 'left', display: 'block', maxWidth: '100%' }}
+    >
+      {label}
+    </Link>
+  ) : (
+    <Typography
+      variant="body2"
+      fontWeight={500}
+      color={theme.palette.text.primary}
+      noWrap
+      title={field.fieldName}
+    >
+      {label}
+    </Typography>
+  );
+
+  return (
+    <Box
+      display="flex"
+      alignItems="baseline"
+      justifyContent="space-between"
+      gap={1}
+      sx={{ py: 0.5 }}
+    >
+      <Box sx={{ minWidth: 0, flex: 1 }}>{nameCell}</Box>
+      <FieldCountCell value={field.upcoming} color={theme.palette.text.primary} />
+      <FieldCountCell value={field.played} color={theme.palette.text.primary} />
+      <FieldCountCell value={field.notPlayed} color={theme.palette.text.primary} />
+    </Box>
+  );
+};
+
+const renderFields = (
+  byField: FieldSummary[],
+  onFieldClick?: (field: SelectedField) => void,
+): React.ReactNode => {
   if (byField.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary">
@@ -156,14 +271,12 @@ const renderFields = (byField: FieldSummary[]): React.ReactNode => {
 
   return (
     <>
+      <FieldHeaderRow
+        labels={['Up', 'Played', 'Not Played']}
+        tooltips={['Upcoming', 'Completed, Forfeit, Did Not Report', 'Postponed, Rainout']}
+      />
       {byField.map((field) => (
-        <SummaryRow
-          key={field.fieldId ?? '__no_field__'}
-          label={truncateFieldName(field.fieldName)}
-          tooltipLabel={field.fieldName}
-          played={field.played}
-          scheduled={field.scheduled}
-        />
+        <FieldRow key={field.fieldId ?? '__no_field__'} field={field} onFieldClick={onFieldClick} />
       ))}
     </>
   );
@@ -226,8 +339,88 @@ const renderStartTime = (byStartTime: StartTimeSummary[]): React.ReactNode => {
   );
 };
 
-const SeasonSummaryWidget: React.FC<SeasonSummaryWidgetProps> = ({ summary, loading, ready }) => {
+interface HomeAwaySubCardProps {
+  homeAway: NonNullable<SeasonSummary['homeAway']>;
+}
+
+const HomeAwaySubCard: React.FC<HomeAwaySubCardProps> = ({ homeAway }) => {
   const theme = useTheme();
+
+  return (
+    <SubCard title="Home / Away">
+      <Box
+        display="flex"
+        alignItems="baseline"
+        justifyContent="space-between"
+        gap={1}
+        sx={{ py: 0.5 }}
+      >
+        <Typography variant="body2" fontWeight={500} color={theme.palette.text.primary}>
+          Home
+        </Typography>
+        <Box display="flex" alignItems="baseline" gap={1} sx={{ flexShrink: 0 }}>
+          <Typography
+            variant="body2"
+            fontWeight={700}
+            color={theme.palette.text.primary}
+            component="span"
+          >
+            {homeAway.home}
+          </Typography>
+          {homeAway.played.home > 0 || homeAway.home - homeAway.played.home > 0 ? (
+            <Typography
+              variant="caption"
+              color={theme.palette.widget.supportingText}
+              component="span"
+            >
+              ({homeAway.played.home} played · {homeAway.home - homeAway.played.home} upcoming)
+            </Typography>
+          ) : null}
+        </Box>
+      </Box>
+      <Box
+        display="flex"
+        alignItems="baseline"
+        justifyContent="space-between"
+        gap={1}
+        sx={{ py: 0.5 }}
+      >
+        <Typography variant="body2" fontWeight={500} color={theme.palette.text.primary}>
+          Away
+        </Typography>
+        <Box display="flex" alignItems="baseline" gap={1} sx={{ flexShrink: 0 }}>
+          <Typography
+            variant="body2"
+            fontWeight={700}
+            color={theme.palette.text.primary}
+            component="span"
+          >
+            {homeAway.away}
+          </Typography>
+          {homeAway.played.away > 0 || homeAway.away - homeAway.played.away > 0 ? (
+            <Typography
+              variant="caption"
+              color={theme.palette.widget.supportingText}
+              component="span"
+            >
+              ({homeAway.played.away} played · {homeAway.away - homeAway.played.away} upcoming)
+            </Typography>
+          ) : null}
+        </Box>
+      </Box>
+    </SubCard>
+  );
+};
+
+const SeasonSummaryWidget: React.FC<SeasonSummaryWidgetProps> = ({
+  summary,
+  loading,
+  ready,
+  games = [],
+  timeZone = 'UTC',
+}) => {
+  const theme = useTheme();
+  const [selectedField, setSelectedField] = useState<SelectedField | null>(null);
 
   if (!ready || loading || !summary || summary.totalGames === 0) {
     return null;
@@ -238,73 +431,101 @@ const SeasonSummaryWidget: React.FC<SeasonSummaryWidgetProps> = ({ summary, load
       ? `${summary.totalGames} games · ${summary.totalPlayed} played · ${summary.totalScheduled} upcoming`
       : `${summary.totalGames} games`;
 
+  const hasGames = games.length > 0;
+  const onFieldClick = hasGames ? setSelectedField : undefined;
+
   return (
-    <WidgetShell accent="primary" disablePadding sx={{ mb: 3 }}>
-      <Accordion
-        disableGutters
-        elevation={0}
-        square
-        sx={{
-          backgroundColor: 'transparent',
-          '&:before': { display: 'none' },
-        }}
-      >
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="season-summary-content"
-          id="season-summary-header"
+    <>
+      <WidgetShell accent="primary" disablePadding sx={{ mb: 3 }}>
+        <Accordion
+          disableGutters
+          elevation={0}
+          square
           sx={{
-            px: 3,
-            py: 1.5,
-            '& .MuiAccordionSummary-content': {
-              display: 'flex',
-              flexDirection: { xs: 'column', sm: 'row' },
-              alignItems: { xs: 'flex-start', sm: 'center' },
-              justifyContent: 'space-between',
-              gap: 1,
-              my: 0,
-            },
+            backgroundColor: 'transparent',
+            '&:before': { display: 'none' },
           }}
         >
-          <Typography variant="h6" fontWeight={700} color={theme.palette.widget.headerText}>
-            Season Summary
-          </Typography>
-          <Typography variant="body2" color={theme.palette.widget.supportingText}>
-            {subtitle}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails sx={{ px: 3, pt: 0, pb: 3 }}>
-          <Box
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="season-summary-content"
+            id="season-summary-header"
             sx={{
-              display: 'flex',
-              flexDirection: { xs: 'column', md: 'row' },
-              gap: { xs: 2, md: 3 },
-              alignItems: 'stretch',
+              px: 3,
+              py: 1.5,
+              '& .MuiAccordionSummary-content': {
+                display: 'flex',
+                flexDirection: { xs: 'column', sm: 'row' },
+                alignItems: { xs: 'flex-start', sm: 'center' },
+                justifyContent: 'space-between',
+                gap: 1,
+                my: 0,
+              },
             }}
           >
-            <SubCard title="Fields">{renderFields(summary.byField)}</SubCard>
-            <Divider
-              orientation="vertical"
-              flexItem
+            <Typography variant="h6" fontWeight={700} color={theme.palette.widget.headerText}>
+              Season Summary
+            </Typography>
+            <Typography variant="body2" color={theme.palette.widget.supportingText}>
+              {subtitle}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 3, pt: 0, pb: 3 }}>
+            <Box
               sx={{
-                display: { xs: 'none', md: 'block' },
-                borderColor: theme.palette.widget.border,
+                display: 'flex',
+                flexDirection: { xs: 'column', md: 'row' },
+                gap: { xs: 2, md: 3 },
+                alignItems: 'stretch',
               }}
-            />
-            <SubCard title="Day of Week">{renderDayType(summary.byDayType)}</SubCard>
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{
-                display: { xs: 'none', md: 'block' },
-                borderColor: theme.palette.widget.border,
-              }}
-            />
-            <SubCard title="Start Time">{renderStartTime(summary.byStartTime)}</SubCard>
-          </Box>
-        </AccordionDetails>
-      </Accordion>
-    </WidgetShell>
+            >
+              {summary.homeAway ? (
+                <>
+                  <HomeAwaySubCard homeAway={summary.homeAway} />
+                  <Divider
+                    orientation="vertical"
+                    flexItem
+                    sx={{
+                      display: { xs: 'none', md: 'block' },
+                      borderColor: theme.palette.widget.border,
+                    }}
+                  />
+                </>
+              ) : null}
+              <SubCard title="Fields">{renderFields(summary.byField, onFieldClick)}</SubCard>
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{
+                  display: { xs: 'none', md: 'block' },
+                  borderColor: theme.palette.widget.border,
+                }}
+              />
+              <SubCard title="Day of Week">{renderDayType(summary.byDayType)}</SubCard>
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{
+                  display: { xs: 'none', md: 'block' },
+                  borderColor: theme.palette.widget.border,
+                }}
+              />
+              <SubCard title="Start Time">{renderStartTime(summary.byStartTime)}</SubCard>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </WidgetShell>
+      {hasGames ? (
+        <FieldDatesDialog
+          open={selectedField !== null}
+          onClose={() => setSelectedField(null)}
+          fieldId={selectedField?.id ?? null}
+          fieldName={selectedField?.name ?? ''}
+          games={games}
+          timeZone={timeZone}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
@@ -219,6 +219,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, onFieldClick }) => {
   const nameCell = onFieldClick ? (
     <Link
       component="button"
+      type="button"
       variant="body2"
       fontWeight={500}
       color={theme.palette.text.primary}

--- a/draco-nodejs/frontend-next/components/schedule/__tests__/FieldDatesDialog.test.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/__tests__/FieldDatesDialog.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import FieldDatesDialog from '../FieldDatesDialog';
+import { GameStatus } from '@/types/schedule';
+import type { Game } from '@/types/schedule';
+
+const makeGame = (overrides: Partial<Game> & { id: string; gameDate: string }): Game => ({
+  id: overrides.id,
+  gameDate: overrides.gameDate,
+  homeTeamId: overrides.homeTeamId ?? 'home-team',
+  homeTeamName: overrides.homeTeamName ?? 'Home Team',
+  visitorTeamId: overrides.visitorTeamId ?? 'visitor-team',
+  visitorTeamName: overrides.visitorTeamName ?? 'Visitor Team',
+  homeScore: overrides.homeScore ?? 0,
+  visitorScore: overrides.visitorScore ?? 0,
+  comment: overrides.comment ?? '',
+  gameStatus: overrides.gameStatus ?? GameStatus.Scheduled,
+  gameStatusText: overrides.gameStatusText ?? '',
+  gameStatusShortText: overrides.gameStatusShortText ?? '',
+  gameType: overrides.gameType ?? 0,
+  fieldId: overrides.fieldId,
+  field: overrides.field,
+  league: overrides.league ?? { id: 'l1', name: 'League' },
+  season: overrides.season ?? { id: 's1', name: 'Season' },
+});
+
+const FIELD_A_ID = 'field-a';
+const FIELD_B_ID = 'field-b';
+
+const gameAtFieldA1 = makeGame({
+  id: 'g1',
+  gameDate: '2024-06-15T19:00:00Z',
+  field: { id: FIELD_A_ID, name: 'Field A', shortName: 'FA', address: '', city: '', state: '' },
+  homeTeamName: 'Alpha',
+  visitorTeamName: 'Beta',
+});
+
+const gameAtFieldA2 = makeGame({
+  id: 'g2',
+  gameDate: '2024-06-10T19:00:00Z',
+  field: { id: FIELD_A_ID, name: 'Field A', shortName: 'FA', address: '', city: '', state: '' },
+  homeTeamName: 'Gamma',
+  visitorTeamName: 'Delta',
+});
+
+const gameAtFieldB = makeGame({
+  id: 'g3',
+  gameDate: '2024-06-12T19:00:00Z',
+  field: { id: FIELD_B_ID, name: 'Field B', shortName: 'FB', address: '', city: '', state: '' },
+  homeTeamName: 'Epsilon',
+  visitorTeamName: 'Zeta',
+});
+
+const allGames = [gameAtFieldA1, gameAtFieldA2, gameAtFieldB];
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  fieldId: FIELD_A_ID,
+  fieldName: 'Field A',
+  games: allGames,
+  timeZone: 'UTC',
+};
+
+describe('FieldDatesDialog', () => {
+  describe('game filtering', () => {
+    it('renders only games matching the given fieldId', () => {
+      render(<FieldDatesDialog {...defaultProps} />);
+
+      expect(screen.getByText('Alpha vs Beta')).toBeInTheDocument();
+      expect(screen.getByText('Gamma vs Delta')).toBeInTheDocument();
+      expect(screen.queryByText('Epsilon vs Zeta')).not.toBeInTheDocument();
+    });
+
+    it('excludes games at other fields', () => {
+      render(<FieldDatesDialog {...defaultProps} />);
+
+      expect(screen.queryByText('Epsilon vs Zeta')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sort order', () => {
+    it('renders games in ascending date order', () => {
+      render(<FieldDatesDialog {...defaultProps} />);
+
+      const rows = screen.getAllByText(/vs/);
+      expect(rows[0]).toHaveTextContent('Gamma vs Delta');
+      expect(rows[1]).toHaveTextContent('Alpha vs Beta');
+    });
+  });
+
+  describe('time formatting', () => {
+    it('formats time using the provided timeZone', () => {
+      render(
+        <FieldDatesDialog {...defaultProps} games={[gameAtFieldA1]} timeZone="America/New_York" />,
+      );
+
+      expect(screen.getByText('3:00 PM')).toBeInTheDocument();
+    });
+
+    it('formats time in UTC when timeZone is UTC', () => {
+      render(<FieldDatesDialog {...defaultProps} games={[gameAtFieldA1]} timeZone="UTC" />);
+
+      expect(screen.getByText('7:00 PM')).toBeInTheDocument();
+    });
+  });
+
+  describe('null fieldId', () => {
+    it('does not render content when fieldId is null and no matching games exist', () => {
+      const noFieldGames = [gameAtFieldA1, gameAtFieldA2];
+      render(
+        <FieldDatesDialog
+          {...defaultProps}
+          fieldId={null}
+          fieldName="No Field / TBD"
+          games={noFieldGames}
+        />,
+      );
+
+      expect(screen.getByText('No games found for this field.')).toBeInTheDocument();
+    });
+
+    it('renders games with no field assignment when fieldId is null', () => {
+      const noFieldGame = makeGame({
+        id: 'gx',
+        gameDate: '2024-07-01T18:00:00Z',
+        homeTeamName: 'Team X',
+        visitorTeamName: 'Team Y',
+      });
+
+      render(
+        <FieldDatesDialog
+          {...defaultProps}
+          fieldId={null}
+          fieldName="No Field / TBD"
+          games={[noFieldGame, gameAtFieldA1]}
+        />,
+      );
+
+      expect(screen.getByText('Team X vs Team Y')).toBeInTheDocument();
+      expect(screen.queryByText('Alpha vs Beta')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('formatResult', () => {
+    it('renders Upcoming for a scheduled game', () => {
+      const scheduledGame = makeGame({
+        id: 'g-sched',
+        gameDate: '2024-08-01T18:00:00Z',
+        field: {
+          id: FIELD_A_ID,
+          name: 'Field A',
+          shortName: 'FA',
+          address: '',
+          city: '',
+          state: '',
+        },
+        gameStatus: GameStatus.Scheduled,
+        gameStatusText: '',
+        homeTeamName: 'TeamX',
+        visitorTeamName: 'TeamY',
+      });
+
+      render(<FieldDatesDialog {...defaultProps} games={[scheduledGame]} />);
+
+      expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    });
+
+    it('renders em dash when gameStatusText is empty string', () => {
+      const emptyStatusGame = makeGame({
+        id: 'g-empty',
+        gameDate: '2024-08-01T18:00:00Z',
+        field: {
+          id: FIELD_A_ID,
+          name: 'Field A',
+          shortName: 'FA',
+          address: '',
+          city: '',
+          state: '',
+        },
+        gameStatus: GameStatus.Completed,
+        gameStatusText: '',
+        homeTeamName: 'TeamA',
+        visitorTeamName: 'TeamB',
+      });
+
+      render(<FieldDatesDialog {...defaultProps} games={[emptyStatusGame]} />);
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  describe('onClose wiring', () => {
+    it('calls onClose when Escape key is pressed', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+
+      render(<FieldDatesDialog {...defaultProps} onClose={onClose} />);
+
+      await user.keyboard('{Escape}');
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the X button is clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+
+      render(<FieldDatesDialog {...defaultProps} onClose={onClose} />);
+
+      await user.click(screen.getByRole('button', { name: 'close' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/__tests__/SchedulePrintView.test.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/__tests__/SchedulePrintView.test.tsx
@@ -1,0 +1,389 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SchedulePrintView from '../SchedulePrintView';
+import { GameStatus } from '@/types/schedule';
+import type { Game } from '@/types/schedule';
+
+const makeGame = (overrides: Partial<Game> & { id: string; gameDate: string }): Game => ({
+  id: overrides.id,
+  gameDate: overrides.gameDate,
+  homeTeamId: overrides.homeTeamId ?? 'home-team',
+  homeTeamName: overrides.homeTeamName ?? 'Home Team',
+  visitorTeamId: overrides.visitorTeamId ?? 'visitor-team',
+  visitorTeamName: overrides.visitorTeamName ?? 'Visitor Team',
+  homeScore: overrides.homeScore ?? 0,
+  visitorScore: overrides.visitorScore ?? 0,
+  comment: overrides.comment ?? '',
+  gameStatus: overrides.gameStatus ?? GameStatus.Scheduled,
+  gameStatusText: overrides.gameStatusText ?? 'Scheduled',
+  gameStatusShortText: overrides.gameStatusShortText ?? '',
+  gameType: overrides.gameType ?? 0,
+  fieldId: overrides.fieldId,
+  field: overrides.field,
+  league: overrides.league ?? { id: 'l1', name: 'Test League' },
+  season: overrides.season ?? { id: 's1', name: 'Season 1' },
+});
+
+const gameDay1a = makeGame({
+  id: 'g1',
+  gameDate: '2024-06-15T19:00:00Z',
+  homeTeamName: 'Alpha',
+  visitorTeamName: 'Beta',
+  gameStatusText: 'Scheduled',
+  league: { id: 'l1', name: 'Weekday League' },
+  field: { id: 'f1', name: 'Central Park', shortName: 'CP', address: '', city: '', state: '' },
+});
+
+const gameDay1b = makeGame({
+  id: 'g2',
+  gameDate: '2024-06-15T21:00:00Z',
+  homeTeamName: 'Gamma',
+  visitorTeamName: 'Delta',
+  gameStatusText: 'Scheduled',
+  league: { id: 'l2', name: 'Night League' },
+});
+
+const gameDay2 = makeGame({
+  id: 'g3',
+  gameDate: '2024-06-20T18:00:00Z',
+  homeTeamName: 'Epsilon',
+  visitorTeamName: 'Zeta',
+  gameStatusText: 'Scheduled',
+  league: { id: 'l1', name: 'Weekday League' },
+});
+
+describe('SchedulePrintView', () => {
+  describe('empty games array', () => {
+    it('renders without crashing when games array is empty', () => {
+      render(<SchedulePrintView games={[]} title="Test Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Test Schedule')).toBeInTheDocument();
+    });
+
+    it('shows "No games to display." message when games array is empty', () => {
+      render(<SchedulePrintView games={[]} title="Test Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('No games to display.')).toBeInTheDocument();
+    });
+
+    it('does not render a table when games array is empty', () => {
+      render(<SchedulePrintView games={[]} title="Test Schedule" timeZone="UTC" />);
+
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('grouping by date', () => {
+    it('renders a date heading for each unique date', () => {
+      render(
+        <SchedulePrintView
+          games={[gameDay1a, gameDay1b, gameDay2]}
+          title="Schedule"
+          timeZone="UTC"
+        />,
+      );
+
+      const headings = screen.getAllByRole('heading', { level: 2, hidden: true });
+      expect(headings).toHaveLength(2);
+    });
+
+    it('groups games from the same date under one heading', () => {
+      render(
+        <SchedulePrintView
+          games={[gameDay1a, gameDay1b, gameDay2]}
+          title="Schedule"
+          timeZone="UTC"
+        />,
+      );
+
+      expect(screen.getByText('Alpha vs Beta')).toBeInTheDocument();
+      expect(screen.getByText('Gamma vs Delta')).toBeInTheDocument();
+      expect(screen.getByText('Epsilon vs Zeta')).toBeInTheDocument();
+    });
+  });
+
+  describe('ascending sort order', () => {
+    it('sorts games in ascending order across dates', () => {
+      const laterGame = makeGame({
+        id: 'late',
+        gameDate: '2024-07-01T18:00:00Z',
+        homeTeamName: 'Last',
+        visitorTeamName: 'Also Last',
+        gameStatusText: 'Scheduled',
+      });
+      const earlierGame = makeGame({
+        id: 'early',
+        gameDate: '2024-05-01T18:00:00Z',
+        homeTeamName: 'First',
+        visitorTeamName: 'Also First',
+        gameStatusText: 'Scheduled',
+      });
+
+      render(
+        <SchedulePrintView games={[laterGame, earlierGame]} title="Schedule" timeZone="UTC" />,
+      );
+
+      const matchups = screen.getAllByText(/vs/);
+      expect(matchups[0]).toHaveTextContent('First vs Also First');
+      expect(matchups[1]).toHaveTextContent('Last vs Also Last');
+    });
+
+    it('sorts games within the same date in ascending time order', () => {
+      render(<SchedulePrintView games={[gameDay1b, gameDay1a]} title="Schedule" timeZone="UTC" />);
+
+      const matchups = screen.getAllByText(/vs/);
+      expect(matchups[0]).toHaveTextContent('Alpha vs Beta');
+      expect(matchups[1]).toHaveTextContent('Gamma vs Delta');
+    });
+  });
+
+  describe('time formatting', () => {
+    it('formats game time using the provided timeZone', () => {
+      render(
+        <SchedulePrintView games={[gameDay1a]} title="Schedule" timeZone="America/New_York" />,
+      );
+
+      expect(screen.getByText('3:00 PM')).toBeInTheDocument();
+    });
+
+    it('formats game time in UTC when timeZone is UTC', () => {
+      render(<SchedulePrintView games={[gameDay1a]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('7:00 PM')).toBeInTheDocument();
+    });
+  });
+
+  describe('status text', () => {
+    it('renders game status text', () => {
+      const postponedGame = makeGame({
+        id: 'p1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Postponed,
+        gameStatusText: 'Postponed',
+      });
+
+      render(<SchedulePrintView games={[postponedGame]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Postponed')).toBeInTheDocument();
+    });
+  });
+
+  describe('score display for played statuses', () => {
+    it('appends score for Completed status (1)', () => {
+      const completedGame = makeGame({
+        id: 'c1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Completed,
+        gameStatusText: 'Final',
+        homeScore: 5,
+        visitorScore: 3,
+      });
+
+      render(<SchedulePrintView games={[completedGame]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Final · 5–3')).toBeInTheDocument();
+    });
+
+    it('appends score for Forfeit status (4)', () => {
+      const forfeitGame = makeGame({
+        id: 'f1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Forfeit,
+        gameStatusText: 'Forfeit',
+        homeScore: 7,
+        visitorScore: 0,
+      });
+
+      render(<SchedulePrintView games={[forfeitGame]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Forfeit · 7–0')).toBeInTheDocument();
+    });
+
+    it('appends score for DidNotReport status (5)', () => {
+      const dnrGame = makeGame({
+        id: 'd1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.DidNotReport,
+        gameStatusText: 'Did Not Report',
+        homeScore: 0,
+        visitorScore: 0,
+      });
+
+      render(<SchedulePrintView games={[dnrGame]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Did Not Report · 0–0')).toBeInTheDocument();
+    });
+  });
+
+  describe('score NOT displayed for unplayed statuses', () => {
+    it('does not append score for Scheduled status (0)', () => {
+      const game = makeGame({
+        id: 's1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+        gameStatusText: 'Scheduled',
+        homeScore: 0,
+        visitorScore: 0,
+      });
+
+      render(<SchedulePrintView games={[game]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Scheduled')).toBeInTheDocument();
+      expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+    });
+
+    it('does not append score for Rainout status (2)', () => {
+      const game = makeGame({
+        id: 'r1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Rainout,
+        gameStatusText: 'Rainout',
+        homeScore: 0,
+        visitorScore: 0,
+      });
+
+      render(<SchedulePrintView games={[game]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Rainout')).toBeInTheDocument();
+      expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+    });
+
+    it('does not append score for Postponed status (3)', () => {
+      const game = makeGame({
+        id: 'pp1',
+        gameDate: '2024-06-15T19:00:00Z',
+        gameStatus: GameStatus.Postponed,
+        gameStatusText: 'Postponed',
+        homeScore: 0,
+        visitorScore: 0,
+      });
+
+      render(<SchedulePrintView games={[game]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Postponed')).toBeInTheDocument();
+      expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('field display', () => {
+    it('shows field name when field is present', () => {
+      const gameWithField = makeGame({
+        id: 'gf1',
+        gameDate: '2024-06-15T19:00:00Z',
+        field: {
+          id: 'f1',
+          name: 'Veterans Field',
+          shortName: 'VF',
+          address: '',
+          city: '',
+          state: '',
+        },
+      });
+
+      render(<SchedulePrintView games={[gameWithField]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Veterans Field')).toBeInTheDocument();
+    });
+
+    it('shows "TBD" when game has no field', () => {
+      const gameNoField = makeGame({
+        id: 'gnf1',
+        gameDate: '2024-06-15T19:00:00Z',
+        fieldId: undefined,
+        field: undefined,
+      });
+
+      render(<SchedulePrintView games={[gameNoField]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('TBD')).toBeInTheDocument();
+    });
+
+    it('falls back to shortName when name is absent', () => {
+      const gameShortNameOnly = makeGame({
+        id: 'gsn1',
+        gameDate: '2024-06-15T19:00:00Z',
+        field: {
+          id: 'f2',
+          name: '',
+          shortName: 'NF',
+          address: '',
+          city: '',
+          state: '',
+        },
+      });
+
+      render(<SchedulePrintView games={[gameShortNameOnly]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('NF')).toBeInTheDocument();
+    });
+  });
+
+  describe('matchup display', () => {
+    it('uses team names when available', () => {
+      render(<SchedulePrintView games={[gameDay1a]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Alpha vs Beta')).toBeInTheDocument();
+    });
+
+    it('falls back to teamId when name is absent', () => {
+      const game: Game = {
+        id: 'gid1',
+        gameDate: '2024-06-15T19:00:00Z',
+        homeTeamId: 'team-id-123',
+        visitorTeamId: 'team-id-456',
+        homeScore: 0,
+        visitorScore: 0,
+        comment: '',
+        gameStatus: GameStatus.Scheduled,
+        gameStatusText: 'Scheduled',
+        gameStatusShortText: '',
+        gameType: 0,
+        league: { id: 'l1', name: 'Test League' },
+        season: { id: 's1', name: 'Season 1' },
+      };
+
+      render(<SchedulePrintView games={[game]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('team-id-123 vs team-id-456')).toBeInTheDocument();
+    });
+  });
+
+  describe('title and subtitle', () => {
+    it('renders the title', () => {
+      render(<SchedulePrintView games={[]} title="My League Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('My League Schedule')).toBeInTheDocument();
+    });
+
+    it('renders subtitle when provided', () => {
+      render(
+        <SchedulePrintView
+          games={[]}
+          title="My League Schedule"
+          subtitle="Spring 2024"
+          timeZone="UTC"
+        />,
+      );
+
+      expect(screen.getByText('Spring 2024')).toBeInTheDocument();
+    });
+
+    it('does not render subtitle text when subtitle prop is absent', () => {
+      render(<SchedulePrintView games={[gameDay1a]} title="My League Schedule" timeZone="UTC" />);
+
+      const subtitleCandidates = screen.queryAllByText(
+        (_, el) => el?.tagName === 'P' && el.textContent !== 'No games to display.',
+      );
+      expect(subtitleCandidates).toHaveLength(0);
+    });
+  });
+
+  describe('league name display', () => {
+    it('renders league name in the table', () => {
+      render(<SchedulePrintView games={[gameDay1a]} title="Schedule" timeZone="UTC" />);
+
+      expect(screen.getByText('Weekday League')).toBeInTheDocument();
+    });
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
@@ -125,6 +125,9 @@ export const useScheduleData = ({
   const [loadingGames, setLoadingGames] = useState(false);
   const [loadingStaticData, setLoadingStaticData] = useState(true);
 
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
   const { startDate, endDate } = computeDateRange(filterType, filterDate);
 
   useEffect(() => {
@@ -281,7 +284,7 @@ export const useScheduleData = ({
       lastRangeRef.current = { start: startDate.getTime(), end: endDate.getTime() };
     } catch (err) {
       console.error('Failed to load games:', err);
-      onError?.('Unable to load games. Please refresh the page.');
+      onErrorRef.current?.('Unable to load games. Please refresh the page.');
     } finally {
       setLoadingGames(false);
     }
@@ -415,7 +418,7 @@ export const useScheduleData = ({
       } catch (err: unknown) {
         if (controller.signal.aborted) return;
         console.error('Failed to load static data:', err);
-        onError?.('Unable to load schedule data. Please refresh the page.');
+        onErrorRef.current?.('Unable to load schedule data. Please refresh the page.');
       } finally {
         if (!controller.signal.aborted) {
           setLoadingStaticData(false);
@@ -428,7 +431,7 @@ export const useScheduleData = ({
     return () => {
       controller.abort();
     };
-  }, [authLoading, accountId, apiClient, adapter, onError]);
+  }, [authLoading, accountId, apiClient, adapter]);
 
   useEffect(() => {
     if (authLoading) {
@@ -499,7 +502,7 @@ export const useScheduleData = ({
       } catch (err) {
         if (controller.signal.aborted) return;
         console.error('Failed to load games:', err);
-        onError?.('Unable to load games. Please refresh the page.');
+        onErrorRef.current?.('Unable to load games. Please refresh the page.');
       } finally {
         if (!controller.signal.aborted) {
           setLoadingGames(false);
@@ -512,7 +515,7 @@ export const useScheduleData = ({
     return () => {
       controller.abort();
     };
-  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate, onError]);
+  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate]);
 
   const filteredGames = games;
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useTeamSeasonSummary.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useTeamSeasonSummary.ts
@@ -2,16 +2,17 @@ import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '../../../context/AuthContext';
 import { useApiClient } from '../../../hooks/useApiClient';
 import { getSportAdapter } from '../adapters';
-import { Game, GameStatus } from '@/types/schedule';
-import { convertUTCToZonedDate } from '../../../utils/dateUtils';
+import { Game } from '@/types/schedule';
+import { buildScheduleSummary } from '../utils/buildScheduleSummary';
 
 export type StartTimeBucket = 'morning' | 'afternoon' | 'earlyEvening' | 'lateEvening' | 'night';
 
 export interface FieldSummary {
   fieldId: string | null;
   fieldName: string;
+  upcoming: number;
   played: number;
-  scheduled: number;
+  notPlayed: number;
 }
 
 export interface DayTypeCounts {
@@ -32,6 +33,7 @@ export interface SeasonSummary {
   byField: FieldSummary[];
   byDayType: { weekday: DayTypeCounts; weekend: DayTypeCounts };
   byStartTime: StartTimeSummary[];
+  homeAway?: { home: number; away: number; played: { home: number; away: number } };
 }
 
 interface UseTeamSeasonSummaryProps {
@@ -48,143 +50,8 @@ interface UseTeamSeasonSummaryProps {
 interface UseTeamSeasonSummaryReturn {
   summary: SeasonSummary | null;
   loading: boolean;
+  games: Game[];
 }
-
-const NO_FIELD_KEY = '__no_field__';
-const NO_FIELD_LABEL = 'No Field / TBD';
-
-const normalizeFieldId = (value?: string | null): string | undefined => {
-  if (typeof value === 'string' && value.trim().length > 0) {
-    return value;
-  }
-  return undefined;
-};
-
-const isPlayedStatus = (status: number): boolean => {
-  return (
-    status === GameStatus.Completed ||
-    status === GameStatus.Forfeit ||
-    status === GameStatus.DidNotReport
-  );
-};
-
-const isExcludedStatus = (status: number): boolean => {
-  return status === GameStatus.Rainout || status === GameStatus.Postponed;
-};
-
-const bucketForHour = (hour: number): StartTimeBucket => {
-  if (hour < 12) return 'morning';
-  if (hour < 16) return 'afternoon';
-  if (hour < 19) return 'earlyEvening';
-  if (hour < 22) return 'lateEvening';
-  return 'night';
-};
-
-const BUCKET_ORDER: StartTimeBucket[] = [
-  'morning',
-  'afternoon',
-  'earlyEvening',
-  'lateEvening',
-  'night',
-];
-
-const buildSummary = (games: Game[], timeZone: string): SeasonSummary => {
-  const fieldMap = new Map<string, FieldSummary>();
-  const dayType = {
-    weekday: { played: 0, scheduled: 0 } as DayTypeCounts,
-    weekend: { played: 0, scheduled: 0 } as DayTypeCounts,
-  };
-  const bucketMap = new Map<StartTimeBucket, StartTimeSummary>();
-
-  let totalPlayed = 0;
-  let totalScheduled = 0;
-
-  for (const game of games) {
-    if (isExcludedStatus(game.gameStatus)) {
-      continue;
-    }
-
-    const played = isPlayedStatus(game.gameStatus);
-
-    if (played) {
-      totalPlayed += 1;
-    } else {
-      totalScheduled += 1;
-    }
-
-    const fieldKey =
-      normalizeFieldId(game.field?.id) ?? normalizeFieldId(game.fieldId) ?? NO_FIELD_KEY;
-    const fieldName =
-      game.field?.name ||
-      game.field?.shortName ||
-      (fieldKey === NO_FIELD_KEY ? NO_FIELD_LABEL : '');
-
-    const existingField = fieldMap.get(fieldKey);
-    if (existingField) {
-      if (played) {
-        existingField.played += 1;
-      } else {
-        existingField.scheduled += 1;
-      }
-    } else {
-      fieldMap.set(fieldKey, {
-        fieldId: fieldKey === NO_FIELD_KEY ? null : fieldKey,
-        fieldName: fieldName || NO_FIELD_LABEL,
-        played: played ? 1 : 0,
-        scheduled: played ? 0 : 1,
-      });
-    }
-
-    const zoned = convertUTCToZonedDate(game.gameDate, timeZone);
-    if (!zoned) {
-      continue;
-    }
-
-    const day = zoned.getDay();
-    const isWeekend = day === 0 || day === 6;
-    const dayBucket = isWeekend ? dayType.weekend : dayType.weekday;
-    if (played) {
-      dayBucket.played += 1;
-    } else {
-      dayBucket.scheduled += 1;
-    }
-
-    const bucket = bucketForHour(zoned.getHours());
-    const existingBucket = bucketMap.get(bucket);
-    if (existingBucket) {
-      if (played) {
-        existingBucket.played += 1;
-      } else {
-        existingBucket.scheduled += 1;
-      }
-    } else {
-      bucketMap.set(bucket, {
-        bucket,
-        played: played ? 1 : 0,
-        scheduled: played ? 0 : 1,
-      });
-    }
-  }
-
-  const byField = Array.from(fieldMap.values()).sort((a, b) => {
-    const totalDiff = b.played + b.scheduled - (a.played + a.scheduled);
-    if (totalDiff !== 0) return totalDiff;
-    return a.fieldName.localeCompare(b.fieldName);
-  });
-
-  const byStartTime = BUCKET_ORDER.filter((bucket) => bucketMap.has(bucket)).map(
-    (bucket) => bucketMap.get(bucket)!,
-  );
-
-  return {
-    totalGames: totalPlayed + totalScheduled,
-    totalPlayed,
-    totalScheduled,
-    byField,
-    byDayType: dayType,
-    byStartTime,
-  };
-};
 
 const addDays = (date: Date, days: number): Date => {
   const next = new Date(date);
@@ -211,6 +78,7 @@ export const useTeamSeasonSummary = ({
 
   const [summary, setSummary] = useState<SeasonSummary | null>(null);
   const [loading, setLoading] = useState(false);
+  const [games, setGames] = useState<Game[]>([]);
 
   const earliestTime = earliestGameDate ? earliestGameDate.getTime() : null;
   const latestTime = latestGameDate ? latestGameDate.getTime() : null;
@@ -221,12 +89,14 @@ export const useTeamSeasonSummary = ({
     }
 
     if (typeof adapter.loadTeamGames !== 'function') {
+      setGames([]);
       setSummary(null);
       setLoading(false);
       return;
     }
 
     if (earliestTime === null || latestTime === null) {
+      setGames([]);
       setSummary(null);
       setLoading(false);
       return;
@@ -240,7 +110,7 @@ export const useTeamSeasonSummary = ({
     const runLoadSummary = async () => {
       try {
         setLoading(true);
-        const games = await adapter.loadTeamGames!({
+        const loadedGames: Game[] = await adapter.loadTeamGames!({
           accountId,
           seasonId,
           teamSeasonId,
@@ -250,11 +120,13 @@ export const useTeamSeasonSummary = ({
           signal: controller.signal,
         });
         if (controller.signal.aborted) return;
-        setSummary(buildSummary(games, timeZone));
+        setGames(loadedGames);
+        setSummary(buildScheduleSummary(loadedGames, { timeZone, teamSeasonId }));
       } catch (err) {
         if (controller.signal.aborted) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
         console.error('Failed to load team season summary:', err);
+        setGames([]);
         setSummary(null);
         onErrorRef.current?.('Unable to load season summary.');
       } finally {
@@ -281,5 +153,5 @@ export const useTeamSeasonSummary = ({
     timeZone,
   ]);
 
-  return { summary, loading };
+  return { summary, loading, games };
 };

--- a/draco-nodejs/frontend-next/components/schedule/utils/__tests__/buildScheduleSummary.test.ts
+++ b/draco-nodejs/frontend-next/components/schedule/utils/__tests__/buildScheduleSummary.test.ts
@@ -1,0 +1,668 @@
+import { describe, it, expect } from 'vitest';
+import { buildScheduleSummary } from '../buildScheduleSummary';
+import { GameStatus } from '@/types/schedule';
+import type { Game } from '@/types/schedule';
+
+const UTC = 'UTC';
+
+const makeGame = (overrides: Partial<Game> & { gameDate: string }): Game => ({
+  id: overrides.id ?? 'g1',
+  gameDate: overrides.gameDate,
+  homeTeamId: overrides.homeTeamId ?? 'home-team',
+  visitorTeamId: overrides.visitorTeamId ?? 'away-team',
+  homeScore: overrides.homeScore ?? 0,
+  visitorScore: overrides.visitorScore ?? 0,
+  comment: overrides.comment ?? '',
+  gameStatus: overrides.gameStatus ?? GameStatus.Scheduled,
+  gameStatusText: overrides.gameStatusText ?? '',
+  gameStatusShortText: overrides.gameStatusShortText ?? '',
+  gameType: overrides.gameType ?? 0,
+  fieldId: overrides.fieldId,
+  field: overrides.field,
+  league: overrides.league ?? { id: 'l1', name: 'League' },
+  season: overrides.season ?? { id: 's1', name: 'Season' },
+});
+
+describe('buildScheduleSummary', () => {
+  describe('empty input', () => {
+    it('returns zeroed summary for empty game list', () => {
+      const result = buildScheduleSummary([], { timeZone: UTC });
+      expect(result.totalGames).toBe(0);
+      expect(result.totalPlayed).toBe(0);
+      expect(result.totalScheduled).toBe(0);
+      expect(result.byField).toHaveLength(0);
+      expect(result.byStartTime).toHaveLength(0);
+      expect(result.byDayType.weekday.played).toBe(0);
+      expect(result.byDayType.weekday.scheduled).toBe(0);
+      expect(result.byDayType.weekend.played).toBe(0);
+      expect(result.byDayType.weekend.scheduled).toBe(0);
+    });
+
+    it('does not populate homeAway when teamSeasonId is not set', () => {
+      const result = buildScheduleSummary([], { timeZone: UTC });
+      expect(result.homeAway).toBeUndefined();
+    });
+  });
+
+  describe('status classification', () => {
+    it('counts Completed, Forfeit, and DidNotReport as played', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T19:00:00Z', gameStatus: GameStatus.Completed }),
+        makeGame({ id: 'g2', gameDate: '2024-06-11T19:00:00Z', gameStatus: GameStatus.Forfeit }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.DidNotReport,
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.totalPlayed).toBe(3);
+      expect(result.totalScheduled).toBe(0);
+      expect(result.totalGames).toBe(3);
+    });
+
+    it('counts Scheduled as upcoming (not played)', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.totalPlayed).toBe(0);
+      expect(result.totalScheduled).toBe(1);
+      expect(result.totalGames).toBe(1);
+    });
+
+    it('excludes Rainout and Postponed from totalGames/played/scheduled but not byField', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T19:00:00Z', gameStatus: GameStatus.Rainout }),
+        makeGame({ id: 'g2', gameDate: '2024-06-11T19:00:00Z', gameStatus: GameStatus.Postponed }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.totalGames).toBe(0);
+      expect(result.totalPlayed).toBe(0);
+      expect(result.totalScheduled).toBe(0);
+      expect(result.byStartTime).toHaveLength(0);
+      expect(result.byField).toHaveLength(1);
+      const field = result.byField[0];
+      expect(field.notPlayed).toBe(2);
+      expect(field.played).toBe(0);
+      expect(field.upcoming).toBe(0);
+    });
+
+    it('handles a mix of all statuses correctly', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T19:00:00Z', gameStatus: GameStatus.Completed }),
+        makeGame({ id: 'g2', gameDate: '2024-06-11T19:00:00Z', gameStatus: GameStatus.Rainout }),
+        makeGame({ id: 'g3', gameDate: '2024-06-12T19:00:00Z', gameStatus: GameStatus.Postponed }),
+        makeGame({ id: 'g4', gameDate: '2024-06-13T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g5', gameDate: '2024-06-14T19:00:00Z', gameStatus: GameStatus.Forfeit }),
+        makeGame({
+          id: 'g6',
+          gameDate: '2024-06-15T19:00:00Z',
+          gameStatus: GameStatus.DidNotReport,
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.totalPlayed).toBe(3);
+      expect(result.totalScheduled).toBe(1);
+      expect(result.totalGames).toBe(4);
+    });
+  });
+
+  describe('field grouping', () => {
+    it('Scheduled contributes to the upcoming bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.upcoming).toBe(1);
+      expect(field!.played).toBe(0);
+      expect(field!.notPlayed).toBe(0);
+    });
+
+    it('Completed contributes to the played bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.played).toBe(1);
+      expect(field!.upcoming).toBe(0);
+      expect(field!.notPlayed).toBe(0);
+    });
+
+    it('DidNotReport contributes to the played bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.DidNotReport,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.played).toBe(1);
+      expect(field!.upcoming).toBe(0);
+      expect(field!.notPlayed).toBe(0);
+    });
+
+    it('Forfeit contributes to the played bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Forfeit,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.played).toBe(1);
+      expect(field!.upcoming).toBe(0);
+      expect(field!.notPlayed).toBe(0);
+    });
+
+    it('Postponed contributes to the notPlayed bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Postponed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.notPlayed).toBe(1);
+      expect(field!.upcoming).toBe(0);
+      expect(field!.played).toBe(0);
+    });
+
+    it('Rainout contributes to the notPlayed bucket', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Rainout,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field!.notPlayed).toBe(1);
+      expect(field!.upcoming).toBe(0);
+      expect(field!.played).toBe(0);
+    });
+
+    it('groups games by field id and uses three-bucket counts', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f2', name: 'Field B', shortName: 'B', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byField).toHaveLength(2);
+      const fieldA = result.byField.find((f) => f.fieldId === 'f1');
+      expect(fieldA).toBeDefined();
+      expect(fieldA!.upcoming).toBe(1);
+      expect(fieldA!.played).toBe(1);
+      expect(fieldA!.notPlayed).toBe(0);
+    });
+
+    it('uses NO_FIELD key when field is missing', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byField).toHaveLength(1);
+      expect(result.byField[0].fieldId).toBeNull();
+      expect(result.byField[0].fieldName).toBe('No Field / TBD');
+    });
+
+    it('uses fieldId fallback when field object is absent but fieldId is present', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          fieldId: 'f-direct',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byField[0].fieldId).toBe('f-direct');
+    });
+
+    it('sorts fields by total games descending (upcoming + played + notPlayed)', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f2', name: 'Field B', shortName: 'B', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Rainout,
+          field: { id: 'f2', name: 'Field B', shortName: 'B', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byField[0].fieldId).toBe('f2');
+      expect(result.byField[1].fieldId).toBe('f1');
+    });
+
+    it('field with more total ranks higher when bucket sums differ', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Forfeit,
+          field: { id: 'f2', name: 'Field B', shortName: 'B', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f2', name: 'Field B', shortName: 'B', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byField[0].fieldId).toBe('f2');
+      expect(result.byField[1].fieldId).toBe('f1');
+    });
+
+    it('reconciliation: upcoming + played + notPlayed equals total game count for that field', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Rainout,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g4',
+          gameDate: '2024-06-13T19:00:00Z',
+          gameStatus: GameStatus.Postponed,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g5',
+          gameDate: '2024-06-14T19:00:00Z',
+          gameStatus: GameStatus.Forfeit,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+        makeGame({
+          id: 'g6',
+          gameDate: '2024-06-15T19:00:00Z',
+          gameStatus: GameStatus.DidNotReport,
+          field: { id: 'f1', name: 'Field A', shortName: 'A', address: '', city: '', state: '' },
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const field = result.byField.find((f) => f.fieldId === 'f1');
+      expect(field).toBeDefined();
+      expect(field!.upcoming + field!.played + field!.notPlayed).toBe(6);
+      const headlineStatuses = new Set([
+        GameStatus.Scheduled,
+        GameStatus.Completed,
+        GameStatus.Forfeit,
+        GameStatus.DidNotReport,
+      ]);
+      const headlineCount = games.filter((g) => headlineStatuses.has(g.gameStatus)).length;
+      expect(field!.upcoming + field!.played).toBe(headlineCount);
+    });
+  });
+
+  describe('weekend vs weekday classification', () => {
+    it('classifies Monday–Friday as weekday', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g2', gameDate: '2024-06-11T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g3', gameDate: '2024-06-12T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g4', gameDate: '2024-06-13T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g5', gameDate: '2024-06-14T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byDayType.weekday.scheduled).toBe(5);
+      expect(result.byDayType.weekend.scheduled).toBe(0);
+    });
+
+    it('classifies Saturday and Sunday as weekend', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-15T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g2', gameDate: '2024-06-16T19:00:00Z', gameStatus: GameStatus.Scheduled }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.byDayType.weekend.scheduled).toBe(2);
+      expect(result.byDayType.weekday.scheduled).toBe(0);
+    });
+  });
+
+  describe('time bucket classification', () => {
+    it('classifies hour < 12 as morning', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T10:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      const morning = result.byStartTime.find((b) => b.bucket === 'morning');
+      expect(morning).toBeDefined();
+      expect(morning!.scheduled).toBe(1);
+    });
+
+    it('classifies hour 12–15 as afternoon', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T14:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      const afternoon = result.byStartTime.find((b) => b.bucket === 'afternoon');
+      expect(afternoon).toBeDefined();
+      expect(afternoon!.scheduled).toBe(1);
+    });
+
+    it('classifies hour 16–18 as earlyEvening', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T17:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      const early = result.byStartTime.find((b) => b.bucket === 'earlyEvening');
+      expect(early).toBeDefined();
+      expect(early!.scheduled).toBe(1);
+    });
+
+    it('classifies hour 19–21 as lateEvening', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T20:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      const late = result.byStartTime.find((b) => b.bucket === 'lateEvening');
+      expect(late).toBeDefined();
+      expect(late!.scheduled).toBe(1);
+    });
+
+    it('classifies hour >= 22 as night', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T22:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      const night = result.byStartTime.find((b) => b.bucket === 'night');
+      expect(night).toBeDefined();
+      expect(night!.scheduled).toBe(1);
+    });
+
+    it('boundary: hour exactly 12 is afternoon not morning', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T12:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      expect(result.byStartTime.find((b) => b.bucket === 'morning')).toBeUndefined();
+      const afternoon = result.byStartTime.find((b) => b.bucket === 'afternoon');
+      expect(afternoon).toBeDefined();
+    });
+
+    it('boundary: hour exactly 16 is earlyEvening not afternoon', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T16:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      expect(result.byStartTime.find((b) => b.bucket === 'afternoon')).toBeUndefined();
+      const early = result.byStartTime.find((b) => b.bucket === 'earlyEvening');
+      expect(early).toBeDefined();
+    });
+
+    it('boundary: hour exactly 19 is lateEvening not earlyEvening', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T19:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      expect(result.byStartTime.find((b) => b.bucket === 'earlyEvening')).toBeUndefined();
+      const late = result.byStartTime.find((b) => b.bucket === 'lateEvening');
+      expect(late).toBeDefined();
+    });
+
+    it('boundary: hour exactly 22 is night not lateEvening', () => {
+      const game = makeGame({
+        id: 'g1',
+        gameDate: '2024-06-10T22:00:00Z',
+        gameStatus: GameStatus.Scheduled,
+      });
+      const result = buildScheduleSummary([game], { timeZone: UTC });
+      expect(result.byStartTime.find((b) => b.bucket === 'lateEvening')).toBeUndefined();
+      const night = result.byStartTime.find((b) => b.bucket === 'night');
+      expect(night).toBeDefined();
+    });
+
+    it('returns buckets in canonical order', () => {
+      const games = [
+        makeGame({ id: 'g1', gameDate: '2024-06-10T22:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g2', gameDate: '2024-06-11T10:00:00Z', gameStatus: GameStatus.Scheduled }),
+        makeGame({ id: 'g3', gameDate: '2024-06-12T17:00:00Z', gameStatus: GameStatus.Scheduled }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      const buckets = result.byStartTime.map((b) => b.bucket);
+      expect(buckets).toEqual(['morning', 'earlyEvening', 'night']);
+    });
+  });
+
+  describe('homeAway — Item 2', () => {
+    it('is undefined when teamSeasonId is not provided', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          homeTeamId: 'team-a',
+          visitorTeamId: 'team-b',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC });
+      expect(result.homeAway).toBeUndefined();
+    });
+
+    it('counts home and away totals when teamSeasonId is provided', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'other',
+          visitorTeamId: 'my-team',
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC, teamSeasonId: 'my-team' });
+      expect(result.homeAway).toBeDefined();
+      expect(result.homeAway!.home).toBe(2);
+      expect(result.homeAway!.away).toBe(1);
+    });
+
+    it('counts played home and away correctly', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Completed,
+          homeTeamId: 'other',
+          visitorTeamId: 'my-team',
+        }),
+        makeGame({
+          id: 'g4',
+          gameDate: '2024-06-13T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'other',
+          visitorTeamId: 'my-team',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC, teamSeasonId: 'my-team' });
+      expect(result.homeAway!.home).toBe(2);
+      expect(result.homeAway!.away).toBe(2);
+      expect(result.homeAway!.played.home).toBe(1);
+      expect(result.homeAway!.played.away).toBe(1);
+    });
+
+    it('excludes Rainout and Postponed from home/away counts', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Rainout,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.Postponed,
+          homeTeamId: 'other',
+          visitorTeamId: 'my-team',
+        }),
+        makeGame({
+          id: 'g3',
+          gameDate: '2024-06-12T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC, teamSeasonId: 'my-team' });
+      expect(result.homeAway!.home).toBe(1);
+      expect(result.homeAway!.away).toBe(0);
+    });
+
+    it('handles team that plays neither side (zeros)', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Scheduled,
+          homeTeamId: 'team-x',
+          visitorTeamId: 'team-y',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC, teamSeasonId: 'my-team' });
+      expect(result.homeAway!.home).toBe(0);
+      expect(result.homeAway!.away).toBe(0);
+      expect(result.homeAway!.played.home).toBe(0);
+      expect(result.homeAway!.played.away).toBe(0);
+    });
+
+    it('handles all played statuses for home/away', () => {
+      const games = [
+        makeGame({
+          id: 'g1',
+          gameDate: '2024-06-10T19:00:00Z',
+          gameStatus: GameStatus.Forfeit,
+          homeTeamId: 'my-team',
+          visitorTeamId: 'other',
+        }),
+        makeGame({
+          id: 'g2',
+          gameDate: '2024-06-11T19:00:00Z',
+          gameStatus: GameStatus.DidNotReport,
+          homeTeamId: 'other',
+          visitorTeamId: 'my-team',
+        }),
+      ];
+      const result = buildScheduleSummary(games, { timeZone: UTC, teamSeasonId: 'my-team' });
+      expect(result.homeAway!.played.home).toBe(1);
+      expect(result.homeAway!.played.away).toBe(1);
+    });
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/utils/buildScheduleSummary.ts
+++ b/draco-nodejs/frontend-next/components/schedule/utils/buildScheduleSummary.ts
@@ -1,0 +1,194 @@
+import { Game, GameStatus } from '@/types/schedule';
+import { convertUTCToZonedDate } from '../../../utils/dateUtils';
+import type {
+  SeasonSummary,
+  FieldSummary,
+  DayTypeCounts,
+  StartTimeBucket,
+  StartTimeSummary,
+} from '../hooks/useTeamSeasonSummary';
+
+export type { SeasonSummary, FieldSummary, DayTypeCounts, StartTimeBucket, StartTimeSummary };
+
+const NO_FIELD_KEY = '__no_field__';
+const NO_FIELD_LABEL = 'No Field / TBD';
+
+const normalizeFieldId = (value?: string | null): string | undefined => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  return undefined;
+};
+
+const isPlayedStatus = (status: number): boolean => {
+  return (
+    status === GameStatus.Completed ||
+    status === GameStatus.Forfeit ||
+    status === GameStatus.DidNotReport
+  );
+};
+
+const isExcludedStatus = (status: number): boolean => {
+  return status === GameStatus.Rainout || status === GameStatus.Postponed;
+};
+
+type FieldBucket = 'upcoming' | 'played' | 'notPlayed';
+
+const fieldBucketForStatus = (status: number): FieldBucket => {
+  if (status === GameStatus.Scheduled) return 'upcoming';
+  if (
+    status === GameStatus.Completed ||
+    status === GameStatus.Forfeit ||
+    status === GameStatus.DidNotReport
+  )
+    return 'played';
+  return 'notPlayed';
+};
+
+const bucketForHour = (hour: number): StartTimeBucket => {
+  if (hour < 12) return 'morning';
+  if (hour < 16) return 'afternoon';
+  if (hour < 19) return 'earlyEvening';
+  if (hour < 22) return 'lateEvening';
+  return 'night';
+};
+
+const BUCKET_ORDER: StartTimeBucket[] = [
+  'morning',
+  'afternoon',
+  'earlyEvening',
+  'lateEvening',
+  'night',
+];
+
+export interface BuildScheduleSummaryOptions {
+  timeZone: string;
+  teamSeasonId?: string;
+}
+
+export const buildScheduleSummary = (
+  games: Game[],
+  options: BuildScheduleSummaryOptions,
+): SeasonSummary => {
+  const { timeZone, teamSeasonId } = options;
+
+  const fieldMap = new Map<string, FieldSummary>();
+  const dayType = {
+    weekday: { played: 0, scheduled: 0 } as DayTypeCounts,
+    weekend: { played: 0, scheduled: 0 } as DayTypeCounts,
+  };
+  const bucketMap = new Map<StartTimeBucket, StartTimeSummary>();
+
+  let totalPlayed = 0;
+  let totalScheduled = 0;
+
+  let homeTotal = 0;
+  let awayTotal = 0;
+  let homePlayed = 0;
+  let awayPlayed = 0;
+
+  for (const game of games) {
+    const fieldKey =
+      normalizeFieldId(game.field?.id) ?? normalizeFieldId(game.fieldId) ?? NO_FIELD_KEY;
+    const fieldName =
+      game.field?.name ||
+      game.field?.shortName ||
+      (fieldKey === NO_FIELD_KEY ? NO_FIELD_LABEL : '');
+    const bucket = fieldBucketForStatus(game.gameStatus);
+
+    const existingField = fieldMap.get(fieldKey);
+    if (existingField) {
+      existingField[bucket] += 1;
+    } else {
+      fieldMap.set(fieldKey, {
+        fieldId: fieldKey === NO_FIELD_KEY ? null : fieldKey,
+        fieldName: fieldName || NO_FIELD_LABEL,
+        upcoming: bucket === 'upcoming' ? 1 : 0,
+        played: bucket === 'played' ? 1 : 0,
+        notPlayed: bucket === 'notPlayed' ? 1 : 0,
+      });
+    }
+
+    if (isExcludedStatus(game.gameStatus)) {
+      continue;
+    }
+
+    const played = isPlayedStatus(game.gameStatus);
+
+    if (played) {
+      totalPlayed += 1;
+    } else {
+      totalScheduled += 1;
+    }
+
+    if (teamSeasonId) {
+      if (game.homeTeamId === teamSeasonId) {
+        homeTotal += 1;
+        if (played) homePlayed += 1;
+      } else if (game.visitorTeamId === teamSeasonId) {
+        awayTotal += 1;
+        if (played) awayPlayed += 1;
+      }
+    }
+
+    const zoned = convertUTCToZonedDate(game.gameDate, timeZone);
+    if (!zoned) {
+      continue;
+    }
+
+    const day = zoned.getDay();
+    const isWeekend = day === 0 || day === 6;
+    const dayBucket = isWeekend ? dayType.weekend : dayType.weekday;
+    if (played) {
+      dayBucket.played += 1;
+    } else {
+      dayBucket.scheduled += 1;
+    }
+
+    const timeBucket = bucketForHour(zoned.getHours());
+    const existingBucket = bucketMap.get(timeBucket);
+    if (existingBucket) {
+      if (played) {
+        existingBucket.played += 1;
+      } else {
+        existingBucket.scheduled += 1;
+      }
+    } else {
+      bucketMap.set(timeBucket, {
+        bucket: timeBucket,
+        played: played ? 1 : 0,
+        scheduled: played ? 0 : 1,
+      });
+    }
+  }
+
+  const byField = Array.from(fieldMap.values()).sort((a, b) => {
+    const totalA = a.upcoming + a.played + a.notPlayed;
+    const totalB = b.upcoming + b.played + b.notPlayed;
+    const totalDiff = totalB - totalA;
+    if (totalDiff !== 0) return totalDiff;
+    return a.fieldName.localeCompare(b.fieldName);
+  });
+
+  const byStartTime = BUCKET_ORDER.filter((bucket) => bucketMap.has(bucket)).map(
+    (bucket) => bucketMap.get(bucket)!,
+  );
+
+  const homeAway = teamSeasonId
+    ? {
+        home: homeTotal,
+        away: awayTotal,
+        played: { home: homePlayed, away: awayPlayed },
+      }
+    : undefined;
+
+  return {
+    totalGames: totalPlayed + totalScheduled,
+    totalPlayed,
+    totalScheduled,
+    byField,
+    byDayType: dayType,
+    byStartTime,
+    homeAway,
+  };
+};

--- a/draco-nodejs/frontend-next/components/schedule/utils/getFilteredScheduleSummary.ts
+++ b/draco-nodejs/frontend-next/components/schedule/utils/getFilteredScheduleSummary.ts
@@ -1,0 +1,23 @@
+import { Game } from '@/types/schedule';
+import { buildScheduleSummary } from './buildScheduleSummary';
+import type { SeasonSummary } from '../hooks/useTeamSeasonSummary';
+
+interface GetFilteredScheduleSummaryProps {
+  games: Game[];
+  timeZone: string;
+  teamSeasonId?: string;
+  ready: boolean;
+}
+
+export const getFilteredScheduleSummary = ({
+  games,
+  timeZone,
+  teamSeasonId,
+  ready,
+}: GetFilteredScheduleSummaryProps): SeasonSummary | null => {
+  if (!ready || games.length === 0) {
+    return null;
+  }
+
+  return buildScheduleSummary(games, { timeZone, teamSeasonId });
+};

--- a/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
@@ -1,0 +1,154 @@
+import { test as base, expect } from '../fixtures/base-fixtures';
+import { ApiHelper, tryCleanup } from '../helpers/api';
+import { getJwtToken, BASE_URL } from '../helpers/auth';
+import { appendCleanupLog } from '../helpers/cleanupLog';
+import { updateSeasonScheduleVisibility } from '@draco/shared-api-client';
+import { createClient, createConfig } from '@draco/shared-api-client/generated/client';
+import type { LeagueSeasonWithDivision, LeagueSeason, TeamSeason } from '@draco/shared-api-client';
+
+type VisibilityFixtureData = {
+  accountId: string;
+  seasonId: string;
+  leagueId: string;
+  leagueSeasonId: string;
+  teamId: string;
+};
+
+function getAdminApiClient() {
+  return createClient(
+    createConfig({
+      baseUrl: BASE_URL,
+      auth: () => getJwtToken(),
+    }),
+  );
+}
+
+async function setScheduleVisible(accountId: string, seasonId: string, visible: boolean) {
+  const client = getAdminApiClient();
+  const { error } = await updateSeasonScheduleVisibility({
+    client,
+    path: { accountId, seasonId },
+    body: { scheduleVisible: visible },
+  });
+  if (error) {
+    throw new Error(`Failed to set schedule visibility: ${JSON.stringify(error)}`);
+  }
+}
+
+async function createVisibilityTestData(workerIndex: number): Promise<VisibilityFixtureData> {
+  const token = getJwtToken();
+  const api = new ApiHelper(BASE_URL, token);
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID || '29';
+  const suffix = `${Date.now() % 10000000}w${workerIndex}`;
+
+  const season: LeagueSeasonWithDivision = await api.createSeason(accountId, {
+    name: `E2E Vis Season ${suffix}`,
+  });
+
+  const league = await api.createLeague(accountId, { name: `E2E Vis Lg ${suffix}` });
+
+  const leagueSeason: LeagueSeason = await api.addLeagueToSeason(accountId, season.id, league.id);
+
+  const team: TeamSeason = await api.createTeam(accountId, season.id, leagueSeason.id, {
+    name: `E2E Vis Team ${suffix}`,
+  });
+
+  await setScheduleVisible(accountId, season.id, true);
+
+  return {
+    accountId,
+    seasonId: season.id,
+    leagueId: league.id,
+    leagueSeasonId: leagueSeason.id,
+    teamId: team.id,
+  };
+}
+
+async function cleanupVisibilityTestData(data: VisibilityFixtureData): Promise<void> {
+  const token = getJwtToken();
+  const api = new ApiHelper(BASE_URL, token);
+  const errors: string[] = [];
+
+  await tryCleanup(errors, () =>
+    api.removeLeagueFromSeason(data.accountId, data.seasonId, data.leagueSeasonId),
+  );
+
+  await tryCleanup(errors, () => api.deleteLeague(data.accountId, data.leagueId));
+
+  await tryCleanup(errors, () => api.deleteSeason(data.accountId, data.seasonId));
+
+  appendCleanupLog('schedule-visibility cleanup', errors);
+
+  if (errors.length > 0) {
+    throw new Error(`Schedule visibility test cleanup failed:\n  ${errors.join('\n  ')}`);
+  }
+}
+
+type WorkerFixtures = {
+  visibilityData: VisibilityFixtureData;
+};
+
+const test = base.extend<object, WorkerFixtures>({
+  visibilityData: [
+    async ({}, use, workerInfo) => {
+      const data = await createVisibilityTestData(workerInfo.workerIndex);
+      await use(data);
+      await cleanupVisibilityTestData(data);
+    },
+    { scope: 'worker' },
+  ],
+});
+
+test.describe('Schedule Visibility Toggle', () => {
+  test.beforeEach(async ({ visibilityData }) => {
+    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, true);
+  });
+
+  test('admin sees schedule visibility toggle on management page', async ({
+    page,
+    visibilityData,
+  }) => {
+    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
+    await page.waitForLoadState('networkidle');
+
+    const toggle = page.getByRole('checkbox', { name: /schedule visible to public/i });
+    await expect(toggle).toBeVisible();
+  });
+
+  test('toggle off hides public schedule', async ({ page, visibilityData }) => {
+    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, false);
+
+    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByText('The schedule has not been published yet. Please check back soon.'),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('toggle on shows public schedule', async ({ page, visibilityData }) => {
+    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, true);
+
+    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByText('The schedule has not been published yet. Please check back soon.'),
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test('admin can flip toggle via UI and state persists', async ({ page, visibilityData }) => {
+    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
+    await page.waitForLoadState('networkidle');
+
+    const toggle = page.getByRole('checkbox', { name: /schedule visible to public/i });
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(toggle).not.toBeChecked();
+  });
+});

--- a/draco-nodejs/frontend-next/eslint.config.mjs
+++ b/draco-nodejs/frontend-next/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextTypescript from 'eslint-config-next/typescript';
 import reactHooks from 'eslint-plugin-react-hooks';
 
 const eslintConfig = [{
-  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts", "e2e/.report/**"]
+  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "coverage/**", "next-env.d.ts", "e2e/.report/**"]
 }, ...nextCoreWebVitals, ...nextTypescript,
   reactHooks.configs.flat['recommended-latest'],
 {

--- a/draco-nodejs/frontend-next/hooks/useCurrentSeason.ts
+++ b/draco-nodejs/frontend-next/hooks/useCurrentSeason.ts
@@ -6,70 +6,122 @@ import { useApiClient } from './useApiClient';
 interface UseCurrentSeasonReturn {
   currentSeasonId: string | null;
   currentSeasonName: string | null;
+  currentSeasonScheduleVisible: boolean | null;
   loading: boolean;
   error: string | null;
   fetchCurrentSeason: () => Promise<string>;
+  refetchCurrentSeason: () => Promise<string>;
 }
 
-/**
- * Custom hook to fetch and manage current season data
- * Eliminates duplication of current season fetching logic across components
- */
 export const useCurrentSeason = (accountId: string): UseCurrentSeasonReturn => {
   const [currentSeasonId, setCurrentSeasonId] = useState<string | null>(null);
   const [currentSeasonName, setCurrentSeasonName] = useState<string | null>(null);
+  const [currentSeasonScheduleVisible, setCurrentSeasonScheduleVisible] = useState<boolean | null>(
+    null,
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const apiClient = useApiClient();
+
   const fetchPromiseRef = useRef<Promise<string> | null>(null);
 
-  const fetchCurrentSeason = async (): Promise<string> => {
-    if (currentSeasonId) {
-      return currentSeasonId;
-    }
+  const depsRef = useRef({
+    accountId,
+    apiClient,
+    currentSeasonId,
+    setCurrentSeasonId,
+    setCurrentSeasonName,
+    setCurrentSeasonScheduleVisible,
+    setLoading,
+    setError,
+  });
+  depsRef.current = {
+    accountId,
+    apiClient,
+    currentSeasonId,
+    setCurrentSeasonId,
+    setCurrentSeasonName,
+    setCurrentSeasonScheduleVisible,
+    setLoading,
+    setError,
+  };
 
-    if (fetchPromiseRef.current) {
-      return fetchPromiseRef.current;
-    }
+  const [stableFns] = useState(() => {
+    const doFetch = async (): Promise<string> => {
+      const {
+        accountId: aid,
+        apiClient: client,
+        setCurrentSeasonId: setSeasonId,
+        setCurrentSeasonName: setSeasonName,
+        setCurrentSeasonScheduleVisible: setScheduleVisible,
+        setLoading: setLoad,
+        setError: setErr,
+      } = depsRef.current;
 
-    const request = (async () => {
       try {
-        setLoading(true);
-        setError(null);
+        setLoad(true);
+        setErr(null);
 
         const result = await getCurrentSeason({
-          client: apiClient,
-          path: { accountId },
+          client,
+          path: { accountId: aid },
           throwOnError: false,
         });
 
         const season = unwrapApiResult(result, 'Failed to load current season');
         const seasonId = season.id;
         const seasonName = season.name;
+        const scheduleVisible = season.scheduleVisible;
 
-        setCurrentSeasonId(seasonId);
-        setCurrentSeasonName(seasonName);
+        setSeasonId(seasonId);
+        setSeasonName(seasonName);
+        setScheduleVisible(scheduleVisible);
 
         return seasonId;
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Failed to load current season';
-        setError(errorMessage);
+        setErr(errorMessage);
         throw new Error(errorMessage);
       } finally {
-        setLoading(false);
+        setLoad(false);
         fetchPromiseRef.current = null;
       }
-    })();
+    };
 
-    fetchPromiseRef.current = request;
-    return request;
-  };
+    const fetchCurrentSeason = (): Promise<string> => {
+      if (depsRef.current.currentSeasonId) {
+        return Promise.resolve(depsRef.current.currentSeasonId);
+      }
+
+      if (fetchPromiseRef.current) {
+        return fetchPromiseRef.current;
+      }
+
+      const request = doFetch();
+      fetchPromiseRef.current = request;
+      return request;
+    };
+
+    const refetchCurrentSeason = (): Promise<string> => {
+      if (fetchPromiseRef.current) {
+        return fetchPromiseRef.current;
+      }
+
+      const request = doFetch();
+      fetchPromiseRef.current = request;
+      return request;
+    };
+
+    return { fetchCurrentSeason, refetchCurrentSeason };
+  });
 
   return {
     currentSeasonId,
     currentSeasonName,
+    currentSeasonScheduleVisible,
     loading,
     error,
-    fetchCurrentSeason,
+    fetchCurrentSeason: stableFns.fetchCurrentSeason,
+    refetchCurrentSeason: stableFns.refetchCurrentSeason,
   };
 };

--- a/draco-nodejs/frontend-next/hooks/useHierarchicalData.ts
+++ b/draco-nodejs/frontend-next/hooks/useHierarchicalData.ts
@@ -44,15 +44,17 @@ export function useHierarchicalData(
         const data = unwrapApiResult(result, 'Failed to load hierarchical data');
         const mapped = mapLeagueSetup(data);
 
-        mapped.season = mapped.season ?? {
+        const resolvedSeason = mapped.season ?? {
           id: seasonId,
           name: 'Season',
           accountId,
+          scheduleVisible: true,
         };
+        mapped.season = resolvedSeason;
 
         const transformedData: HierarchicalSeason = {
-          id: mapped.season.id,
-          name: mapped.season.name || 'Season',
+          id: resolvedSeason.id,
+          name: resolvedSeason.name || 'Season',
           totalPlayers: 0,
           totalManagers: 0,
           leagues: mapped.leagueSeasons.map((league) => {

--- a/draco-nodejs/frontend-next/services/emailRecipientService.ts
+++ b/draco-nodejs/frontend-next/services/emailRecipientService.ts
@@ -681,6 +681,7 @@ export class EmailRecipientService {
           id: seasonId,
           name: '',
           accountId,
+          scheduleVisible: true,
         };
 
         return mapped.leagueSeasons;

--- a/draco-nodejs/shared/shared-schemas/seasonBase.ts
+++ b/draco-nodejs/shared/shared-schemas/seasonBase.ts
@@ -12,6 +12,11 @@ export const SeasonNameSchema = z.object({
 export const SeasonSchema = SeasonNameSchema.extend({
   accountId: bigintToStringSchema,
   isCurrent: z.boolean().optional(),
+  scheduleVisible: z.boolean(),
+});
+
+export const UpdateScheduleVisibilitySchema = z.object({
+  scheduleVisible: z.boolean(),
 });
 
 export const UpsertSeasonSchema = SeasonNameSchema.omit({
@@ -40,3 +45,4 @@ export type CopySeasonDataType = z.infer<typeof CopySeasonDataSchema>;
 export type SetCurrentSeasonDataType = z.infer<typeof SetCurrentSeasonDataSchema>;
 export type SeasonParticipantCountDataType = z.infer<typeof SeasonParticipantCountDataSchema>;
 export type UpsertSeasonType = z.infer<typeof UpsertSeasonSchema>;
+export type UpdateScheduleVisibilityType = z.infer<typeof UpdateScheduleVisibilitySchema>;


### PR DESCRIPTION
Introduce a schedule visibility flag for seasons and an API to update it. Adds a new database migration and Prisma schema field (season.schedulevisible, default true), repository/interface support and an updateScheduleVisibility method. Registers a PATCH /api/accounts/{accountId}/seasons/{seasonId}/schedule-visibility endpoint and OpenAPI schema (UpdateScheduleVisibility), updates response formatters to include scheduleVisible, and adjusts various backend routes to respect visibility. Adds tests covering games/team-schedule visibility guards and updates frontend components/hooks to surface and print schedule visibility.