### PR TITLE
Add player statistics links across components

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/hall-of-fame/HallOfFamePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/hall-of-fame/HallOfFamePage.tsx
@@ -825,7 +825,7 @@ const HallOfFamePage: React.FC<HallOfFamePageProps> = ({ accountId }) => {
                   <Grid container spacing={3}>
                     {membersForSelectedYear.map((member) => (
                       <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={member.id}>
-                        <HofMemberCard member={member} />
+                        <HofMemberCard member={member} accountId={accountId} />
                       </Grid>
                     ))}
                   </Grid>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/social-hub/member-businesses/MemberBusinessDirectoryPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/social-hub/member-businesses/MemberBusinessDirectoryPage.tsx
@@ -156,7 +156,7 @@ const MemberBusinessDirectoryPage: React.FC = () => {
         {businesses.map((business) => (
           <Card key={business.id} variant="outlined" sx={{ borderColor: 'divider' }}>
             <CardContent>
-              <MemberBusinessSummary business={business} />
+              <MemberBusinessSummary business={business} accountId={accountId} />
             </CardContent>
           </Card>
         ))}

--- a/draco-nodejs/frontend-next/components/hall-of-fame/HofMemberCard.tsx
+++ b/draco-nodejs/frontend-next/components/hall-of-fame/HofMemberCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import NextLink from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import {
   Avatar,
   Box,
@@ -16,21 +18,50 @@ import { alpha, useTheme } from '@mui/material/styles';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import type { HofMemberType } from '@draco/shared-schemas';
 import { sanitizeRichContent } from '@/utils/sanitization';
+import { buildPlayerStatisticsHref } from '@/utils/playerLinks';
 import RichTextContent from '../common/RichTextContent';
 
 export interface HofMemberCardProps {
   member: HofMemberType;
+  accountId?: string;
+  playerLinkLabel?: string;
   elevation?: number;
   sx?: SxProps<Theme>;
 }
 
-const HofMemberCard: React.FC<HofMemberCardProps> = ({ member, elevation = 1, sx }) => {
+const HofMemberCard: React.FC<HofMemberCardProps> = ({
+  member,
+  accountId,
+  playerLinkLabel = 'Hall of Fame',
+  elevation = 1,
+  sx,
+}) => {
   const theme = useTheme();
-  const { contact, biographyHtml, yearInducted } = member;
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { contact, contactId, biographyHtml, yearInducted } = member;
   const sanitized = biographyHtml ? sanitizeRichContent(biographyHtml) : null;
   const sanitizedBio = sanitized && sanitized.length > 0 ? sanitized : null;
 
   const displayName = contact.displayName ?? `${contact.firstName} ${contact.lastName}`.trim();
+
+  const currentLocation = (() => {
+    if (!pathname) {
+      return null;
+    }
+    const query = searchParams?.toString() ?? '';
+    return query.length > 0 ? `${pathname}?${query}` : pathname;
+  })();
+
+  const playerHref = accountId
+    ? buildPlayerStatisticsHref({
+        accountId,
+        contactId,
+        returnTo: currentLocation,
+        returnLabel: playerLinkLabel,
+      })
+    : null;
+
   const baseColor = theme.palette.primary.main;
   const avatarShadow = theme.shadows[4];
   const avatarBorderColor = alpha(baseColor, theme.palette.mode === 'dark' ? 0.6 : 0.25);
@@ -67,14 +98,35 @@ const HofMemberCard: React.FC<HofMemberCardProps> = ({ member, elevation = 1, sx
           </Avatar>
 
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography
-              variant="h6"
-              component="h3"
-              sx={{ fontWeight: 700, color: 'text.primary' }}
-              noWrap
-            >
-              {displayName}
-            </Typography>
+            {playerHref ? (
+              <Typography
+                component={NextLink}
+                href={playerHref}
+                prefetch={false}
+                variant="h6"
+                sx={{
+                  display: 'block',
+                  fontWeight: 700,
+                  color: 'primary.main',
+                  textDecoration: 'none',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {displayName}
+              </Typography>
+            ) : (
+              <Typography
+                variant="h6"
+                component="h3"
+                sx={{ fontWeight: 700, color: 'text.primary' }}
+                noWrap
+              >
+                {displayName}
+              </Typography>
+            )}
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
               <Chip
                 icon={<EmojiEventsIcon fontSize="small" />}

--- a/draco-nodejs/frontend-next/components/hall-of-fame/HofSpotlightWidget.tsx
+++ b/draco-nodejs/frontend-next/components/hall-of-fame/HofSpotlightWidget.tsx
@@ -186,7 +186,12 @@ const HofSpotlightWidget: React.FC<HofSpotlightWidgetProps> = ({ accountId, hide
         ) : hallOfFameMembers.length > 0 ? (
           <Stack spacing={2} sx={{ width: '100%' }}>
             {hallOfFameMembers.map((member) => (
-              <HofMemberCard key={member.id} member={member} />
+              <HofMemberCard
+                key={member.id}
+                member={member}
+                accountId={accountId}
+                playerLinkLabel="Hall of Fame Spotlight"
+              />
             ))}
           </Stack>
         ) : (

--- a/draco-nodejs/frontend-next/components/profile/MemberBusinessSummary.tsx
+++ b/draco-nodejs/frontend-next/components/profile/MemberBusinessSummary.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import type { FC } from 'react';
+import NextLink from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { Box, Link as MuiLink, Stack, Typography } from '@mui/material';
 import type { MemberBusinessType } from '@draco/shared-schemas';
 import UserAvatar from '@/components/users/UserAvatar';
+import { buildPlayerStatisticsHref } from '@/utils/playerLinks';
 
 interface MemberBusinessSummaryProps {
   business: MemberBusinessType;
   compact?: boolean;
+  accountId?: string;
+  playerLinkLabel?: string;
 }
 
 interface RenderLineOptions {
@@ -40,11 +45,37 @@ const renderLine = (
   );
 };
 
-const MemberBusinessSummary: FC<MemberBusinessSummaryProps> = ({ business, compact = false }) => {
+const MemberBusinessSummary: FC<MemberBusinessSummaryProps> = ({
+  business,
+  compact = false,
+  accountId,
+  playerLinkLabel = 'Member Businesses',
+}) => {
   const titleVariant = compact ? 'subtitle2' : 'h6';
   const descriptionVariant = compact ? 'body2' : 'body1';
   const ownerNameVariant = compact ? 'body2' : 'body1';
   const avatarSize = compact ? 32 : 40;
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentLocation = (() => {
+    if (!pathname) {
+      return null;
+    }
+    const query = searchParams?.toString() ?? '';
+    return query.length > 0 ? `${pathname}?${query}` : pathname;
+  })();
+
+  const playerHref = accountId
+    ? buildPlayerStatisticsHref({
+        accountId,
+        contactId: business.contact.id,
+        returnTo: currentLocation,
+        returnLabel: playerLinkLabel,
+      })
+    : null;
+
+  const ownerName = `${business.contact.firstName} ${business.contact.lastName}`;
 
   return (
     <Stack spacing={1.25}>
@@ -58,9 +89,26 @@ const MemberBusinessSummary: FC<MemberBusinessSummaryProps> = ({ business, compa
           }}
           size={avatarSize}
         />
-        <Typography variant={ownerNameVariant} fontWeight={600}>
-          {business.contact.firstName} {business.contact.lastName}
-        </Typography>
+        {playerHref ? (
+          <Typography
+            component={NextLink}
+            href={playerHref}
+            prefetch={false}
+            variant={ownerNameVariant}
+            sx={{
+              fontWeight: 600,
+              color: 'primary.main',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            {ownerName}
+          </Typography>
+        ) : (
+          <Typography variant={ownerNameVariant} fontWeight={600}>
+            {ownerName}
+          </Typography>
+        )}
       </Stack>
 
       <Box>

--- a/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
+++ b/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import NextLink from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
@@ -24,6 +26,7 @@ import {
 import { useAuth } from '@/context/AuthContext';
 import { useApiClient } from '@/hooks/useApiClient';
 import { unwrapApiResult } from '@/utils/apiResult';
+import { buildPlayerStatisticsHref } from '@/utils/playerLinks';
 import {
   getPublicTeamRosterMembers,
   getTeamRosterMembers as apiGetTeamRosterMembers,
@@ -64,6 +67,16 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
   const { settings: accountSettings } = useAccountSettings(accountId);
   const apiClient = useApiClient();
   const { token } = useAuth();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentLocation = (() => {
+    if (!pathname) {
+      return null;
+    }
+    const query = searchParams?.toString() ?? '';
+    return query.length > 0 ? `${pathname}?${query}` : pathname;
+  })();
+  const playerLinkLabel = 'Team Roster';
   const isAuthenticated = Boolean(token);
   const hasPrivateAccess = isAuthenticated && canViewSensitiveDetails;
   const allowPhotoEdit = Boolean(canEditPhotos);
@@ -345,6 +358,13 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
               lastName: member.player.contact.lastName,
               photoUrl: member.player.contact.photoUrl,
             };
+            const playerHref = buildPlayerStatisticsHref({
+              accountId,
+              contactId: member.player.contact.id,
+              returnTo: currentLocation,
+              returnLabel: playerLinkLabel,
+            });
+            const displayName = getContactDisplayName(member.player.contact);
 
             return (
               <TableRow key={member.id} hover>
@@ -368,9 +388,27 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
                       }
                     />
                     <Box sx={{ flex: 1 }}>
-                      <Typography variant="body2" fontWeight={600}>
-                        {getContactDisplayName(member.player.contact)}
-                      </Typography>
+                      {playerHref ? (
+                        <Typography
+                          component={NextLink}
+                          href={playerHref}
+                          prefetch={false}
+                          variant="body2"
+                          sx={{
+                            display: 'block',
+                            fontWeight: 600,
+                            color: 'primary.main',
+                            textDecoration: 'none',
+                            '&:hover': { textDecoration: 'underline' },
+                          }}
+                        >
+                          {displayName}
+                        </Typography>
+                      ) : (
+                        <Typography variant="body2" fontWeight={600}>
+                          {displayName}
+                        </Typography>
+                      )}
                       <Typography variant="caption" color="text.secondary">
                         First Year: {member.player.firstYear || 'Not set'}
                       </Typography>

--- a/draco-nodejs/frontend-next/components/social/MemberBusinessSpotlightWidget.tsx
+++ b/draco-nodejs/frontend-next/components/social/MemberBusinessSpotlightWidget.tsx
@@ -106,7 +106,12 @@ const MemberBusinessSpotlightWidget: React.FC<MemberBusinessSpotlightWidgetProps
       <Stack spacing={2}>
         {businesses.map((business, index) => (
           <React.Fragment key={business.id}>
-            <MemberBusinessSummary business={business} compact />
+            <MemberBusinessSummary
+              business={business}
+              compact
+              accountId={accountId}
+              playerLinkLabel="Member Business Spotlight"
+            />
             {index < businesses.length - 1 ? (
               <Divider sx={{ borderColor: 'widget.border' }} />
             ) : null}

--- a/draco-nodejs/frontend-next/components/surveys/SurveySpotlightWidget.tsx
+++ b/draco-nodejs/frontend-next/components/surveys/SurveySpotlightWidget.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import {
   Alert,
   Box,
@@ -17,6 +18,7 @@ import { getPlayerSurveySpotlight, getPlayerSurveyTeamSpotlight } from '@draco/s
 import { PlayerSurveySpotlightSchema, type PlayerSurveySpotlightType } from '@draco/shared-schemas';
 import { useApiClient } from '@/hooks/useApiClient';
 import { ApiClientError, unwrapApiResult } from '@/utils/apiResult';
+import { buildPlayerStatisticsHref } from '@/utils/playerLinks';
 import WidgetShell from '../ui/WidgetShell';
 
 type SpotlightStatus = 'loading' | 'success' | 'empty' | 'error';
@@ -106,11 +108,22 @@ const SurveySpotlightWidget: React.FC<SurveySpotlightWidgetProps> = ({
   viewSurveysLabel = 'View Surveys',
 }) => {
   const apiClient = useApiClient();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [status, setStatus] = React.useState<SpotlightStatus>('loading');
   const [spotlight, setSpotlight] = React.useState<PlayerSurveySpotlightType | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
   const fallbackMessage = getFallbackError(teamSeasonId);
+
+  const currentLocation = (() => {
+    if (!pathname) {
+      return null;
+    }
+    const query = searchParams?.toString() ?? '';
+    return query.length > 0 ? `${pathname}?${query}` : pathname;
+  })();
+  const playerLinkLabel = title;
   const accountSurveyHref = surveysHref
     ? surveysHref
     : accountId
@@ -248,6 +261,12 @@ const SurveySpotlightWidget: React.FC<SurveySpotlightWidgetProps> = ({
 
     const playerName = formatPlayerName(spotlight);
     const teamSuffix = spotlight.teamName ? ` • ${spotlight.teamName}` : '';
+    const playerHref = buildPlayerStatisticsHref({
+      accountId,
+      contactId: spotlight.player.id,
+      returnTo: currentLocation,
+      returnLabel: playerLinkLabel,
+    });
 
     return (
       <Stack spacing={2}>
@@ -263,7 +282,27 @@ const SurveySpotlightWidget: React.FC<SurveySpotlightWidgetProps> = ({
               {playerName.charAt(0)}
             </Avatar>
             <Typography variant="body2" color="text.secondary">
-              — {playerName}
+              {'— '}
+              {playerHref ? (
+                <Typography
+                  component={Link}
+                  href={playerHref}
+                  prefetch={false}
+                  variant="body2"
+                  sx={{
+                    color: 'primary.main',
+                    fontWeight: 600,
+                    textDecoration: 'none',
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  {playerName}
+                </Typography>
+              ) : (
+                <Typography component="span" variant="body2" sx={{ fontWeight: 600 }}>
+                  {playerName}
+                </Typography>
+              )}
               {teamSuffix}
             </Typography>
           </Stack>

--- a/draco-nodejs/frontend-next/components/surveys/__tests__/SurveySpotlightWidget.test.tsx
+++ b/draco-nodejs/frontend-next/components/surveys/__tests__/SurveySpotlightWidget.test.tsx
@@ -22,6 +22,11 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/account/acc-1/surveys',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 const buildSpotlightResponse = (overrides = {}) =>
   ({
     data: {

--- a/draco-nodejs/frontend-next/components/team/TeamManagersWidget.tsx
+++ b/draco-nodejs/frontend-next/components/team/TeamManagersWidget.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import NextLink from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { Alert, Box, CircularProgress, Link as MuiLink, Typography } from '@mui/material';
 import EmailIcon from '@mui/icons-material/EmailOutlined';
 import PhoneIcon from '@mui/icons-material/Phone';
@@ -12,6 +14,7 @@ import { useApiClient } from '@/hooks/useApiClient';
 import { useAuth } from '@/context/AuthContext';
 import { getContactDisplayName } from '@/utils/contactUtils';
 import { formatPhoneNumber } from '@/utils/phoneNumber';
+import { buildPlayerStatisticsHref } from '@/utils/playerLinks';
 import UserAvatar from '@/components/users/UserAvatar';
 import ContactPhotoUploadDialog from '@/components/users/ContactPhotoUploadDialog';
 import PhotoDeleteDialog from '@/components/users/PhotoDeleteDialog';
@@ -36,6 +39,16 @@ const TeamManagersWidget: React.FC<TeamManagersWidgetProps> = ({
 }) => {
   const apiClient = useApiClient();
   const { token } = useAuth();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentLocation = (() => {
+    if (!pathname) {
+      return null;
+    }
+    const query = searchParams?.toString() ?? '';
+    return query.length > 0 ? `${pathname}?${query}` : pathname;
+  })();
+  const playerLinkLabel = 'Team Managers';
 
   const [managers, setManagers] = React.useState<TeamManagerType[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -177,6 +190,13 @@ const TeamManagersWidget: React.FC<TeamManagersWidgetProps> = ({
     const showContactInfo = canViewContactInfo;
     const phoneEntries = showContactInfo ? buildPhoneEntries(manager) : [];
     const canEditManagerPhoto = Boolean(canEditPhotos && token);
+    const displayName = getContactDisplayName(contact);
+    const playerHref = buildPlayerStatisticsHref({
+      accountId,
+      contactId: contact.id,
+      returnTo: currentLocation,
+      returnLabel: playerLinkLabel,
+    });
     return (
       <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
@@ -200,9 +220,27 @@ const TeamManagersWidget: React.FC<TeamManagersWidgetProps> = ({
             }
           />
           <Box>
-            <Typography variant="subtitle1" fontWeight={600}>
-              {getContactDisplayName(contact)}
-            </Typography>
+            {playerHref ? (
+              <Typography
+                component={NextLink}
+                href={playerHref}
+                prefetch={false}
+                variant="subtitle1"
+                sx={{
+                  display: 'block',
+                  fontWeight: 600,
+                  color: 'primary.main',
+                  textDecoration: 'none',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {displayName}
+              </Typography>
+            ) : (
+              <Typography variant="subtitle1" fontWeight={600}>
+                {displayName}
+              </Typography>
+            )}
             {manager.team?.name ? (
               <Typography variant="body2" color="text.secondary">
                 {manager.team.name}

--- a/draco-nodejs/frontend-next/utils/playerLinks.ts
+++ b/draco-nodejs/frontend-next/utils/playerLinks.ts
@@ -1,0 +1,41 @@
+export interface BuildPlayerStatisticsHrefOptions {
+  accountId: string;
+  contactId: string | number | null | undefined;
+  returnTo?: string | null;
+  returnLabel?: string | null;
+}
+
+export const buildPlayerStatisticsHref = ({
+  accountId,
+  contactId,
+  returnTo,
+  returnLabel,
+}: BuildPlayerStatisticsHrefOptions): string | null => {
+  if (!accountId) {
+    return null;
+  }
+
+  if (contactId === null || contactId === undefined) {
+    return null;
+  }
+
+  const identifier = typeof contactId === 'number' ? String(contactId) : String(contactId).trim();
+
+  if (!identifier) {
+    return null;
+  }
+
+  const basePath = `/account/${accountId}/players/${identifier}/statistics`;
+  const query = new URLSearchParams();
+
+  if (returnTo) {
+    query.set('returnTo', returnTo);
+    const label = returnLabel?.trim() ?? '';
+    if (label.length > 0) {
+      query.set('returnLabel', label);
+    }
+  }
+
+  const queryString = query.toString();
+  return queryString.length > 0 ? `${basePath}?${queryString}` : basePath;
+};


### PR DESCRIPTION
Introduce buildPlayerStatisticsHref util and wire player statistics links into multiple components (HofMemberCard, HofSpotlightWidget, HallOfFamePage, MemberBusinessSummary, MemberBusinessDirectoryPage, MemberBusinessSpotlightWidget, TeamRosterWidget, TeamManagersWidget, SurveySpotlightWidget). Components now use next/link and next/navigation to build contextual hrefs that include returnTo/returnLabel query params, and fall back when accountId/contactId are absent. Also add a small test mock for next/navigation used by SurveySpotlightWidget tests.