### PR TITLE
Include team names when formatting games

### DIFF
--- a/draco-nodejs/backend/src/services/scheduleService.ts
+++ b/draco-nodejs/backend/src/services/scheduleService.ts
@@ -492,7 +492,15 @@ export class ScheduleService {
 
     const createdGame = await this.scheduleRepository.createGame(createData);
 
-    return ScheduleResponseFormatter.formatGame(createdGame);
+    const teamNames = await this.scheduleRepository.getTeamNames([
+      createdGame.hteamid,
+      createdGame.vteamid,
+    ]);
+
+    return ScheduleResponseFormatter.formatGame(createdGame, {
+      homeTeamName: teamNames.get(createdGame.hteamid.toString()),
+      visitorTeamName: teamNames.get(createdGame.vteamid.toString()),
+    });
   }
 
   async updateGame(
@@ -594,7 +602,15 @@ export class ScheduleService {
 
     const updatedGame = await this.scheduleRepository.updateGame(gameId, updateData);
 
-    return ScheduleResponseFormatter.formatGame(updatedGame);
+    const teamNames = await this.scheduleRepository.getTeamNames([
+      updatedGame.hteamid,
+      updatedGame.vteamid,
+    ]);
+
+    return ScheduleResponseFormatter.formatGame(updatedGame, {
+      homeTeamName: teamNames.get(updatedGame.hteamid.toString()),
+      visitorTeamName: teamNames.get(updatedGame.vteamid.toString()),
+    });
   }
 
   async deleteGame(accountId: bigint, seasonId: bigint, gameId: bigint): Promise<boolean> {

--- a/draco-nodejs/backend/src/services/scheduleService.ts
+++ b/draco-nodejs/backend/src/services/scheduleService.ts
@@ -492,15 +492,7 @@ export class ScheduleService {
 
     const createdGame = await this.scheduleRepository.createGame(createData);
 
-    const teamNames = await this.scheduleRepository.getTeamNames([
-      createdGame.hteamid,
-      createdGame.vteamid,
-    ]);
-
-    return ScheduleResponseFormatter.formatGame(createdGame, {
-      homeTeamName: teamNames.get(createdGame.hteamid.toString()),
-      visitorTeamName: teamNames.get(createdGame.vteamid.toString()),
-    });
+    return this.formatGameWithTeamNames(createdGame);
   }
 
   async updateGame(
@@ -602,15 +594,7 @@ export class ScheduleService {
 
     const updatedGame = await this.scheduleRepository.updateGame(gameId, updateData);
 
-    const teamNames = await this.scheduleRepository.getTeamNames([
-      updatedGame.hteamid,
-      updatedGame.vteamid,
-    ]);
-
-    return ScheduleResponseFormatter.formatGame(updatedGame, {
-      homeTeamName: teamNames.get(updatedGame.hteamid.toString()),
-      visitorTeamName: teamNames.get(updatedGame.vteamid.toString()),
-    });
+    return this.formatGameWithTeamNames(updatedGame);
   }
 
   async deleteGame(accountId: bigint, seasonId: bigint, gameId: bigint): Promise<boolean> {
@@ -707,6 +691,15 @@ export class ScheduleService {
       return null;
     }
     return BigInt(contact.id);
+  }
+
+  private async formatGameWithTeamNames(game: dbScheduleGameWithDetails): Promise<GameType> {
+    const teamNames = await this.scheduleRepository.getTeamNames([game.hteamid, game.vteamid]);
+
+    return ScheduleResponseFormatter.formatGame(game, {
+      homeTeamName: teamNames.get(game.hteamid.toString()),
+      visitorTeamName: teamNames.get(game.vteamid.toString()),
+    });
   }
 
   private parseGameDate(dateString: string): Date {


### PR DESCRIPTION
After creating or updating a game, fetch home/visitor team names via scheduleRepository.getTeamNames and pass them as homeTeamName and visitorTeamName to ScheduleResponseFormatter.formatGame. This enriches the game response with human-readable team names.