### PR TITLE
Improve print CSS and layout for printing

### DIFF
--- a/draco-nodejs/backend/src/routes/seasons.ts
+++ b/draco-nodejs/backend/src/routes/seasons.ts
@@ -33,6 +33,7 @@ router.get(
       includeDivisions,
     });
 
+    res.setHeader('Cache-Control', 'no-store');
     res.json(season);
   }),
 );

--- a/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
+++ b/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
@@ -19,14 +19,18 @@ const PrintableLayout: React.FC<PrintableLayoutProps> = ({ children, title, subt
             size: letter portrait;
             margin: 0.4in;
           }
-          body * { visibility: hidden !important; }
-          .dr-print-root, .dr-print-root * { visibility: visible !important; }
-          .dr-print-root {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
+          body *:not(:has(.dr-print-root)):not(.dr-print-root):not(.dr-print-root *) {
+            display: none !important;
           }
+          html, body { min-height: 0 !important; height: auto !important; margin: 0 !important; padding: 0 !important; }
+          body :has(.dr-print-root):not(.dr-print-root) {
+            min-height: 0 !important;
+            height: auto !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            background: none !important;
+          }
+          .dr-print-root { display: block; width: 100%; }
           .print-hidden { display: none !important; }
           .dr-print-row { page-break-inside: avoid; }
         }

--- a/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
+++ b/draco-nodejs/frontend-next/components/print/PrintableLayout.tsx
@@ -22,7 +22,12 @@ const PrintableLayout: React.FC<PrintableLayoutProps> = ({ children, title, subt
           body *:not(:has(.dr-print-root)):not(.dr-print-root):not(.dr-print-root *) {
             display: none !important;
           }
-          html, body { min-height: 0 !important; height: auto !important; margin: 0 !important; padding: 0 !important; }
+          html, body {
+            min-height: 0 !important;
+            height: auto !important;
+            margin: 0 !important;
+            padding: 0 !important;
+          }
           body :has(.dr-print-root):not(.dr-print-root) {
             min-height: 0 !important;
             height: auto !important;

--- a/draco-nodejs/frontend-next/e2e/pages/community-messages.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/community-messages.page.ts
@@ -14,7 +14,9 @@ export class CommunityMessagesPage {
   }
 
   async goto(accountId: string) {
-    await this.page.goto(`/account/${accountId}/social-hub/community`);
-    await this.heading.waitFor({ timeout: 15_000 });
+    await this.page.goto(`/account/${accountId}/social-hub/community`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await this.heading.waitFor({ timeout: 30_000 });
   }
 }

--- a/draco-nodejs/frontend-next/e2e/tests/community/social-hub.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/community/social-hub.spec.ts
@@ -36,11 +36,13 @@ test.describe('Social Hub', () => {
   });
 
   test('community messages sub-page loads', async ({ page, accountId }) => {
-    await page.goto(`/account/${accountId}/social-hub/community`);
-    await expect(page.getByRole('main')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Community Messages' })).toBeVisible({
-      timeout: 15_000,
+    await page.goto(`/account/${accountId}/social-hub/community`, {
+      waitUntil: 'domcontentloaded',
     });
+    await expect(page.getByRole('heading', { name: 'Community Messages' })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('main')).toBeVisible();
   });
 
   test('member businesses sub-page loads', async ({ page, accountId }) => {

--- a/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
@@ -1,5 +1,7 @@
-import { test, expect } from '../fixtures/base-fixtures';
+import { test, expect, getRequiredE2eTestAccountId } from '../fixtures/base-fixtures';
 import { getJwtToken, BASE_URL } from '../helpers/auth';
+import { tryCleanup } from '../helpers/api';
+import { appendCleanupLog } from '../helpers/cleanupLog';
 import { getCurrentSeason, updateSeasonScheduleVisibility } from '@draco/shared-api-client';
 import { createClient, createConfig } from '@draco/shared-api-client/generated/client';
 
@@ -27,7 +29,7 @@ async function setScheduleVisible(accountId: string, seasonId: string, visible: 
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Schedule Visibility Toggle', () => {
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID || '29';
+  const accountId = getRequiredE2eTestAccountId();
   let seasonId: string;
   let originalVisibility: boolean;
 
@@ -52,9 +54,10 @@ test.describe('Schedule Visibility Toggle', () => {
   });
 
   test.afterAll(async () => {
-    if (seasonId) {
-      await setScheduleVisible(accountId, seasonId, originalVisibility);
-    }
+    if (!seasonId) return;
+    const errors: string[] = [];
+    await tryCleanup(errors, () => setScheduleVisible(accountId, seasonId, originalVisibility));
+    appendCleanupLog('schedule-visibility cleanup', errors);
   });
 
   test.beforeEach(async () => {
@@ -62,8 +65,9 @@ test.describe('Schedule Visibility Toggle', () => {
   });
 
   test('admin sees schedule visibility toggle on management page', async ({ page }) => {
-    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`, {
+      waitUntil: 'domcontentloaded',
+    });
 
     const toggle = page.getByRole('switch', { name: /schedule visible to public/i });
     await expect(toggle).toBeVisible();
@@ -72,8 +76,9 @@ test.describe('Schedule Visibility Toggle', () => {
   test('toggle off hides public schedule', async ({ page }) => {
     await setScheduleVisible(accountId, seasonId, false);
 
-    await page.goto(`${BASE_URL}/account/${accountId}/schedule`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule`, {
+      waitUntil: 'domcontentloaded',
+    });
 
     await expect(
       page.getByText('The schedule has not been published yet. Please check back soon.'),
@@ -83,8 +88,9 @@ test.describe('Schedule Visibility Toggle', () => {
   test('toggle on shows public schedule', async ({ page }) => {
     await setScheduleVisible(accountId, seasonId, true);
 
-    await page.goto(`${BASE_URL}/account/${accountId}/schedule`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule`, {
+      waitUntil: 'domcontentloaded',
+    });
 
     await expect(
       page.getByText('The schedule has not been published yet. Please check back soon.'),
@@ -92,8 +98,9 @@ test.describe('Schedule Visibility Toggle', () => {
   });
 
   test('admin can flip toggle via UI and state persists', async ({ page }) => {
-    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`, {
+      waitUntil: 'domcontentloaded',
+    });
 
     const toggle = page.getByRole('switch', { name: /schedule visible to public/i });
     await expect(toggle).toBeChecked();
@@ -101,8 +108,7 @@ test.describe('Schedule Visibility Toggle', () => {
     await toggle.click();
     await expect(toggle).not.toBeChecked();
 
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(toggle).not.toBeChecked();
   });
 });

--- a/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/schedule-visibility.spec.ts
@@ -1,18 +1,7 @@
-import { test as base, expect } from '../fixtures/base-fixtures';
-import { ApiHelper, tryCleanup } from '../helpers/api';
+import { test, expect } from '../fixtures/base-fixtures';
 import { getJwtToken, BASE_URL } from '../helpers/auth';
-import { appendCleanupLog } from '../helpers/cleanupLog';
-import { updateSeasonScheduleVisibility } from '@draco/shared-api-client';
+import { getCurrentSeason, updateSeasonScheduleVisibility } from '@draco/shared-api-client';
 import { createClient, createConfig } from '@draco/shared-api-client/generated/client';
-import type { LeagueSeasonWithDivision, LeagueSeason, TeamSeason } from '@draco/shared-api-client';
-
-type VisibilityFixtureData = {
-  accountId: string;
-  seasonId: string;
-  leagueId: string;
-  leagueSeasonId: string;
-  teamId: string;
-};
 
 function getAdminApiClient() {
   return createClient(
@@ -35,90 +24,55 @@ async function setScheduleVisible(accountId: string, seasonId: string, visible: 
   }
 }
 
-async function createVisibilityTestData(workerIndex: number): Promise<VisibilityFixtureData> {
-  const token = getJwtToken();
-  const api = new ApiHelper(BASE_URL, token);
-  const accountId = process.env.E2E_TEST_ACCOUNT_ID || '29';
-  const suffix = `${Date.now() % 10000000}w${workerIndex}`;
-
-  const season: LeagueSeasonWithDivision = await api.createSeason(accountId, {
-    name: `E2E Vis Season ${suffix}`,
-  });
-
-  const league = await api.createLeague(accountId, { name: `E2E Vis Lg ${suffix}` });
-
-  const leagueSeason: LeagueSeason = await api.addLeagueToSeason(accountId, season.id, league.id);
-
-  const team: TeamSeason = await api.createTeam(accountId, season.id, leagueSeason.id, {
-    name: `E2E Vis Team ${suffix}`,
-  });
-
-  await setScheduleVisible(accountId, season.id, true);
-
-  return {
-    accountId,
-    seasonId: season.id,
-    leagueId: league.id,
-    leagueSeasonId: leagueSeason.id,
-    teamId: team.id,
-  };
-}
-
-async function cleanupVisibilityTestData(data: VisibilityFixtureData): Promise<void> {
-  const token = getJwtToken();
-  const api = new ApiHelper(BASE_URL, token);
-  const errors: string[] = [];
-
-  await tryCleanup(errors, () =>
-    api.removeLeagueFromSeason(data.accountId, data.seasonId, data.leagueSeasonId),
-  );
-
-  await tryCleanup(errors, () => api.deleteLeague(data.accountId, data.leagueId));
-
-  await tryCleanup(errors, () => api.deleteSeason(data.accountId, data.seasonId));
-
-  appendCleanupLog('schedule-visibility cleanup', errors);
-
-  if (errors.length > 0) {
-    throw new Error(`Schedule visibility test cleanup failed:\n  ${errors.join('\n  ')}`);
-  }
-}
-
-type WorkerFixtures = {
-  visibilityData: VisibilityFixtureData;
-};
-
-const test = base.extend<object, WorkerFixtures>({
-  visibilityData: [
-    async ({}, use, workerInfo) => {
-      const data = await createVisibilityTestData(workerInfo.workerIndex);
-      await use(data);
-      await cleanupVisibilityTestData(data);
-    },
-    { scope: 'worker' },
-  ],
-});
+test.describe.configure({ mode: 'serial' });
 
 test.describe('Schedule Visibility Toggle', () => {
-  test.beforeEach(async ({ visibilityData }) => {
-    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, true);
+  const accountId = process.env.E2E_TEST_ACCOUNT_ID || '29';
+  let seasonId: string;
+  let originalVisibility: boolean;
+
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'mutates a singleton account-level flag; running on multiple projects in parallel races on the same row',
+  );
+
+  test.beforeAll(async () => {
+    const client = getAdminApiClient();
+    const { data, error } = await getCurrentSeason({
+      client,
+      path: { accountId },
+    });
+    if (error || !data) {
+      throw new Error(
+        `Failed to load current season for account ${accountId}: ${JSON.stringify(error)}`,
+      );
+    }
+    seasonId = data.id;
+    originalVisibility = data.scheduleVisible ?? false;
   });
 
-  test('admin sees schedule visibility toggle on management page', async ({
-    page,
-    visibilityData,
-  }) => {
-    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
+  test.afterAll(async () => {
+    if (seasonId) {
+      await setScheduleVisible(accountId, seasonId, originalVisibility);
+    }
+  });
+
+  test.beforeEach(async () => {
+    await setScheduleVisible(accountId, seasonId, true);
+  });
+
+  test('admin sees schedule visibility toggle on management page', async ({ page }) => {
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`);
     await page.waitForLoadState('networkidle');
 
     const toggle = page.getByRole('switch', { name: /schedule visible to public/i });
     await expect(toggle).toBeVisible();
   });
 
-  test('toggle off hides public schedule', async ({ page, visibilityData }) => {
-    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, false);
+  test('toggle off hides public schedule', async ({ page }) => {
+    await setScheduleVisible(accountId, seasonId, false);
 
-    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule`);
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule`);
     await page.waitForLoadState('networkidle');
 
     await expect(
@@ -126,10 +80,10 @@ test.describe('Schedule Visibility Toggle', () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test('toggle on shows public schedule', async ({ page, visibilityData }) => {
-    await setScheduleVisible(visibilityData.accountId, visibilityData.seasonId, true);
+  test('toggle on shows public schedule', async ({ page }) => {
+    await setScheduleVisible(accountId, seasonId, true);
 
-    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule`);
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule`);
     await page.waitForLoadState('networkidle');
 
     await expect(
@@ -137,8 +91,8 @@ test.describe('Schedule Visibility Toggle', () => {
     ).not.toBeVisible({ timeout: 10_000 });
   });
 
-  test('admin can flip toggle via UI and state persists', async ({ page, visibilityData }) => {
-    await page.goto(`${BASE_URL}/account/${visibilityData.accountId}/schedule-management`);
+  test('admin can flip toggle via UI and state persists', async ({ page }) => {
+    await page.goto(`${BASE_URL}/account/${accountId}/schedule-management`);
     await page.waitForLoadState('networkidle');
 
     const toggle = page.getByRole('switch', { name: /schedule visible to public/i });

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -46,7 +46,7 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     }
 
     const firstCard = teamSchedulePage.gameCards.first();
-    const noGamesText = page.getByText(/^no games/i).first();
+    const noGamesText = page.getByText(/^No games(?:$| found)/i).first();
     await expect(firstCard.or(noGamesText)).toBeVisible({ timeout: 15_000 });
 
     const cardCount = await teamSchedulePage.gameCards.count();

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -9,7 +9,6 @@ test.describe('Team Schedule - Game Details Dialog', () => {
   });
 
   test('schedule page loads', async ({ page, accountId, seasonId, teamSeasonId }) => {
-    if (!seasonId || !teamSeasonId) return;
     const teamSchedulePage = new TeamSchedulePage(page);
     await teamSchedulePage.goto(accountId, seasonId, teamSeasonId);
     await expect(teamSchedulePage.mainContent).toBeVisible();
@@ -22,7 +21,6 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     seasonId,
     teamSeasonId,
   }) => {
-    if (!seasonId || !teamSeasonId) return;
     test.setTimeout(45_000);
 
     const teamSchedulePage = new TeamSchedulePage(page);

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -8,21 +8,35 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     }
   });
 
-  let teamSchedulePage: TeamSchedulePage;
-
-  test.beforeEach(async ({ page, accountId, seasonId, teamSeasonId }) => {
+  test('schedule page loads', async ({ page, accountId, seasonId, teamSeasonId }) => {
     if (!seasonId || !teamSeasonId) return;
-    teamSchedulePage = new TeamSchedulePage(page);
+    const teamSchedulePage = new TeamSchedulePage(page);
     await teamSchedulePage.goto(accountId, seasonId, teamSeasonId);
-  });
-
-  test('schedule page loads', async () => {
     await expect(teamSchedulePage.mainContent).toBeVisible();
     await expect(teamSchedulePage.scheduleBreadcrumb).toBeVisible();
   });
 
-  test('clicking a game opens the Game Details dialog with real team names', async ({ page }) => {
+  test('clicking a game opens the Game Details dialog with real team names', async ({
+    page,
+    accountId,
+    seasonId,
+    teamSeasonId,
+  }) => {
+    if (!seasonId || !teamSeasonId) return;
     test.setTimeout(45_000);
+
+    const teamSchedulePage = new TeamSchedulePage(page);
+
+    const gamesResponsePromise = page.waitForResponse(
+      (resp) => {
+        const url = resp.url();
+        return /\/teams\/[^/]+\/schedule\?/.test(url) && url.includes('startDate=') && resp.ok();
+      },
+      { timeout: 30_000 },
+    );
+
+    await teamSchedulePage.goto(accountId, seasonId, teamSeasonId);
+    await gamesResponsePromise;
 
     const monthButtonCount = await teamSchedulePage.monthButton.count();
     if (monthButtonCount > 0) {
@@ -32,13 +46,6 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     }
 
     const firstCard = teamSchedulePage.gameCards.first();
-    const noGamesText = page.getByText(/no games found/i).first();
-    await expect(async () => {
-      const hasVisibleCard = await firstCard.isVisible().catch(() => false);
-      const hasVisibleEmptyState = await noGamesText.isVisible().catch(() => false);
-      expect(hasVisibleCard || hasVisibleEmptyState).toBe(true);
-    }).toPass({ timeout: 15_000 });
-
     const cardCount = await teamSchedulePage.gameCards.count();
     test.skip(cardCount === 0, 'No games visible for this team/season');
 

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -46,7 +46,7 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     }
 
     const firstCard = teamSchedulePage.gameCards.first();
-    const noGamesText = page.getByText(/no games found/i).first();
+    const noGamesText = page.getByText(/^no games/i).first();
     await expect(firstCard.or(noGamesText)).toBeVisible({ timeout: 15_000 });
 
     const cardCount = await teamSchedulePage.gameCards.count();

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -46,6 +46,9 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     }
 
     const firstCard = teamSchedulePage.gameCards.first();
+    const noGamesText = page.getByText(/no games found/i).first();
+    await expect(firstCard.or(noGamesText)).toBeVisible({ timeout: 15_000 });
+
     const cardCount = await teamSchedulePage.gameCards.count();
     test.skip(cardCount === 0, 'No games visible for this team/season');
 


### PR DESCRIPTION
## Summary

### Print CSS / layout (primary)
Replace the previous visibility-based print hack with a more robust display-based approach that hides everything except `.dr-print-root` using `:not(:has(.dr-print-root))`. Remove absolute positioning, set `.dr-print-root` to `display: block` at full width, and reset `html`/`body` min-height/height/margins to avoid clipping. Add rules to normalize containers that contain the print root (remove background, reset height/margins/padding). Leave print-hidden and page-break rules intact. These changes fix clipping/stacking issues and preserve layout when printing. Note: relies on CSS `:has()` (supported in all current evergreen browsers).

### Backend
- Add `Cache-Control: no-store` to `GET /api/accounts/:accountId/seasons/current` so freshly toggled `scheduleVisible` is reflected immediately by clients/CDN proxies.

### E2E test stability
- `schedule-visibility.spec.ts`: simplified to mutate the current season's `scheduleVisible` flag and restore it (instead of creating a per-worker dedicated season). Configured `serial` mode and skipped on non-chromium projects to avoid the singleton-flag race. Cleanup wrapped in `tryCleanup` + `appendCleanupLog` so teardown can never throw. `E2E_TEST_ACCOUNT_ID` resolution goes through `getRequiredE2eTestAccountId()`. Replaced `waitForLoadState('networkidle')` with `waitUntil: 'domcontentloaded'` + element waits.
- `team-schedule.spec.ts`: pull `accountId`/`seasonId`/`teamSeasonId` per-test, await the schedule API response, and wait for either a game card or the empty-state text before counting cards (prevents transient zero-count flake).

## Test plan
- [x] `pnpm frontend:lint`
- [x] `pnpm frontend:type-check`
- [ ] `pnpm frontend:e2e -- e2e/tests/schedule-visibility.spec.ts`
- [ ] `pnpm frontend:e2e -- e2e/tests/sports/team-schedule.spec.ts`
- [ ] Manual print verification across pages with `PrintableLayout`