### PR TITLE
Increase CourseDetailView test timeout to 15s

### DIFF
--- a/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
+++ b/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
@@ -148,7 +148,7 @@ describe('CourseDetailView', () => {
           name: 'Updated Course',
         }),
       );
-    });
+    }, 15000);
 
     it('save button shows saving state while onSave is in progress', async () => {
       const user = userEvent.setup();


### PR DESCRIPTION
Add a 15000ms timeout to the CourseDetailView test hook to allow longer async operations and reduce flaky failures in the test suite. Change applied to frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx.