### PR TITLE
Validate team/league role season

### DIFF
--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -276,14 +276,20 @@ export class PrismaContactRepository implements IContactRepository {
             AND EXISTS (
               SELECT 1 FROM teamsseason ts_v
               JOIN leagueseason ls_v ON ts_v.leagueseasonid = ls_v.id
-              WHERE ts_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+              JOIN league l_v ON ls_v.leagueid = l_v.id
+              WHERE ts_v.id = cr.roledata
+                AND ls_v.seasonid = ${seasonId}
+                AND l_v.accountid = ${accountId}
             )
           )
           OR (
             cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
             AND EXISTS (
               SELECT 1 FROM leagueseason ls_v
-              WHERE ls_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+              JOIN league l_v ON ls_v.leagueid = l_v.id
+              WHERE ls_v.id = cr.roledata
+                AND ls_v.seasonid = ${seasonId}
+                AND l_v.accountid = ${accountId}
             )
           )
         `
@@ -301,6 +307,11 @@ export class PrismaContactRepository implements IContactRepository {
         AND ts.leagueseasonid = ls_ts.id
         AND ls_ts.seasonid = ${seasonId}
       )
+      LEFT JOIN league l_ts ON (
+        cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
+        AND ls_ts.leagueid = l_ts.id
+        AND l_ts.accountid = ${accountId}
+      )
       LEFT JOIN leagueseason ls ON (
         cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
         AND cr.roledata = ls.id
@@ -309,11 +320,13 @@ export class PrismaContactRepository implements IContactRepository {
       LEFT JOIN league l ON (
         cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
         AND ls.leagueid = l.id
+        AND l.accountid = ${accountId}
       )
         `
         : Prisma.sql`
       LEFT JOIN teamsseason ts ON FALSE
       LEFT JOIN leagueseason ls_ts ON FALSE
+      LEFT JOIN league l_ts ON FALSE
       LEFT JOIN leagueseason ls ON FALSE
       LEFT JOIN league l ON FALSE
         `;
@@ -321,8 +334,8 @@ export class PrismaContactRepository implements IContactRepository {
     const onlyWithRolesSeasonScoped =
       seasonId !== null
         ? Prisma.sql`
-          OR (cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]}) AND ls_ts.id IS NOT NULL)
-          OR (cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]} AND ls.id IS NOT NULL)
+          OR (cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]}) AND l_ts.id IS NOT NULL)
+          OR (cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]} AND l.id IS NOT NULL)
         `
         : Prisma.empty;
 
@@ -422,6 +435,7 @@ export class PrismaContactRepository implements IContactRepository {
         AND (
           ${!onlyWithRoles ? Prisma.sql`cr.roleid IS NULL OR` : Prisma.empty}
           (cr.roleid IN (${ROLE_IDS[RoleNamesType.ACCOUNT_ADMIN]}, ${ROLE_IDS[RoleNamesType.ACCOUNT_PHOTO_ADMIN]}) AND cr.roledata = ${accountId})
+          OR cr.roleid = ${ROLE_IDS[RoleNamesType.ADMINISTRATOR]}
           ${onlyWithRolesSeasonScoped}
         )
       ORDER BY ${Prisma.raw(sortColumn)} ${Prisma.raw(orderDirection)} ${Prisma.raw(nullsOrder)}, contacts.firstname ${Prisma.raw(orderDirection)}, cr.roleid

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -248,6 +248,16 @@ export class PrismaContactRepository implements IContactRepository {
     `);
   }
 
+  /**
+   * Search contacts with role context resolved per-row.
+   *
+   * When `seasonId` is `null`, team and league role predicates are intentionally
+   * omitted from the query: only account-level (`AccountAdmin`,
+   * `AccountPhotoAdmin`) and global (`Administrator`) roles are returned. This
+   * supports the no-current-season state (e.g., a freshly created account).
+   * Pass a concrete `seasonId` to also resolve `TeamAdmin`, `TeamPhotoAdmin`,
+   * and `LeagueAdmin` roles scoped to that season.
+   */
   async searchContactsWithRoles(
     accountId: bigint,
     options: ContactQueryOptions,
@@ -256,8 +266,65 @@ export class PrismaContactRepository implements IContactRepository {
     const { includeContactDetails, searchQuery, onlyWithRoles, pagination, advancedFilter } =
       options;
 
-    // Build advanced filter condition
     const advancedFilterCondition = this.buildAdvancedFilterCondition(advancedFilter);
+
+    const seasonScopedRolePredicates =
+      seasonId !== null
+        ? Prisma.sql`
+          OR (
+            cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
+            AND EXISTS (
+              SELECT 1 FROM teamsseason ts_v
+              JOIN leagueseason ls_v ON ts_v.leagueseasonid = ls_v.id
+              WHERE ts_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+            )
+          )
+          OR (
+            cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
+            AND EXISTS (
+              SELECT 1 FROM leagueseason ls_v
+              WHERE ls_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+            )
+          )
+        `
+        : Prisma.empty;
+
+    const teamLeagueJoins =
+      seasonId !== null
+        ? Prisma.sql`
+      LEFT JOIN teamsseason ts ON (
+        cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
+        AND cr.roledata = ts.id
+      )
+      LEFT JOIN leagueseason ls_ts ON (
+        cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
+        AND ts.leagueseasonid = ls_ts.id
+        AND ls_ts.seasonid = ${seasonId}
+      )
+      LEFT JOIN leagueseason ls ON (
+        cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
+        AND cr.roledata = ls.id
+        AND ls.seasonid = ${seasonId}
+      )
+      LEFT JOIN league l ON (
+        cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
+        AND ls.leagueid = l.id
+      )
+        `
+        : Prisma.sql`
+      LEFT JOIN teamsseason ts ON FALSE
+      LEFT JOIN leagueseason ls_ts ON FALSE
+      LEFT JOIN leagueseason ls ON FALSE
+      LEFT JOIN league l ON FALSE
+        `;
+
+    const onlyWithRolesSeasonScoped =
+      seasonId !== null
+        ? Prisma.sql`
+          OR (cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]}) AND ls_ts.id IS NOT NULL)
+          OR (cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]} AND ls.id IS NOT NULL)
+        `
+        : Prisma.empty;
 
     // Determine sort field and order
     // Map sort fields to SQL columns (hardcoded for defense in depth)
@@ -331,55 +398,13 @@ export class PrismaContactRepository implements IContactRepository {
         contacts.id = cr.contactid
         AND cr.accountid = ${accountId}
         AND (
-          -- Include all valid roles based on type-specific validation
-          cr.roleid IS NULL  -- This won't match but keeps structure
-
-          -- Account roles: Validate roledata matches accountId
+          cr.roleid IS NULL
           OR (cr.roleid IN (${ROLE_IDS[RoleNamesType.ACCOUNT_ADMIN]}, ${ROLE_IDS[RoleNamesType.ACCOUNT_PHOTO_ADMIN]}) AND cr.roledata = ${accountId})
-
-          -- Global roles: No additional restrictions
           OR cr.roleid = ${ROLE_IDS[RoleNamesType.ADMINISTRATOR]}
-
-          -- Team roles: must reference a team in the requested season
-          OR (
-            cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
-            AND EXISTS (
-              SELECT 1 FROM teamsseason ts_v
-              JOIN leagueseason ls_v ON ts_v.leagueseasonid = ls_v.id
-              WHERE ts_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
-            )
-          )
-
-          -- League role: must reference a leagueseason in the requested season
-          OR (
-            cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
-            AND EXISTS (
-              SELECT 1 FROM leagueseason ls_v
-              WHERE ls_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
-            )
-          )
+          ${seasonScopedRolePredicates}
         )
       )
-      -- Team roles: Join to teamsseason and validate season
-      LEFT JOIN teamsseason ts ON (
-        cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
-        AND cr.roledata = ts.id
-      )
-      LEFT JOIN leagueseason ls_ts ON (
-        cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
-        AND ts.leagueseasonid = ls_ts.id
-        AND ls_ts.seasonid = ${seasonId}
-      )
-      -- League role: Join to leagueseason and validate season
-      LEFT JOIN leagueseason ls ON (
-        cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
-        AND cr.roledata = ls.id
-        AND ls.seasonid = ${seasonId}
-      )
-      LEFT JOIN league l ON (
-        cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
-        AND ls.leagueid = l.id
-      )
+      ${teamLeagueJoins}
       WHERE
         contacts.creatoraccountid = ${accountId}
         ${
@@ -395,22 +420,9 @@ export class PrismaContactRepository implements IContactRepository {
         }
         ${advancedFilterCondition}
         AND (
-          ${
-            !onlyWithRoles
-              ? Prisma.sql`
-          -- Include contacts with no roles but only for the given account
-          cr.roleid IS NULL OR
-          `
-              : Prisma.empty
-          }
-          -- Include valid team roles (must have valid season)
-          (cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]}) AND ls_ts.id IS NOT NULL)
-
-          -- Include valid league roles (must have valid season)
-          OR (cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]} AND ls.id IS NOT NULL)
-
-          -- Include valid account roles
-          OR (cr.roleid IN (${ROLE_IDS[RoleNamesType.ACCOUNT_ADMIN]}, ${ROLE_IDS[RoleNamesType.ACCOUNT_PHOTO_ADMIN]}) AND cr.roledata = ${accountId})
+          ${!onlyWithRoles ? Prisma.sql`cr.roleid IS NULL OR` : Prisma.empty}
+          (cr.roleid IN (${ROLE_IDS[RoleNamesType.ACCOUNT_ADMIN]}, ${ROLE_IDS[RoleNamesType.ACCOUNT_PHOTO_ADMIN]}) AND cr.roledata = ${accountId})
+          ${onlyWithRolesSeasonScoped}
         )
       ORDER BY ${Prisma.raw(sortColumn)} ${Prisma.raw(orderDirection)} ${Prisma.raw(nullsOrder)}, contacts.firstname ${Prisma.raw(orderDirection)}, cr.roleid
       ${pagination ? Prisma.sql`LIMIT ${pagination.limit + 1} OFFSET ${(pagination.page - 1) * pagination.limit}` : Prisma.empty}

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -251,7 +251,7 @@ export class PrismaContactRepository implements IContactRepository {
   async searchContactsWithRoles(
     accountId: bigint,
     options: ContactQueryOptions,
-    seasonId?: bigint | null,
+    seasonId: bigint | null,
   ): Promise<dbContactWithRoleAndDetails[]> {
     const { includeContactDetails, searchQuery, onlyWithRoles, pagination, advancedFilter } =
       options;

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -340,8 +340,24 @@ export class PrismaContactRepository implements IContactRepository {
           -- Global roles: No additional restrictions
           OR cr.roleid = ${ROLE_IDS[RoleNamesType.ADMINISTRATOR]}
 
-          -- Team and League roles: Will be validated by subsequent joins
-          OR cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]}, ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]})
+          -- Team roles: must reference a team in the requested season
+          OR (
+            cr.roleid IN (${ROLE_IDS[RoleNamesType.TEAM_ADMIN]}, ${ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]})
+            AND EXISTS (
+              SELECT 1 FROM teamsseason ts_v
+              JOIN leagueseason ls_v ON ts_v.leagueseasonid = ls_v.id
+              WHERE ts_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+            )
+          )
+
+          -- League role: must reference a leagueseason in the requested season
+          OR (
+            cr.roleid = ${ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]}
+            AND EXISTS (
+              SELECT 1 FROM leagueseason ls_v
+              WHERE ls_v.id = cr.roledata AND ls_v.seasonid = ${seasonId}
+            )
+          )
         )
       )
       -- Team roles: Join to teamsseason and validate season

--- a/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
@@ -40,7 +40,7 @@ export interface IContactRepository extends IBaseRepository<contacts> {
   searchContactsWithRoles(
     accountId: bigint,
     options: ContactQueryOptions,
-    seasonId?: bigint | null,
+    seasonId: bigint | null,
   ): Promise<dbContactWithRoleAndDetails[]>;
   searchContactsByName(
     accountId: bigint,

--- a/draco-nodejs/backend/src/services/contactService.ts
+++ b/draco-nodejs/backend/src/services/contactService.ts
@@ -228,6 +228,10 @@ export class ContactService {
       return this.getContactsSimple(accountId, options);
     }
 
+    if (seasonId === undefined || seasonId === null) {
+      throw new ValidationError('seasonId is required when includeRoles is true');
+    }
+
     const rows = await this.contactRepository.searchContactsWithRoles(accountId, options, seasonId);
 
     // Transform the flat rows into the desired structure

--- a/draco-nodejs/backend/src/services/contactService.ts
+++ b/draco-nodejs/backend/src/services/contactService.ts
@@ -206,11 +206,13 @@ export class ContactService {
   }
 
   /**
-   * Get contacts with their roles for a specific account and season
-   * Uses raw SQL for complex role context joins when includeRoles is true
-   * @param accountId - The account ID to get contacts for
-   * @param seasonId - The season ID for role context (optional, defaults to null for backward compatibility)
-   * @param options - Query options including includeRoles, searchQuery, and pagination
+   * Get contacts with their roles for a specific account and season.
+   * Uses raw SQL for complex role context joins when `includeRoles` is true.
+   *
+   * When `seasonId` is omitted or null and `includeRoles` is true, only
+   * account-level and global roles are resolved. Team and league roles are
+   * season-scoped and are excluded in this case (e.g., a freshly created
+   * account that has no current season yet).
    */
   async getContactsWithRoles(
     accountId: bigint,
@@ -223,16 +225,15 @@ export class ContactService {
       pagination.page = 1;
     }
 
-    // If roles are not requested, use the simple Prisma query
     if (!includeRoles) {
       return this.getContactsSimple(accountId, options);
     }
 
-    if (seasonId === undefined || seasonId === null) {
-      throw new ValidationError('seasonId is required when includeRoles is true');
-    }
-
-    const rows = await this.contactRepository.searchContactsWithRoles(accountId, options, seasonId);
+    const rows = await this.contactRepository.searchContactsWithRoles(
+      accountId,
+      options,
+      seasonId ?? null,
+    );
 
     // Transform the flat rows into the desired structure
     return ContactResponseFormatter.formatPagedContactRolesResponse(

--- a/draco-nodejs/frontend-next/components/GameCard.tsx
+++ b/draco-nodejs/frontend-next/components/GameCard.tsx
@@ -566,7 +566,7 @@ const GameCard: React.FC<GameCardProps> = ({
                     sx={{ color: 'text.primary' }}
                     noWrap
                   >
-                    {game.homeTeamName}
+                    @ {game.homeTeamName}
                   </Typography>
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.homeCourseHandicap)}
@@ -716,7 +716,7 @@ const GameCard: React.FC<GameCardProps> = ({
                     sx={{ color: 'text.primary' }}
                     noWrap
                   >
-                    {game.homeTeamName}
+                    @ {game.homeTeamName}
                   </Typography>
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.homeCourseHandicap)}

--- a/draco-nodejs/frontend-next/components/__tests__/GameListDisplay.test.tsx
+++ b/draco-nodejs/frontend-next/components/__tests__/GameListDisplay.test.tsx
@@ -59,7 +59,7 @@ describe('GameListDisplay', () => {
     renderWithTheme(<GameListDisplay sections={mockSections} />);
 
     expect(screen.getByText('Test Section')).toBeInTheDocument();
-    expect(screen.getByText('Home Team')).toBeInTheDocument();
+    expect(screen.getByText(/@\s*Home Team/)).toBeInTheDocument();
     expect(screen.getByText('Visitor Team')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('GameListDisplay', () => {
     renderWithTheme(<GameListDisplay sections={mockSections} layout="horizontal" />);
 
     expect(screen.getByText('Test Section')).toBeInTheDocument();
-    expect(screen.getByText('Home Team')).toBeInTheDocument();
+    expect(screen.getByText(/@\s*Home Team/)).toBeInTheDocument();
     expect(screen.getByText('Visitor Team')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe('GameListDisplay', () => {
     renderWithTheme(<GameListDisplay sections={scheduledSections} />);
 
     expect(screen.getByText('Scheduled Games')).toBeInTheDocument();
-    expect(screen.getByText('Home Team')).toBeInTheDocument();
+    expect(screen.getByText(/@\s*Home Team/)).toBeInTheDocument();
     expect(screen.getByText('Visitor Team')).toBeInTheDocument();
     expect(screen.getByText('TF')).toBeInTheDocument();
   });

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -47,9 +47,15 @@ test.describe('Team Schedule - Game Details Dialog', () => {
     await expect
       .poll(
         async () => {
-          const cards = await teamSchedulePage.gameCards.count();
-          const noGames = await noGamesLocator.count();
-          return cards > 0 || noGames > 0;
+          const firstCardVisible = await teamSchedulePage.gameCards
+            .first()
+            .isVisible()
+            .catch(() => false);
+          const noGamesVisible = await noGamesLocator
+            .first()
+            .isVisible()
+            .catch(() => false);
+          return firstCardVisible || noGamesVisible;
         },
         { timeout: 15_000 },
       )

--- a/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/team-schedule.spec.ts
@@ -43,13 +43,22 @@ test.describe('Team Schedule - Game Details Dialog', () => {
       await teamSchedulePage.monthButton.click();
     }
 
-    const firstCard = teamSchedulePage.gameCards.first();
-    const noGamesText = page.getByText(/^No games(?:$| found)/i).first();
-    await expect(firstCard.or(noGamesText)).toBeVisible({ timeout: 15_000 });
+    const noGamesLocator = page.getByText(/^No games(?:$| found)/i);
+    await expect
+      .poll(
+        async () => {
+          const cards = await teamSchedulePage.gameCards.count();
+          const noGames = await noGamesLocator.count();
+          return cards > 0 || noGames > 0;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
 
     const cardCount = await teamSchedulePage.gameCards.count();
     test.skip(cardCount === 0, 'No games visible for this team/season');
 
+    const firstCard = teamSchedulePage.gameCards.first();
     await firstCard.scrollIntoViewIfNeeded();
     await firstCard.click();
 


### PR DESCRIPTION
Tighten role checks in PrismaContactRepository SQL to ensure team and league roles reference the requested season. Replace the previous broad IN check with EXISTS subqueries: team roles (TEAM_ADMIN, TEAM_PHOTO_ADMIN) must reference a teamsseason whose leagueseason matches the provided seasonId, and LEAGUE_ADMIN must reference a leagueseason with the seasonId. This prevents cross-season role matches.