### PR TITLE
Add games management endpoint and UI mode

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -47498,6 +47498,176 @@
         }
       }
     },
+    "/api/accounts/{accountId}/seasons/{seasonId}/games/manage": {
+      "get": {
+        "operationId": "listSeasonGamesForManagement",
+        "summary": "List season games for management",
+        "description": "Retrieve games for a season for management UI. Requires account.games.manage and is not gated by the public schedule-visibility toggle.",
+        "tags": [
+          "Games"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Return games occurring on or after this ISO date."
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Return games occurring on or before this ISO date."
+          },
+          {
+            "name": "teamId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            },
+            "description": "Filter to games where the given team season participates."
+          },
+          {
+            "name": "hasRecap",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Only include games that have at least one recap when true."
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of games with pagination metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GamesWithRecaps"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Season not found within the account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/accounts/{accountId}/seasons/{seasonId}/games/{gameId}": {
       "put": {
         "operationId": "updateGame",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -33713,6 +33713,118 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/games/manage:
+    get:
+      operationId: listSeasonGamesForManagement
+      summary: List season games for management
+      description: Retrieve games for a season for management UI. Requires
+        account.games.manage and is not gated by the public schedule-visibility
+        toggle.
+      tags:
+        - Games
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Return games occurring on or after this ISO date.
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Return games occurring on or before this ISO date.
+        - name: teamId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: number
+          description: Filter to games where the given team season participates.
+        - name: hasRecap
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: Only include games that have at least one recap when true.
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: sortOrder
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: asc
+      responses:
+        "200":
+          description: List of games with pagination metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GamesWithRecaps"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Season not found within the account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
   /api/accounts/{accountId}/seasons/{seasonId}/games/{gameId}:
     put:
       operationId: updateGame

--- a/draco-nodejs/backend/src/openapi/paths/games/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/games/index.ts
@@ -249,6 +249,161 @@ export const registerGamesEndpoints = ({ registry, schemaRefs, z }: RegisterCont
   });
 
   /**
+   * GET /api/accounts/:accountId/seasons/:seasonId/games/manage
+   * List games for season-management UI; bypasses public-visibility gating.
+   */
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/games/manage',
+    operationId: 'listSeasonGamesForManagement',
+    summary: 'List season games for management',
+    description:
+      'Retrieve games for a season for management UI. Requires account.games.manage and is not gated by the public schedule-visibility toggle.',
+    tags: ['Games'],
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'startDate',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'string',
+          format: 'date-time',
+        },
+        description: 'Return games occurring on or after this ISO date.',
+      },
+      {
+        name: 'endDate',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'string',
+          format: 'date-time',
+        },
+        description: 'Return games occurring on or before this ISO date.',
+      },
+      {
+        name: 'teamId',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+        description: 'Filter to games where the given team season participates.',
+      },
+      {
+        name: 'hasRecap',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'boolean',
+        },
+        description: 'Only include games that have at least one recap when true.',
+      },
+      {
+        name: 'page',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'integer',
+          minimum: 1,
+          default: 1,
+        },
+      },
+      {
+        name: 'limit',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+          default: 50,
+        },
+      },
+      {
+        name: 'sortOrder',
+        in: 'query',
+        required: false,
+        schema: {
+          type: 'string',
+          enum: ['asc', 'desc'],
+          default: 'asc',
+        },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'List of games with pagination metadata',
+        content: {
+          'application/json': {
+            schema: GamesWithRecapsSchemaRef,
+          },
+        },
+      },
+      400: {
+        description: 'Validation error',
+        content: {
+          'application/json': {
+            schema: ValidationErrorSchemaRef,
+          },
+        },
+      },
+      401: {
+        description: 'Authentication required',
+        content: {
+          'application/json': {
+            schema: AuthenticationErrorSchemaRef,
+          },
+        },
+      },
+      403: {
+        description: 'Insufficient permissions',
+        content: {
+          'application/json': {
+            schema: AuthorizationErrorSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Season not found within the account',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
+          },
+        },
+      },
+      500: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
+
+  /**
    * POST /api/accounts/:accountId/seasons/:seasonId/games
    * Create a new game
    */

--- a/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/games-visibility.test.ts
@@ -71,10 +71,10 @@ const defaultGamesResponse = {
   pagination: { total: 1, page: 1, limit: 20 },
 };
 
-let app: Express;
-let router: Router;
+describe('games visibility', () => {
+  let app: Express;
+  let router: Router;
 
-describe('GET / (season games) - visibility guard', () => {
   beforeAll(async () => {
     process.env.JWT_SECRET = 'test-secret'; // pragma: allowlist secret
 
@@ -109,14 +109,6 @@ describe('GET / (season games) - visibility guard', () => {
     });
   });
 
-  beforeEach(() => {
-    vi.resetAllMocks();
-    scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
-    roleServiceMock.hasPermission.mockResolvedValue(false);
-    seasonServiceMock.findSeasonById.mockResolvedValue(defaultSeason);
-    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
-  });
-
   afterAll(() => {
     vi.restoreAllMocks();
   });
@@ -135,6 +127,7 @@ describe('GET / (season games) - visibility guard', () => {
       hasManagePermission?: boolean;
       isHiddenCurrentSeason?: boolean;
       withAuth?: boolean;
+      routePath?: string;
     } = {},
   ) => {
     const {
@@ -142,6 +135,7 @@ describe('GET / (season games) - visibility guard', () => {
       hasManagePermission = false,
       isHiddenCurrentSeason = false,
       withAuth = true,
+      routePath = '/',
     } = options;
 
     roleServiceMock.hasPermission.mockResolvedValue(hasManagePermission);
@@ -149,11 +143,11 @@ describe('GET / (season games) - visibility guard', () => {
 
     const layer = (router.stack as RouteLayer[]).find(
       (stackLayer) =>
-        stackLayer.route && stackLayer.route.path === '/' && stackLayer.route.methods['get'],
+        stackLayer.route && stackLayer.route.path === routePath && stackLayer.route.methods['get'],
     );
 
     if (!layer?.route) {
-      throw new Error('Route GET / not found');
+      throw new Error(`Route GET ${routePath} not found`);
     }
 
     const handlers = layer.route.stack.map((s) => s.handle);
@@ -239,126 +233,163 @@ describe('GET / (season games) - visibility guard', () => {
     return { req, res, error: lastError };
   };
 
-  it('returns games when season is visible (current) and caller is unauthenticated', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: false,
-      isHiddenCurrentSeason: false,
+  describe('GET / (public season games)', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+      scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
+      roleServiceMock.hasPermission.mockResolvedValue(false);
+      seasonServiceMock.findSeasonById.mockResolvedValue(defaultSeason);
+      seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
     });
 
-    expect(res.body).toEqual(defaultGamesResponse);
-    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    it('returns games when season is visible and caller is unauthenticated', async () => {
+      const { res } = await runGamesRoute({
+        withAuth: false,
+        isHiddenCurrentSeason: false,
+      });
+
+      expect(res.body).toEqual(defaultGamesResponse);
+      expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    });
+
+    it('returns empty games when current season is hidden and caller is unauthenticated', async () => {
+      const { res } = await runGamesRoute({
+        withAuth: false,
+        isHiddenCurrentSeason: true,
+      });
+
+      expect(res.body).toEqual({
+        games: [],
+        pagination: { total: 0, page: 1, limit: 50 },
+      });
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+    });
+
+    it('returns games when season is hidden but season is NOT current (historical access)', async () => {
+      const { res } = await runGamesRoute({
+        withAuth: false,
+        isHiddenCurrentSeason: false,
+      });
+
+      expect(res.body).toEqual(defaultGamesResponse);
+      expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    });
+
+    it('returns empty games when current season is hidden, even for an authenticated AccountAdmin', async () => {
+      const { res } = await runGamesRoute({
+        withAuth: true,
+        hasManagePermission: true,
+        isHiddenCurrentSeason: true,
+      });
+
+      expect(res.body).toEqual({
+        games: [],
+        pagination: { total: 0, page: 1, limit: 50 },
+      });
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+    });
+
+    it('does not consult roleService.hasPermission on the public route', async () => {
+      await runGamesRoute({
+        withAuth: true,
+        hasManagePermission: true,
+        isHiddenCurrentSeason: false,
+      });
+
+      expect(roleServiceMock.hasPermission).not.toHaveBeenCalled();
+    });
+
+    it('returns games when season is visible and authenticated caller hits the public route', async () => {
+      const { res } = await runGamesRoute({
+        withAuth: true,
+        isHiddenCurrentSeason: false,
+      });
+
+      expect(res.body).toEqual(defaultGamesResponse);
+      expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+    });
+
+    it('returns 404 when seasonId does not belong to accountId', async () => {
+      seasonServiceMock.findSeasonById.mockResolvedValue(null);
+
+      const { res, error } = await runGamesRoute({
+        withAuth: true,
+        isHiddenCurrentSeason: false,
+      });
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+      expect(res.body).toBeUndefined();
+    });
+
+    it('returns 404 for unauthenticated callers when seasonId belongs to another account', async () => {
+      seasonServiceMock.findSeasonById.mockResolvedValue(null);
+
+      const { error } = await runGamesRoute({
+        withAuth: false,
+      });
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
+    });
   });
 
-  it('returns empty games when current season is hidden and caller is unauthenticated', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: false,
-      isHiddenCurrentSeason: true,
+  describe('GET /manage (season games for management)', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+      scheduleServiceMock.listSeasonGames.mockResolvedValue(defaultGamesResponse);
+      roleServiceMock.hasPermission.mockResolvedValue(true);
+      seasonServiceMock.findSeasonById.mockResolvedValue(defaultSeason);
+      seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(false);
     });
 
-    expect(res.body).toEqual({
-      games: [],
-      pagination: { total: 0, page: 1, limit: 50 },
-    });
-    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
-  });
+    it('returns games when current season is visible', async () => {
+      const { res } = await runGamesRoute({
+        routePath: '/manage',
+        withAuth: true,
+        hasManagePermission: true,
+        isHiddenCurrentSeason: false,
+      });
 
-  it('returns empty games when current season is hidden and authenticated non-admin calls without permission', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: true,
-      hasManagePermission: false,
-      isHiddenCurrentSeason: true,
+      expect(res.body).toEqual(defaultGamesResponse);
+      expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
     });
 
-    expect(res.body).toEqual({
-      games: [],
-      pagination: { total: 0, page: 1, limit: 50 },
-    });
-    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
-  });
+    it('returns games when current season is hidden (visibility toggle does not gate management)', async () => {
+      const { res } = await runGamesRoute({
+        routePath: '/manage',
+        withAuth: true,
+        hasManagePermission: true,
+        isHiddenCurrentSeason: true,
+      });
 
-  it('returns games when season is hidden but season is NOT current (historical access)', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: false,
-      isHiddenCurrentSeason: false,
-    });
-
-    expect(res.body).toEqual(defaultGamesResponse);
-    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
-  });
-
-  it('returns games when current season is hidden but AccountAdmin has account.games.manage', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: true,
-      hasManagePermission: true,
-      isHiddenCurrentSeason: true,
+      expect(res.body).toEqual(defaultGamesResponse);
+      expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
+      expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
     });
 
-    expect(res.body).toEqual(defaultGamesResponse);
-    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
-    expect(roleServiceMock.hasPermission).toHaveBeenCalledWith('user-1', 'account.games.manage', {
-      accountId: BigInt(ACCOUNT_ID),
-    });
-  });
+    it('rejects unauthenticated requests via authenticateToken', async () => {
+      const { error } = await runGamesRoute({
+        routePath: '/manage',
+        withAuth: false,
+      });
 
-  it('skips isScheduleHiddenForCurrentSeason entirely when caller has account.games.manage', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: true,
-      hasManagePermission: true,
-      isHiddenCurrentSeason: true,
+      expect(error).toBeInstanceOf(AuthorizationError);
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
     });
 
-    expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
-    expect(res.body).toEqual(defaultGamesResponse);
-  });
+    it('returns 404 when seasonId does not belong to accountId', async () => {
+      seasonServiceMock.findSeasonById.mockResolvedValue(null);
 
-  it('returns games when season is visible and authenticated admin calls', async () => {
-    const { res } = await runGamesRoute({
-      withAuth: true,
-      hasManagePermission: true,
-      isHiddenCurrentSeason: false,
+      const { error } = await runGamesRoute({
+        routePath: '/manage',
+        withAuth: true,
+        hasManagePermission: true,
+      });
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
     });
-
-    expect(res.body).toEqual(defaultGamesResponse);
-    expect(scheduleServiceMock.listSeasonGames).toHaveBeenCalled();
-  });
-
-  it('returns 404 (no games) when seasonId does not belong to accountId, regardless of permission', async () => {
-    seasonServiceMock.findSeasonById.mockResolvedValue(null);
-
-    const { res, error } = await runGamesRoute({
-      withAuth: true,
-      hasManagePermission: true,
-      isHiddenCurrentSeason: false,
-    });
-
-    expect(error).toBeInstanceOf(NotFoundError);
-    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
-    expect(res.body).toBeUndefined();
-  });
-
-  it('returns 404 for unauthenticated callers when seasonId belongs to another account', async () => {
-    seasonServiceMock.findSeasonById.mockResolvedValue(null);
-
-    const { error } = await runGamesRoute({
-      withAuth: false,
-    });
-
-    expect(error).toBeInstanceOf(NotFoundError);
-    expect(seasonServiceMock.isScheduleHiddenForCurrentSeason).not.toHaveBeenCalled();
-    expect(scheduleServiceMock.listSeasonGames).not.toHaveBeenCalled();
-  });
-
-  it('checks permission using the authenticated userId from req.user', async () => {
-    const customUserId = 'admin-user-42';
-    roleServiceMock.hasPermission.mockResolvedValue(true);
-    seasonServiceMock.isScheduleHiddenForCurrentSeason.mockResolvedValue(true);
-
-    await runGamesRoute({ withAuth: true, userId: customUserId, hasManagePermission: true });
-
-    expect(roleServiceMock.hasPermission).toHaveBeenCalledWith(
-      customUserId,
-      'account.games.manage',
-      { accountId: BigInt(ACCOUNT_ID) },
-    );
   });
 });

--- a/draco-nodejs/backend/src/routes/games.ts
+++ b/draco-nodejs/backend/src/routes/games.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { authenticateToken, optionalAuth } from '../middleware/authMiddleware.js';
+import { authenticateToken } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { PaginationHelper } from '../utils/pagination.js';
@@ -20,7 +20,6 @@ import {
 const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
 const scheduleService = ServiceFactory.getScheduleService();
-const roleService = ServiceFactory.getRoleService();
 const seasonService = ServiceFactory.getSeasonService();
 
 const parseSeasonParams = (params: ParamsObject) => {
@@ -45,6 +44,42 @@ const parseGameOnlyParams = (params: ParamsObject) => {
   } catch {
     throw new ValidationError('Invalid gameId');
   }
+};
+
+const parseListGamesQuery = (req: Request) => {
+  const { startDate, endDate, teamId, hasRecap } = req.query;
+  const pagination = PaginationHelper.parseParams(req.query);
+
+  let parsedTeamId: bigint | undefined;
+  if (teamId) {
+    try {
+      parsedTeamId = BigInt(String(teamId));
+    } catch {
+      throw new ValidationError('Invalid teamId');
+    }
+  }
+
+  const parsedStartDate = startDate ? new Date(String(startDate)) : undefined;
+  const parsedEndDate = endDate ? new Date(String(endDate)) : undefined;
+
+  if (parsedStartDate && Number.isNaN(parsedStartDate.getTime())) {
+    throw new ValidationError('Invalid startDate');
+  }
+  if (parsedEndDate && Number.isNaN(parsedEndDate.getTime())) {
+    throw new ValidationError('Invalid endDate');
+  }
+
+  const includeRecaps = String(hasRecap) === 'true';
+
+  return {
+    pagination,
+    filters: {
+      startDate: parsedStartDate,
+      endDate: parsedEndDate,
+      teamId: parsedTeamId,
+      hasRecap: includeRecaps ? true : undefined,
+    },
+  };
 };
 
 /**
@@ -77,74 +112,73 @@ router.put(
  */
 router.get(
   '/',
-  optionalAuth,
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, seasonId } = parseSeasonParams(req.params);
-    const { startDate, endDate, teamId, hasRecap } = req.query;
-
-    const paginationParams = PaginationHelper.parseParams(req.query);
 
     const season = await seasonService.findSeasonById(accountId, seasonId);
     if (!season) {
       throw new NotFoundError('Season not found');
     }
 
-    const userId = req.user?.id;
-    const hasManagePermission = userId
-      ? await roleService.hasPermission(userId, 'account.games.manage', { accountId })
-      : false;
+    const { pagination, filters } = parseListGamesQuery(req);
 
-    if (!hasManagePermission) {
-      const hidden = await seasonService.isScheduleHiddenForCurrentSeason(accountId, seasonId);
-      if (hidden) {
-        res.json({
-          games: [],
-          pagination: {
-            total: 0,
-            page: paginationParams.page,
-            limit: paginationParams.limit,
-          },
-        });
-        return;
-      }
+    const hidden = await seasonService.isScheduleHiddenForCurrentSeason(accountId, seasonId);
+    if (hidden) {
+      res.json({
+        games: [],
+        pagination: {
+          total: 0,
+          page: pagination.page,
+          limit: pagination.limit,
+        },
+      });
+      return;
     }
-
-    let parsedTeamId: bigint | undefined;
-    if (teamId) {
-      try {
-        parsedTeamId = BigInt(String(teamId));
-      } catch {
-        throw new ValidationError('Invalid teamId');
-      }
-    }
-
-    const parsedStartDate = startDate ? new Date(String(startDate)) : undefined;
-    const parsedEndDate = endDate ? new Date(String(endDate)) : undefined;
-
-    if (parsedStartDate && Number.isNaN(parsedStartDate.getTime())) {
-      throw new ValidationError('Invalid startDate');
-    }
-
-    if (parsedEndDate && Number.isNaN(parsedEndDate.getTime())) {
-      throw new ValidationError('Invalid endDate');
-    }
-
-    const includeRecaps = String(hasRecap) === 'true';
 
     const response = await scheduleService.listSeasonGames(
       seasonId,
       {
-        page: paginationParams.page,
-        limit: paginationParams.limit,
-        skip: paginationParams.skip,
-        sortOrder: paginationParams.sortOrder,
+        page: pagination.page,
+        limit: pagination.limit,
+        skip: pagination.skip,
+        sortOrder: pagination.sortOrder,
       },
+      filters,
+    );
+
+    res.json(response);
+  }),
+);
+
+/**
+ * GET /api/accounts/:accountId/seasons/:seasonId/games/manage
+ * List games for season-management UI. Requires account.games.manage and
+ * is not gated by the season's public-visibility toggle.
+ */
+router.get(
+  '/manage',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('account.games.manage'),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId } = parseSeasonParams(req.params);
+
+    const season = await seasonService.findSeasonById(accountId, seasonId);
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const { pagination, filters } = parseListGamesQuery(req);
+
+    const response = await scheduleService.listSeasonGames(
+      seasonId,
       {
-        startDate: parsedStartDate,
-        endDate: parsedEndDate,
-        teamId: parsedTeamId,
-        hasRecap: includeRecaps ? true : undefined,
+        page: pagination.page,
+        limit: pagination.limit,
+        skip: pagination.skip,
+        sortOrder: pagination.sortOrder,
       },
+      filters,
     );
 
     res.json(response);

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
@@ -140,6 +140,7 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
     filterType,
     filterDate,
     onError: setError,
+    mode: 'manage',
   });
 
   const {

--- a/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
@@ -99,6 +99,7 @@ async function loadGames({
   endDate,
   apiClient,
   mode = 'public',
+  signal,
 }: LoadGamesParams): Promise<Game[]> {
   const aggregated = new Map<string, Game>();
   let page = 1;
@@ -114,6 +115,7 @@ async function loadGames({
         page: currentPage,
         limit: API_PAGE_LIMIT,
       },
+      signal,
       throwOnError: false as const,
     };
 
@@ -123,7 +125,15 @@ async function loadGames({
   };
 
   while (true) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
     const result = await fetchPage(page);
+
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
 
     const data = unwrapApiResult(result, 'Failed to load games');
     const mappedGames = data.games.map(mapGameResponseToScheduleGame);

--- a/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/adapters/baseballAdapter.ts
@@ -2,6 +2,7 @@ import {
   listAccountFields,
   listAccountUmpires,
   listSeasonGames,
+  listSeasonGamesForManagement,
   listSeasonLeagueSeasons,
   listTeamSeasonSchedule,
   createGame,
@@ -97,23 +98,32 @@ async function loadGames({
   startDate,
   endDate,
   apiClient,
+  mode = 'public',
 }: LoadGamesParams): Promise<Game[]> {
   const aggregated = new Map<string, Game>();
   let page = 1;
 
-  while (true) {
-    const result = await listSeasonGames({
+  const fetchPage = (currentPage: number) => {
+    const requestOptions = {
       client: apiClient,
       path: { accountId, seasonId },
       query: {
         startDate: startDate.toISOString(),
         endDate: endDate.toISOString(),
-        sortOrder: 'asc',
-        page,
+        sortOrder: 'asc' as const,
+        page: currentPage,
         limit: API_PAGE_LIMIT,
       },
-      throwOnError: false,
-    });
+      throwOnError: false as const,
+    };
+
+    return mode === 'manage'
+      ? listSeasonGamesForManagement(requestOptions)
+      : listSeasonGames(requestOptions);
+  };
+
+  while (true) {
+    const result = await fetchPage(page);
 
     const data = unwrapApiResult(result, 'Failed to load games');
     const mappedGames = data.games.map(mapGameResponseToScheduleGame);

--- a/draco-nodejs/frontend-next/components/schedule/adapters/golfAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/adapters/golfAdapter.ts
@@ -142,7 +142,12 @@ async function loadGames({
   startDate,
   endDate,
   apiClient,
+  signal,
 }: LoadGamesParams): Promise<Game[]> {
+  if (signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
+
   const result = await listGolfMatchesForSeason({
     client: apiClient,
     path: { accountId, seasonId },
@@ -150,8 +155,13 @@ async function loadGames({
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
     },
+    signal,
     throwOnError: false,
   });
+
+  if (signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
 
   const matches = unwrapApiResult(result, 'Failed to load matches');
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
@@ -22,6 +22,7 @@ import {
   getMonthRangeForKey,
   sortGamesAscending,
 } from './scheduleDateHelpers';
+import type { ScheduleAccessMode } from '../types/sportAdapter';
 
 interface UseScheduleDataProps {
   accountId: string;
@@ -29,6 +30,7 @@ interface UseScheduleDataProps {
   filterType: FilterType;
   filterDate: Date;
   onError?: (message: string) => void;
+  mode?: ScheduleAccessMode;
 }
 
 interface UseScheduleDataReturn {
@@ -100,6 +102,7 @@ export const useScheduleData = ({
   filterType,
   filterDate,
   onError,
+  mode = 'public',
 }: UseScheduleDataProps): UseScheduleDataReturn => {
   const { loading: authLoading } = useAuth();
   const apiClient = useApiClient();
@@ -262,6 +265,7 @@ export const useScheduleData = ({
               startDate: start,
               endDate: end,
               apiClient,
+              mode,
             });
 
             gamesCacheRef.current.set(monthKey, loadedGames);
@@ -477,6 +481,7 @@ export const useScheduleData = ({
                 startDate: start,
                 endDate: end,
                 apiClient,
+                mode,
               });
 
               gamesCacheRef.current.set(monthKey, loadedGames);
@@ -515,7 +520,7 @@ export const useScheduleData = ({
     return () => {
       controller.abort();
     };
-  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate]);
+  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate, mode]);
 
   const filteredGames = games;
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
@@ -482,6 +482,7 @@ export const useScheduleData = ({
                 endDate: end,
                 apiClient,
                 mode,
+                signal: controller.signal,
               });
 
               gamesCacheRef.current.set(monthKey, loadedGames);

--- a/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
@@ -23,12 +23,15 @@ export interface ScheduleOfficial {
   email: string;
 }
 
+export type ScheduleAccessMode = 'public' | 'manage';
+
 export interface LoadGamesParams {
   accountId: string;
   seasonId: string;
   startDate: Date;
   endDate: Date;
   apiClient: Client;
+  mode?: ScheduleAccessMode;
 }
 
 export interface LoadTeamGamesParams {

--- a/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
+++ b/draco-nodejs/frontend-next/components/schedule/types/sportAdapter.ts
@@ -32,6 +32,7 @@ export interface LoadGamesParams {
   endDate: Date;
   apiClient: Client;
   mode?: ScheduleAccessMode;
+  signal?: AbortSignal;
 }
 
 export interface LoadTeamGamesParams {

--- a/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
@@ -111,7 +111,7 @@ test.describe('Schedule Visibility Toggle', () => {
     await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
     await page.waitForLoadState('networkidle');
 
-    const toggle = page.getByRole('checkbox', { name: /schedule visible to public/i });
+    const toggle = page.getByRole('switch', { name: /schedule visible to public/i });
     await expect(toggle).toBeVisible();
   });
 
@@ -141,7 +141,7 @@ test.describe('Schedule Visibility Toggle', () => {
     await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
     await page.waitForLoadState('networkidle');
 
-    const toggle = page.getByRole('checkbox', { name: /schedule visible to public/i });
+    const toggle = page.getByRole('switch', { name: /schedule visible to public/i });
     await expect(toggle).toBeChecked();
 
     await toggle.click();


### PR DESCRIPTION
Introduce a management-only games listing and wire it through backend, OpenAPI, tests, and frontend. Backend: add GET /api/accounts/{accountId}/seasons/{seasonId}/games/manage to OpenAPI (json/yaml) and register the path; implement router.get('/manage') which requires authentication and account.games.manage permission and bypasses the public schedule-visibility toggle; extract parseListGamesQuery helper for query parsing/validation and reuse it from both public and management routes; remove optionalAuth from the public route and keep visibility gating only on the public endpoint. Tests: refactor games-visibility tests to cover both the public route and the new /manage route, adjust mocks and expectations, and improve route lookup to support testing different paths. Frontend: add 'manage' mode to schedule adapters/types/hooks, call listSeasonGamesForManagement when mode='manage', pass mode from ScheduleManagement page, and update e2e selector role from checkbox to switch. This change enables an admin management UI to list season games regardless of the public visibility toggle while keeping public access gated by the schedule visibility setting.