### PR TITLE
Replace MUI Selects with Autocomplete components

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -24,6 +24,7 @@ import {
 } from '@draco/shared-api-client';
 import { useApiClient } from '../../../hooks/useApiClient';
 import { useAccountMembership } from '../../../hooks/useAccountMembership';
+import { useCurrentSeason } from '../../../hooks/useCurrentSeason';
 import { unwrapApiResult } from '@/utils/apiResult';
 import {
   AccountSeasonWithStatusType,
@@ -80,6 +81,15 @@ const BaseballAccountHome: React.FC = () => {
     loading: membershipLoading,
     error: membershipError,
   } = useAccountMembership(accountIdStr);
+  const { currentSeasonScheduleVisible, fetchCurrentSeason } = useCurrentSeason(accountIdStr ?? '');
+
+  useEffect(() => {
+    if (accountIdStr) {
+      void fetchCurrentSeason();
+    }
+  }, [accountIdStr, fetchCurrentSeason]);
+
+  const scheduleHidden = currentSeasonScheduleVisible === false;
   const isAccountMember = isMember === true;
   const hasAccountContact = Boolean(isAccountMember);
   const canSubmitPhotos = Boolean(isAccountMember);
@@ -923,7 +933,7 @@ const BaseballAccountHome: React.FC = () => {
               <AccountPollsCard accountId={accountIdStr} isAuthorizedForAccount />
             ) : null}
 
-            {currentSeason ? (
+            {currentSeason && !scheduleHidden ? (
               <TodayScoreboard
                 accountId={accountIdStr}
                 layout="vertical"
@@ -936,11 +946,11 @@ const BaseballAccountHome: React.FC = () => {
               />
             ) : null}
 
-            {currentSeason ? (
+            {currentSeason && !scheduleHidden ? (
               <GameRecapsWidget accountId={accountIdStr} seasonId={currentSeason.id} />
             ) : null}
 
-            {currentSeason ? (
+            {currentSeason && !scheduleHidden ? (
               <YesterdayScoreboard
                 accountId={accountIdStr}
                 layout="vertical"

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -104,6 +104,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
   const apiClient = useApiClient();
   const {
     currentSeasonId,
+    currentSeasonScheduleVisible,
     loading: currentSeasonLoading,
     fetchCurrentSeason,
   } = useCurrentSeason(accountId);
@@ -499,7 +500,8 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     hasRole('Administrator') || hasRoleInAccount('AccountAdmin', accountId) || hasRole('TeamAdmin');
 
   const upcomingSections = [{ title: 'Upcoming Games', games: upcomingGames }];
-  const hasUpcomingGames = upcomingGames.length > 0;
+  const scheduleHidden = isCurrentSeason && currentSeasonScheduleVisible === false;
+  const hasUpcomingGames = upcomingGames.length > 0 && !scheduleHidden;
 
   const completedSections = [{ title: 'Completed Games', games: completedGames }];
 

--- a/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
@@ -408,8 +408,7 @@ const GameDialogInner: React.FC<GameDialogInnerProps> = ({
                 name="leagueSeasonId"
                 control={control}
                 render={({ field, fieldState }) => {
-                  const selectedOption =
-                    leagues.find((league) => league.id === field.value) ?? null;
+                  const selectedOption = leagues.find((league) => league.id === field.value);
                   return (
                     <Autocomplete
                       options={leagues}
@@ -420,6 +419,7 @@ const GameDialogInner: React.FC<GameDialogInnerProps> = ({
                       onChange={(_, option) => field.onChange(option?.id ?? '')}
                       onBlur={field.onBlur}
                       disabled={!canEditSchedule}
+                      disableClearable
                       autoHighlight
                       autoSelect
                       size="small"
@@ -430,7 +430,7 @@ const GameDialogInner: React.FC<GameDialogInnerProps> = ({
                           inputRef={field.ref}
                           label="League"
                           required
-                          autoFocus
+                          autoFocus={canEditSchedule}
                           error={!!fieldState.error}
                           helperText={fieldState.error?.message}
                         />

--- a/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
@@ -1,19 +1,17 @@
 import React, { useState } from 'react';
 import {
   Alert,
+  Autocomplete,
   Box,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   Typography,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
+  TextField,
   CircularProgress,
   Stack,
-  FormHelperText,
+  createFilterOptions,
 } from '@mui/material';
 import { Controller, FormProvider, useForm, useWatch, type Resolver } from 'react-hook-form';
 import { z } from 'zod';
@@ -113,6 +111,11 @@ const createGameDialogSchema = (gameStatus: number, timeZone: string) =>
 
 type GameDialogSchema = ReturnType<typeof createGameDialogSchema>;
 export type GameDialogFormValues = z.infer<GameDialogSchema>;
+
+const leagueStartsWithFilter = createFilterOptions<{ id: string; name: string }>({
+  matchFrom: 'start',
+  stringify: (option) => option.name,
+});
 
 const buildInitialFormValues = (
   mode: 'create' | 'edit',
@@ -404,24 +407,37 @@ const GameDialogInner: React.FC<GameDialogInnerProps> = ({
               <Controller
                 name="leagueSeasonId"
                 control={control}
-                render={({ field, fieldState }) => (
-                  <FormControl
-                    fullWidth
-                    size="small"
-                    disabled={!canEditSchedule}
-                    error={!!fieldState.error}
-                  >
-                    <InputLabel>League</InputLabel>
-                    <Select {...field} label="League" value={field.value ?? ''}>
-                      {leagues.map((league) => (
-                        <MenuItem key={league.id} value={league.id}>
-                          {league.name}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <FormHelperText>{fieldState.error?.message}</FormHelperText>
-                  </FormControl>
-                )}
+                render={({ field, fieldState }) => {
+                  const selectedOption =
+                    leagues.find((league) => league.id === field.value) ?? null;
+                  return (
+                    <Autocomplete
+                      options={leagues}
+                      getOptionLabel={(option) => option.name}
+                      isOptionEqualToValue={(option, value) => option.id === value.id}
+                      filterOptions={leagueStartsWithFilter}
+                      value={selectedOption}
+                      onChange={(_, option) => field.onChange(option?.id ?? '')}
+                      onBlur={field.onBlur}
+                      disabled={!canEditSchedule}
+                      autoHighlight
+                      autoSelect
+                      size="small"
+                      fullWidth
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          inputRef={field.ref}
+                          label="League"
+                          required
+                          autoFocus
+                          error={!!fieldState.error}
+                          helperText={fieldState.error?.message}
+                        />
+                      )}
+                    />
+                  );
+                }}
               />
             ) : (
               <Typography variant="body1" sx={{ fontWeight: 500, color: 'text.secondary' }}>

--- a/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
@@ -45,6 +45,7 @@ const ControlledOptionAutocomplete: React.FC<ControlledOptionAutocompleteProps> 
 }) => {
   const { control } = useFormContext<GameDialogFormValues>();
   const resolvedOptions = includeEmpty ? [NONE_OPTION, ...options] : options;
+  const disableClearable = required && !includeEmpty;
 
   return (
     <Controller
@@ -52,13 +53,18 @@ const ControlledOptionAutocomplete: React.FC<ControlledOptionAutocompleteProps> 
       control={control}
       render={({ field, fieldState }) => {
         const currentValue = field.value ?? '';
-        const selectedOption =
-          resolvedOptions.find((option) => option.id === currentValue) ??
-          (includeEmpty ? NONE_OPTION : null);
+        const knownOption = resolvedOptions.find((option) => option.id === currentValue);
+        const unknownOption: AutoOption | null =
+          !knownOption && currentValue ? { id: currentValue, label: 'Unknown' } : null;
+        const displayOptions = unknownOption
+          ? [unknownOption, ...resolvedOptions]
+          : resolvedOptions;
+        const selectedOption = knownOption ?? unknownOption ?? (includeEmpty ? NONE_OPTION : null);
+        const hasUnknownValue = Boolean(unknownOption);
 
         return (
           <Autocomplete
-            options={resolvedOptions}
+            options={displayOptions}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(option, value) => option.id === value.id}
             filterOptions={startsWithFilter}
@@ -67,6 +73,7 @@ const ControlledOptionAutocomplete: React.FC<ControlledOptionAutocompleteProps> 
             onBlur={field.onBlur}
             autoHighlight
             autoSelect
+            disableClearable={disableClearable}
             fullWidth
             renderInput={(params) => (
               <TextField
@@ -74,8 +81,11 @@ const ControlledOptionAutocomplete: React.FC<ControlledOptionAutocompleteProps> 
                 inputRef={field.ref}
                 label={label}
                 required={required}
-                error={!!fieldState.error}
-                helperText={fieldState.error?.message}
+                error={!!fieldState.error || hasUnknownValue}
+                helperText={
+                  fieldState.error?.message ??
+                  (hasUnknownValue ? 'Selection is no longer available' : undefined)
+                }
               />
             )}
           />

--- a/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
@@ -1,25 +1,102 @@
 'use client';
 
 import React from 'react';
-import {
-  Box,
-  TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  FormHelperText,
-} from '@mui/material';
+import { Autocomplete, Box, TextField, createFilterOptions } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { getReadOnlyInputProps, getReadOnlyDatePickerInputProps } from '../../../utils/formUtils';
 import { useGameFormContext } from '../contexts/GameFormContext';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, type FieldPath } from 'react-hook-form';
 import type { GameDialogFormValues } from '../dialogs/GameDialog';
+import { GameType } from '@/types/schedule';
 
 const EMPTY_LABEL = 'None';
+
+type AutoOption = { id: string; label: string };
+
+const NONE_OPTION: AutoOption = { id: '', label: EMPTY_LABEL };
+
+const startsWithFilter = createFilterOptions<AutoOption>({
+  matchFrom: 'start',
+  stringify: (option) => option.label,
+});
+
+type StringFieldName = Extract<
+  FieldPath<GameDialogFormValues>,
+  'homeTeamId' | 'visitorTeamId' | 'fieldId' | 'umpire1' | 'umpire2' | 'umpire3' | 'umpire4'
+>;
+
+interface ControlledOptionAutocompleteProps {
+  name: StringFieldName;
+  label: string;
+  options: AutoOption[];
+  required?: boolean;
+  includeEmpty?: boolean;
+}
+
+const ControlledOptionAutocomplete: React.FC<ControlledOptionAutocompleteProps> = ({
+  name,
+  label,
+  options,
+  required,
+  includeEmpty,
+}) => {
+  const { control } = useFormContext<GameDialogFormValues>();
+  const resolvedOptions = includeEmpty ? [NONE_OPTION, ...options] : options;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field, fieldState }) => {
+        const currentValue = field.value ?? '';
+        const selectedOption =
+          resolvedOptions.find((option) => option.id === currentValue) ??
+          (includeEmpty ? NONE_OPTION : null);
+
+        return (
+          <Autocomplete
+            options={resolvedOptions}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, value) => option.id === value.id}
+            filterOptions={startsWithFilter}
+            value={selectedOption}
+            onChange={(_, option) => field.onChange(option?.id ?? '')}
+            onBlur={field.onBlur}
+            autoHighlight
+            autoSelect
+            fullWidth
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                inputRef={field.ref}
+                label={label}
+                required={required}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+        );
+      }}
+    />
+  );
+};
+
+type GameTypeOption = { value: number; label: string };
+
+const GAME_TYPE_OPTIONS: GameTypeOption[] = [
+  { value: GameType.RegularSeason, label: 'Regular Season' },
+  { value: GameType.Playoff, label: 'Playoff' },
+  { value: GameType.Exhibition, label: 'Exhibition' },
+];
+
+const startsWithGameTypeFilter = createFilterOptions<GameTypeOption>({
+  matchFrom: 'start',
+  stringify: (option) => option.label,
+});
 
 const GameFormFields: React.FC = () => {
   const {
@@ -40,9 +117,30 @@ const GameFormFields: React.FC = () => {
     getTeamName,
     getFieldName,
     getGameTypeText,
+    selectedGame,
   } = useGameFormContext();
 
   const commentValue = watch('comment') ?? '';
+  const isEditMode = Boolean(selectedGame);
+
+  const teamOptions: AutoOption[] = leagueTeams.map((team) => ({
+    id: team.id,
+    label: team.name ?? 'Unknown Team',
+  }));
+  const fieldOptions: AutoOption[] = fields.map((fieldOption) => ({
+    id: fieldOption.id,
+    label: fieldOption.name,
+  }));
+  const buildUmpireOptions = (position: string, currentValue: string): AutoOption[] =>
+    getAvailableUmpires(position, currentValue).map((umpire) => ({
+      id: umpire.id,
+      label: `${umpire.firstName} ${umpire.lastName}`.trim(),
+    }));
+
+  const getUmpireLabel = (umpireId: string): string => {
+    const umpire = umpires.find((candidate) => candidate.id === umpireId);
+    return umpire ? `${umpire.firstName} ${umpire.lastName}`.trim() : 'Unknown';
+  };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -62,6 +160,7 @@ const GameFormFields: React.FC = () => {
                   textField: {
                     fullWidth: true,
                     required: true,
+                    autoFocus: canEditSchedule && isEditMode,
                     error: !!errors.gameDate,
                     helperText: errors.gameDate?.message,
                     InputProps: !canEditSchedule ? getReadOnlyDatePickerInputProps() : undefined,
@@ -95,342 +194,216 @@ const GameFormFields: React.FC = () => {
 
         {/* Teams */}
         <Box sx={{ display: 'flex', gap: 2 }}>
-          <Controller
-            name="homeTeamId"
-            control={control}
-            render={({ field }) =>
-              canEditSchedule ? (
-                <FormControl fullWidth required error={!!errors.homeTeamId}>
-                  <InputLabel>Home Team</InputLabel>
-                  <Select {...field} label="Home Team">
-                    {leagueTeams.map((team) => (
-                      <MenuItem key={team.id} value={team.id}>
-                        {team.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  <FormHelperText>{errors.homeTeamId?.message}</FormHelperText>
-                </FormControl>
-              ) : (
+          {canEditSchedule ? (
+            <ControlledOptionAutocomplete
+              name="homeTeamId"
+              label="Home Team"
+              options={teamOptions}
+              required
+            />
+          ) : (
+            <Controller
+              name="homeTeamId"
+              control={control}
+              render={({ field }) => (
                 <TextField
                   fullWidth
                   label="Home Team"
                   value={getTeamName(field.value || '')}
                   InputProps={getReadOnlyInputProps()}
                 />
-              )
-            }
-          />
-          <Controller
-            name="visitorTeamId"
-            control={control}
-            render={({ field }) =>
-              canEditSchedule ? (
-                <FormControl fullWidth required error={!!errors.visitorTeamId}>
-                  <InputLabel>Visitor Team</InputLabel>
-                  <Select {...field} label="Visitor Team">
-                    {leagueTeams.map((team) => (
-                      <MenuItem key={team.id} value={team.id}>
-                        {team.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  <FormHelperText>{errors.visitorTeamId?.message}</FormHelperText>
-                </FormControl>
-              ) : (
+              )}
+            />
+          )}
+          {canEditSchedule ? (
+            <ControlledOptionAutocomplete
+              name="visitorTeamId"
+              label="Visitor Team"
+              options={teamOptions}
+              required
+            />
+          ) : (
+            <Controller
+              name="visitorTeamId"
+              control={control}
+              render={({ field }) => (
                 <TextField
                   fullWidth
                   label="Visitor Team"
                   value={getTeamName(field.value || '')}
                   InputProps={getReadOnlyInputProps()}
                 />
-              )
-            }
-          />
+              )}
+            />
+          )}
         </Box>
 
         {/* Field and Game Type */}
         <Box sx={{ display: 'flex', gap: 2 }}>
-          <Controller
-            name="fieldId"
-            control={control}
-            render={({ field }) =>
-              canEditSchedule ? (
-                <FormControl fullWidth error={!!errors.fieldId}>
-                  <InputLabel shrink>Field</InputLabel>
-                  <Select
-                    {...field}
-                    label="Field"
-                    displayEmpty
-                    value={field.value ?? ''}
-                    renderValue={(selected) => {
-                      if (!selected) {
-                        return EMPTY_LABEL;
-                      }
-                      const option = fields.find((item) => item.id === selected);
-                      return option?.name ?? 'Unknown';
-                    }}
-                  >
-                    <MenuItem value="">
-                      <em>{EMPTY_LABEL}</em>
-                    </MenuItem>
-                    {fields.map((fieldOption) => (
-                      <MenuItem key={fieldOption.id} value={fieldOption.id}>
-                        {fieldOption.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  <FormHelperText>{errors.fieldId?.message}</FormHelperText>
-                </FormControl>
-              ) : (
+          {canEditSchedule ? (
+            <ControlledOptionAutocomplete
+              name="fieldId"
+              label="Field"
+              options={fieldOptions}
+              includeEmpty
+            />
+          ) : (
+            <Controller
+              name="fieldId"
+              control={control}
+              render={({ field }) => (
                 <TextField
                   fullWidth
                   label="Field"
                   value={getFieldName(field.value || undefined)}
                   InputProps={getReadOnlyInputProps()}
                 />
-              )
-            }
-          />
-          <Controller
-            name="gameType"
-            control={control}
-            render={({ field }) =>
-              canEditSchedule ? (
-                <FormControl fullWidth error={!!errors.gameType}>
-                  <InputLabel>Game Type</InputLabel>
-                  <Select {...field} label="Game Type">
-                    <MenuItem value={0}>Regular Season</MenuItem>
-                    <MenuItem value={1}>Playoff</MenuItem>
-                    <MenuItem value={2}>Exhibition</MenuItem>
-                  </Select>
-                  <FormHelperText>{errors.gameType?.message}</FormHelperText>
-                </FormControl>
-              ) : (
+              )}
+            />
+          )}
+          {canEditSchedule ? (
+            <Controller
+              name="gameType"
+              control={control}
+              render={({ field, fieldState }) => {
+                const selectedOption =
+                  GAME_TYPE_OPTIONS.find((option) => option.value === field.value) ?? null;
+                return (
+                  <Autocomplete
+                    options={GAME_TYPE_OPTIONS}
+                    getOptionLabel={(option) => option.label}
+                    isOptionEqualToValue={(option, value) => option.value === value.value}
+                    filterOptions={startsWithGameTypeFilter}
+                    value={selectedOption}
+                    onChange={(_, option) =>
+                      field.onChange(option ? option.value : GameType.RegularSeason)
+                    }
+                    onBlur={field.onBlur}
+                    autoHighlight
+                    autoSelect
+                    fullWidth
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        inputRef={field.ref}
+                        label="Game Type"
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                      />
+                    )}
+                  />
+                );
+              }}
+            />
+          ) : (
+            <Controller
+              name="gameType"
+              control={control}
+              render={({ field }) => (
                 <TextField
                   fullWidth
                   label="Game Type"
                   value={getGameTypeText(field.value ?? '')}
                   InputProps={getReadOnlyInputProps()}
                 />
-              )
-            }
-          />
+              )}
+            />
+          )}
         </Box>
 
         {/* Umpires Row 1 */}
         {isAccountAdmin && hasOfficials && (
           <Box sx={{ display: 'flex', gap: 2 }}>
-            <Controller
-              name="umpire1"
-              control={control}
-              render={({ field }) =>
-                canEditSchedule ? (
-                  <FormControl fullWidth error={!!errors.umpire1}>
-                    <InputLabel id="umpire1-label" shrink>
-                      Umpire 1
-                    </InputLabel>
-                    <Select
-                      {...field}
-                      labelId="umpire1-label"
-                      label="Umpire 1"
-                      displayEmpty
-                      value={field.value ?? ''}
-                      renderValue={(selected) => {
-                        if (!selected) {
-                          return EMPTY_LABEL;
-                        }
-                        const option = umpires.find((umpire) => umpire.id === selected);
-                        return option ? `${option.firstName} ${option.lastName}`.trim() : 'Unknown';
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>{EMPTY_LABEL}</em>
-                      </MenuItem>
-                      {getAvailableUmpires('umpire1', field.value ?? '').map((umpire) => (
-                        <MenuItem key={umpire.id} value={umpire.id}>
-                          {`${umpire.firstName} ${umpire.lastName}`.trim()}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <FormHelperText>{errors.umpire1?.message}</FormHelperText>
-                  </FormControl>
-                ) : (
+            {canEditSchedule ? (
+              <ControlledOptionAutocomplete
+                name="umpire1"
+                label="Umpire 1"
+                options={buildUmpireOptions('umpire1', watch('umpire1') ?? '')}
+                includeEmpty
+              />
+            ) : (
+              <Controller
+                name="umpire1"
+                control={control}
+                render={({ field }) => (
                   <TextField
                     fullWidth
                     label="Umpire 1"
-                    value={
-                      field.value
-                        ? (() => {
-                            const u = umpires.find((u) => u.id === field.value);
-                            return u ? `${u.firstName} ${u.lastName}`.trim() : 'Unknown';
-                          })()
-                        : EMPTY_LABEL
-                    }
+                    value={field.value ? getUmpireLabel(field.value) : EMPTY_LABEL}
                     InputProps={getReadOnlyInputProps()}
                   />
-                )
-              }
-            />
-            <Controller
-              name="umpire2"
-              control={control}
-              render={({ field }) =>
-                canEditSchedule ? (
-                  <FormControl fullWidth error={!!errors.umpire2}>
-                    <InputLabel id="umpire2-label" shrink>
-                      Umpire 2
-                    </InputLabel>
-                    <Select
-                      {...field}
-                      labelId="umpire2-label"
-                      label="Umpire 2"
-                      displayEmpty
-                      value={field.value ?? ''}
-                      renderValue={(selected) => {
-                        if (!selected) {
-                          return EMPTY_LABEL;
-                        }
-                        const option = umpires.find((umpire) => umpire.id === selected);
-                        return option ? `${option.firstName} ${option.lastName}`.trim() : 'Unknown';
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>{EMPTY_LABEL}</em>
-                      </MenuItem>
-                      {getAvailableUmpires('umpire2', field.value ?? '').map((umpire) => (
-                        <MenuItem key={umpire.id} value={umpire.id}>
-                          {`${umpire.firstName} ${umpire.lastName}`.trim()}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <FormHelperText>{errors.umpire2?.message}</FormHelperText>
-                  </FormControl>
-                ) : (
+                )}
+              />
+            )}
+            {canEditSchedule ? (
+              <ControlledOptionAutocomplete
+                name="umpire2"
+                label="Umpire 2"
+                options={buildUmpireOptions('umpire2', watch('umpire2') ?? '')}
+                includeEmpty
+              />
+            ) : (
+              <Controller
+                name="umpire2"
+                control={control}
+                render={({ field }) => (
                   <TextField
                     fullWidth
                     label="Umpire 2"
-                    value={
-                      field.value
-                        ? (() => {
-                            const u = umpires.find((u) => u.id === field.value);
-                            return u ? `${u.firstName} ${u.lastName}`.trim() : 'Unknown';
-                          })()
-                        : EMPTY_LABEL
-                    }
+                    value={field.value ? getUmpireLabel(field.value) : EMPTY_LABEL}
                     InputProps={getReadOnlyInputProps()}
                   />
-                )
-              }
-            />
+                )}
+              />
+            )}
           </Box>
         )}
 
         {/* Umpires Row 2 */}
         {isAccountAdmin && hasOfficials && (
           <Box sx={{ display: 'flex', gap: 2 }}>
-            <Controller
-              name="umpire3"
-              control={control}
-              render={({ field }) =>
-                canEditSchedule ? (
-                  <FormControl fullWidth error={!!errors.umpire3}>
-                    <InputLabel id="umpire3-label" shrink>
-                      Umpire 3
-                    </InputLabel>
-                    <Select
-                      {...field}
-                      labelId="umpire3-label"
-                      label="Umpire 3"
-                      displayEmpty
-                      value={field.value ?? ''}
-                      renderValue={(selected) => {
-                        if (!selected) {
-                          return EMPTY_LABEL;
-                        }
-                        const option = umpires.find((umpire) => umpire.id === selected);
-                        return option ? `${option.firstName} ${option.lastName}`.trim() : 'Unknown';
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>{EMPTY_LABEL}</em>
-                      </MenuItem>
-                      {getAvailableUmpires('umpire3', field.value ?? '').map((umpire) => (
-                        <MenuItem key={umpire.id} value={umpire.id}>
-                          {`${umpire.firstName} ${umpire.lastName}`.trim()}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <FormHelperText>{errors.umpire3?.message}</FormHelperText>
-                  </FormControl>
-                ) : (
+            {canEditSchedule ? (
+              <ControlledOptionAutocomplete
+                name="umpire3"
+                label="Umpire 3"
+                options={buildUmpireOptions('umpire3', watch('umpire3') ?? '')}
+                includeEmpty
+              />
+            ) : (
+              <Controller
+                name="umpire3"
+                control={control}
+                render={({ field }) => (
                   <TextField
                     fullWidth
                     label="Umpire 3"
-                    value={
-                      field.value
-                        ? (() => {
-                            const u = umpires.find((u) => u.id === field.value);
-                            return u ? `${u.firstName} ${u.lastName}`.trim() : 'Unknown';
-                          })()
-                        : EMPTY_LABEL
-                    }
+                    value={field.value ? getUmpireLabel(field.value) : EMPTY_LABEL}
                     InputProps={getReadOnlyInputProps()}
                   />
-                )
-              }
-            />
-            <Controller
-              name="umpire4"
-              control={control}
-              render={({ field }) =>
-                canEditSchedule ? (
-                  <FormControl fullWidth error={!!errors.umpire4}>
-                    <InputLabel id="umpire4-label" shrink>
-                      Umpire 4
-                    </InputLabel>
-                    <Select
-                      {...field}
-                      labelId="umpire4-label"
-                      label="Umpire 4"
-                      displayEmpty
-                      value={field.value ?? ''}
-                      renderValue={(selected) => {
-                        if (!selected) {
-                          return EMPTY_LABEL;
-                        }
-                        const option = umpires.find((umpire) => umpire.id === selected);
-                        return option ? `${option.firstName} ${option.lastName}`.trim() : 'Unknown';
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>{EMPTY_LABEL}</em>
-                      </MenuItem>
-                      {getAvailableUmpires('umpire4', field.value ?? '').map((umpire) => (
-                        <MenuItem key={umpire.id} value={umpire.id}>
-                          {`${umpire.firstName} ${umpire.lastName}`.trim()}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <FormHelperText>{errors.umpire4?.message}</FormHelperText>
-                  </FormControl>
-                ) : (
+                )}
+              />
+            )}
+            {canEditSchedule ? (
+              <ControlledOptionAutocomplete
+                name="umpire4"
+                label="Umpire 4"
+                options={buildUmpireOptions('umpire4', watch('umpire4') ?? '')}
+                includeEmpty
+              />
+            ) : (
+              <Controller
+                name="umpire4"
+                control={control}
+                render={({ field }) => (
                   <TextField
                     fullWidth
                     label="Umpire 4"
-                    value={
-                      field.value
-                        ? (() => {
-                            const u = umpires.find((u) => u.id === field.value);
-                            return u ? `${u.firstName} ${u.lastName}`.trim() : 'Unknown';
-                          })()
-                        : EMPTY_LABEL
-                    }
+                    value={field.value ? getUmpireLabel(field.value) : EMPTY_LABEL}
                     InputProps={getReadOnlyInputProps()}
                   />
-                )
-              }
-            />
+                )}
+              />
+            )}
           </Box>
         )}
 


### PR DESCRIPTION
Replace multiple Select/FormControl usages with MUI Autocomplete for better typeahead UX and consistent filtering. Added createFilterOptions helpers (leagueStartsWithFilter, startsWithFilter, startsWithGameTypeFilter) and a reusable ControlledOptionAutocomplete component to bind Autocomplete to react-hook-form. Converted league, home/visitor teams, field, game type, and umpire selects to Autocomplete (with support for an explicit empty option where needed) and preserved read-only rendering paths. Also added GAME_TYPE_OPTIONS and utility helpers for building options and labels, and adjusted datepicker autofocus behavior for edit mode. Overall refactor improves usability and centralizes option handling.