### PR TITLE
Add .ics calendar export utilities and UI

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -22,8 +22,17 @@ import usePrintAction from '../../../../components/print/usePrintAction';
 import SchedulePrintView from '../../../../components/schedule/SchedulePrintView';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import PrintIcon from '@mui/icons-material/Print';
+import EventIcon from '@mui/icons-material/Event';
+import {
+  buildIcsContent,
+  downloadIcsFile,
+  formatLocalDateStamp,
+  gameToCalendarEvent,
+  sanitizeIcsFilename,
+} from '../../../../utils/calendar';
 
 interface ScheduleProps {
   accountId: string;
@@ -155,6 +164,19 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
 
   const printTitle = currentSeasonName ? `${currentSeasonName} Schedule` : 'Schedule';
 
+  const handleDownloadCalendar = () => {
+    if (filteredGames.length === 0) return;
+    const pageHref = `/account/${accountId}/schedule`;
+    const origin = window.location.origin;
+    const events = filteredGames.map((game) =>
+      gameToCalendarEvent(convertGameToGameCardDataWithTeams(game), { origin, pageHref }),
+    );
+    const accountName = currentAccount?.name ?? 'account';
+    const yyyymmdd = formatLocalDateStamp(new Date());
+    const filename = `${sanitizeIcsFilename(`${accountName}_schedule_${yyyymmdd}`)}.ics`;
+    downloadIcsFile(filename, buildIcsContent(events));
+  };
+
   const handleViewModeChange = (mode: ViewMode) => {
     setManualViewMode(mode === defaultViewMode ? null : mode);
   };
@@ -192,7 +214,23 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
       title="Schedule"
       seasonName={currentSeasonName}
       breadcrumbs={
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mb: 2 }}>
+          <Tooltip
+            title={filteredGames.length === 0 ? 'No games to export' : 'Download schedule (.ics)'}
+          >
+            <span>
+              <Button
+                className="print-hidden"
+                variant="outlined"
+                size="small"
+                startIcon={<EventIcon />}
+                onClick={handleDownloadCalendar}
+                disabled={filteredGames.length === 0}
+              >
+                Download .ics
+              </Button>
+            </span>
+          </Tooltip>
           <Button
             className="print-hidden"
             variant="outlined"

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -32,9 +32,18 @@ import SeasonSummaryWidget from '../../../../../../../../components/schedule/Sea
 import usePrintAction from '../../../../../../../../components/print/usePrintAction';
 import SchedulePrintView from '../../../../../../../../components/schedule/SchedulePrintView';
 import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
 import PrintIcon from '@mui/icons-material/Print';
+import EventIcon from '@mui/icons-material/Event';
 import { isGolfLeagueAccountType } from '../../../../../../../../utils/accountTypeUtils';
 import Stack from '@mui/material/Stack';
+import {
+  buildIcsContent,
+  downloadIcsFile,
+  formatLocalDateStamp,
+  gameToCalendarEvent,
+  sanitizeIcsFilename,
+} from '../../../../../../../../utils/calendar';
 
 interface TeamSchedulePageProps {
   accountId: string;
@@ -228,6 +237,19 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
 
   const printTitle = [teamName ?? 'Team', seasonName ?? ''].filter(Boolean).join(' — ');
 
+  const handleDownloadCalendar = () => {
+    if (filteredGames.length === 0) return;
+    const pageHref = `/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`;
+    const origin = window.location.origin;
+    const events = filteredGames.map((game) =>
+      gameToCalendarEvent(convertGameToGameCardDataWithTeams(game), { origin, pageHref }),
+    );
+    const baseName = teamName ?? 'team';
+    const yyyymmdd = formatLocalDateStamp(new Date());
+    const filename = `${sanitizeIcsFilename(`${baseName}_schedule_${yyyymmdd}`)}.ics`;
+    downloadIcsFile(filename, buildIcsContent(events));
+  };
+
   const handleViewModeChange = (mode: ViewMode) => {
     setManualViewMode(mode === defaultViewMode ? null : mode);
   };
@@ -290,15 +312,33 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
             </Link>
             <Typography color="text.primary">Schedule</Typography>
           </Breadcrumbs>
-          <Button
-            className="print-hidden"
-            variant="outlined"
-            size="small"
-            startIcon={<PrintIcon />}
-            onClick={triggerPrint}
-          >
-            Print
-          </Button>
+          <Stack direction="row" spacing={1}>
+            <Tooltip
+              title={filteredGames.length === 0 ? 'No games to export' : 'Download schedule (.ics)'}
+            >
+              <span>
+                <Button
+                  className="print-hidden"
+                  variant="outlined"
+                  size="small"
+                  startIcon={<EventIcon />}
+                  onClick={handleDownloadCalendar}
+                  disabled={filteredGames.length === 0}
+                >
+                  Download .ics
+                </Button>
+              </span>
+            </Tooltip>
+            <Button
+              className="print-hidden"
+              variant="outlined"
+              size="small"
+              startIcon={<PrintIcon />}
+              onClick={triggerPrint}
+            >
+              Print
+            </Button>
+          </Stack>
         </Stack>
       }
       seasonName={null}

--- a/draco-nodejs/frontend-next/components/workouts/WorkoutDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/workouts/WorkoutDisplay.tsx
@@ -25,6 +25,12 @@ import { unwrapApiResult } from '../../utils/apiResult';
 import { FieldDetailsCard, type FieldDetails } from '../fields/FieldDetailsCard';
 import ButtonBase from '@mui/material/ButtonBase';
 import RichTextContent from '../common/RichTextContent';
+import {
+  buildIcsContent,
+  downloadIcsFile,
+  sanitizeIcsFilename,
+  type CalendarEvent,
+} from '../../utils/calendar';
 
 interface WorkoutDisplayProps {
   accountId: string;
@@ -186,48 +192,16 @@ export const WorkoutDisplay: React.FC<WorkoutDisplayProps> = ({
 
   const handleAddToCalendar = () => {
     if (!workout) return;
-
-    // Create calendar event data
-    const eventTitle = workout.workoutDesc;
-    const eventStart = new Date(workout.workoutDate);
-    const eventEnd = new Date(workout.workoutDate); // Assuming it's a single-day event
-    const eventLocation = getFieldName(workout.field?.id || null);
-    const eventDescription = workout.comments || '';
-    const eventUrl = `/account/${accountId}/workouts`;
-
-    // Format dates for iCal format
-    const formatDateForICal = (date: Date) => {
-      return date
-        .toISOString()
-        .replace(/[-:]/g, '')
-        .replace(/\.\d{3}/, '');
+    const event: CalendarEvent = {
+      uid: `workout-${workout.id}@draco`,
+      title: workout.workoutDesc,
+      start: new Date(workout.workoutDate),
+      end: new Date(workout.workoutDate),
+      location: getFieldName(workout.field?.id || null),
+      description: workout.comments || '',
+      url: `${window.location.origin}/account/${accountId}/workouts`,
     };
-
-    // Create iCal content
-    const icalContent = [
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'PRODID:-//Draco//Workout Calendar//EN',
-      'BEGIN:VEVENT',
-      `DTSTART:${formatDateForICal(eventStart)}`,
-      `DTEND:${formatDateForICal(eventEnd)}`,
-      `SUMMARY:${eventTitle}`,
-      `DESCRIPTION:${eventDescription}`,
-      `LOCATION:${eventLocation}`,
-      `URL:${window.location.origin}${eventUrl}`,
-      'END:VEVENT',
-      'END:VCALENDAR',
-    ].join('\r\n');
-
-    // Create and download the .ics file
-    const blob = new Blob([icalContent], { type: 'text/calendar;charset=utf-8' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `${eventTitle.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.ics`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(link.href);
+    downloadIcsFile(`${sanitizeIcsFilename(workout.workoutDesc)}.ics`, buildIcsContent([event]));
   };
 
   if (loading) {

--- a/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import type { GameCardData } from '../../components/GameCard';
+import {
+  buildIcsContent,
+  CalendarEvent,
+  gameToCalendarEvent,
+  sanitizeIcsFilename,
+} from '../calendar';
+
+const sampleEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  uid: 'game-123@draco',
+  title: 'Eagles @ Hawks',
+  start: new Date(Date.UTC(2026, 4, 4, 18, 30, 0)),
+  end: new Date(Date.UTC(2026, 4, 4, 18, 30, 0)),
+  location: 'Memorial Field',
+  description: 'Regular season game',
+  url: 'https://example.com/account/1/schedule',
+  ...overrides,
+});
+
+const baseGame: GameCardData = {
+  id: '42',
+  date: '2026-05-04T18:30:00.000Z',
+  homeTeamId: 'home-1',
+  visitorTeamId: 'visitor-1',
+  homeTeamName: 'Hawks',
+  visitorTeamName: 'Eagles',
+  homeScore: 0,
+  visitorScore: 0,
+  gameStatus: 0,
+  gameStatusText: 'Scheduled',
+  leagueName: 'AAA',
+  fieldId: 'f1',
+  fieldName: 'Memorial Field',
+  fieldShortName: 'MF',
+  hasGameRecap: false,
+  gameRecaps: [],
+};
+
+describe('buildIcsContent', () => {
+  it('produces a valid VCALENDAR envelope', () => {
+    const ics = buildIcsContent([sampleEvent()]);
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('VERSION:2.0');
+    expect(ics).toContain('PRODID:-//Draco//Calendar//EN');
+    expect(ics).toContain('CALSCALE:GREGORIAN');
+    expect(ics).toContain('END:VCALENDAR');
+  });
+
+  it('emits required event properties for each event', () => {
+    const ics = buildIcsContent([sampleEvent()]);
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('END:VEVENT');
+    expect(ics).toContain('UID:game-123@draco');
+    expect(ics).toMatch(/DTSTAMP:\d{8}T\d{6}Z/);
+    expect(ics).toContain('DTSTART:20260504T183000Z');
+    expect(ics).toContain('DTEND:20260504T183000Z');
+    expect(ics).toContain('SUMMARY:Eagles @ Hawks');
+  });
+
+  it('escapes commas, semicolons, backslashes, and newlines in text fields', () => {
+    const ics = buildIcsContent([
+      sampleEvent({
+        title: 'Bring water, snacks; gear',
+        description: 'Line one\nLine two; with a path C:\\Sports',
+        location: 'Field 1, North Lot',
+      }),
+    ]);
+    expect(ics).toContain('SUMMARY:Bring water\\, snacks\\; gear');
+    expect(ics).toContain('LOCATION:Field 1\\, North Lot');
+    expect(ics).toContain('DESCRIPTION:Line one\\nLine two\\; with a path C:\\\\Sports');
+  });
+
+  it('emits multiple VEVENT blocks in input order', () => {
+    const ics = buildIcsContent([
+      sampleEvent({ uid: 'a', title: 'First' }),
+      sampleEvent({ uid: 'b', title: 'Second' }),
+    ]);
+    const blocks = ics.split('BEGIN:VEVENT').slice(1);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain('UID:a');
+    expect(blocks[0]).toContain('SUMMARY:First');
+    expect(blocks[1]).toContain('UID:b');
+    expect(blocks[1]).toContain('SUMMARY:Second');
+  });
+
+  it('folds lines longer than 75 octets per RFC 5545', () => {
+    const longDescription = 'x'.repeat(200);
+    const ics = buildIcsContent([sampleEvent({ description: longDescription })]);
+    const descriptionLines = ics
+      .split('\r\n')
+      .filter((line) => line.startsWith('DESCRIPTION:') || line.startsWith(' '));
+    expect(descriptionLines.length).toBeGreaterThan(1);
+    for (const line of descriptionLines) {
+      const byteLength = new TextEncoder().encode(line).length;
+      expect(byteLength).toBeLessThanOrEqual(75);
+    }
+  });
+
+  it('joins lines with CRLF', () => {
+    const ics = buildIcsContent([sampleEvent()]);
+    expect(ics.includes('\r\n')).toBe(true);
+    expect(ics.includes('\n\n')).toBe(false);
+  });
+});
+
+describe('sanitizeIcsFilename', () => {
+  it('lowercases and replaces non-alphanumeric runs with single underscore', () => {
+    expect(sanitizeIcsFilename('Spring 2026 Schedule!')).toBe('spring_2026_schedule');
+  });
+
+  it('strips path separators', () => {
+    expect(sanitizeIcsFilename('teams/eagles\\hawks')).toBe('teams_eagles_hawks');
+  });
+
+  it('falls back to "calendar" for empty input', () => {
+    expect(sanitizeIcsFilename('   ')).toBe('calendar');
+    expect(sanitizeIcsFilename('!!!')).toBe('calendar');
+  });
+});
+
+describe('gameToCalendarEvent', () => {
+  it('builds Visitor @ Home title with league prefix', () => {
+    const event = gameToCalendarEvent(baseGame, {
+      origin: 'https://example.com',
+      pageHref: '/account/1/schedule',
+    });
+    expect(event.title).toBe('AAA: Eagles @ Hawks');
+  });
+
+  it('produces a zero-duration event matching the workouts pattern', () => {
+    const event = gameToCalendarEvent(baseGame, {
+      origin: 'https://example.com',
+      pageHref: '/account/1/schedule',
+    });
+    expect(event.start.toISOString()).toBe(event.end.toISOString());
+  });
+
+  it('uses fieldDetails address when present', () => {
+    const event = gameToCalendarEvent(
+      {
+        ...baseGame,
+        fieldDetails: {
+          id: 'f1',
+          name: 'Memorial Field',
+          shortName: 'MF',
+          address: '123 Main St',
+          city: 'Springfield',
+          state: 'IL',
+          zip: '62701',
+        },
+      },
+      { origin: 'https://example.com', pageHref: '/account/1/schedule' },
+    );
+    expect(event.location).toBe('Memorial Field, 123 Main St, Springfield, IL 62701');
+  });
+
+  it('falls back to fieldName when fieldDetails is absent', () => {
+    const event = gameToCalendarEvent(baseGame, {
+      origin: 'https://example.com',
+      pageHref: '/account/1/schedule',
+    });
+    expect(event.location).toBe('Memorial Field');
+  });
+
+  it('uses a stable UID derived from game id', () => {
+    const event = gameToCalendarEvent(baseGame, {
+      origin: 'https://example.com',
+      pageHref: '/account/1/schedule',
+    });
+    expect(event.uid).toBe('game-42@draco');
+  });
+
+  it('builds URL from origin and pageHref', () => {
+    const event = gameToCalendarEvent(baseGame, {
+      origin: 'https://example.com',
+      pageHref: '/account/1/schedule',
+    });
+    expect(event.url).toBe('https://example.com/account/1/schedule');
+  });
+});

--- a/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { GameCardData } from '../../components/GameCard';
 import {
   buildIcsContent,
-  CalendarEvent,
+  type CalendarEvent,
   gameToCalendarEvent,
   sanitizeIcsFilename,
 } from '../calendar';

--- a/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/calendar.test.ts
@@ -102,6 +102,11 @@ describe('buildIcsContent', () => {
     expect(ics.includes('\r\n')).toBe(true);
     expect(ics.includes('\n\n')).toBe(false);
   });
+
+  it('terminates the final line with CRLF per RFC 5545', () => {
+    const ics = buildIcsContent([sampleEvent()]);
+    expect(ics.endsWith('END:VCALENDAR\r\n')).toBe(true);
+  });
 });
 
 describe('sanitizeIcsFilename', () => {

--- a/draco-nodejs/frontend-next/utils/calendar.ts
+++ b/draco-nodejs/frontend-next/utils/calendar.ts
@@ -1,4 +1,5 @@
 import type { GameCardData } from '../components/GameCard';
+import { downloadBlob } from './downloadUtils';
 
 export interface CalendarEvent {
   uid: string;
@@ -106,13 +107,7 @@ export const sanitizeIcsFilename = (input: string): string => {
 
 export const downloadIcsFile = (filename: string, content: string): void => {
   const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(link.href);
+  downloadBlob(blob, filename);
 };
 
 const formatFieldAddress = (game: GameCardData): string => {

--- a/draco-nodejs/frontend-next/utils/calendar.ts
+++ b/draco-nodejs/frontend-next/utils/calendar.ts
@@ -91,7 +91,7 @@ export const buildIcsContent = (
     lines.push(...buildEventLines(event, dtStamp));
   }
   lines.push('END:VCALENDAR');
-  return lines.map(foldIcsLine).join('\r\n');
+  return `${lines.map(foldIcsLine).join('\r\n')}\r\n`;
 };
 
 export const formatLocalDateStamp = (date: Date): string => {

--- a/draco-nodejs/frontend-next/utils/calendar.ts
+++ b/draco-nodejs/frontend-next/utils/calendar.ts
@@ -1,0 +1,163 @@
+import type { GameCardData } from '../components/GameCard';
+
+export interface CalendarEvent {
+  uid: string;
+  title: string;
+  start: Date;
+  end: Date;
+  location?: string;
+  description?: string;
+  url?: string;
+}
+
+const DEFAULT_PROD_ID = '-//Draco//Calendar//EN';
+const ICS_LINE_OCTET_LIMIT = 75;
+
+const escapeIcsText = (value: string): string =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+
+const formatIcsDateTime = (date: Date): string => {
+  const pad = (value: number, length = 2) => value.toString().padStart(length, '0');
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`
+  );
+};
+
+const foldIcsLine = (line: string): string => {
+  const encoder = new TextEncoder();
+  if (encoder.encode(line).length <= ICS_LINE_OCTET_LIMIT) {
+    return line;
+  }
+  const segments: string[] = [];
+  let current = '';
+  let currentBytes = 0;
+  for (const char of line) {
+    const charBytes = encoder.encode(char).length;
+    const limit = segments.length === 0 ? ICS_LINE_OCTET_LIMIT : ICS_LINE_OCTET_LIMIT - 1;
+    if (currentBytes + charBytes > limit) {
+      segments.push(current);
+      current = char;
+      currentBytes = charBytes;
+    } else {
+      current += char;
+      currentBytes += charBytes;
+    }
+  }
+  if (current.length > 0) {
+    segments.push(current);
+  }
+  return segments.join('\r\n ');
+};
+
+const buildEventLines = (event: CalendarEvent, dtStamp: string): string[] => {
+  const lines: string[] = ['BEGIN:VEVENT'];
+  lines.push(`UID:${escapeIcsText(event.uid)}`);
+  lines.push(`DTSTAMP:${dtStamp}`);
+  lines.push(`DTSTART:${formatIcsDateTime(event.start)}`);
+  lines.push(`DTEND:${formatIcsDateTime(event.end)}`);
+  lines.push(`SUMMARY:${escapeIcsText(event.title)}`);
+  if (event.description) {
+    lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`);
+  }
+  if (event.location) {
+    lines.push(`LOCATION:${escapeIcsText(event.location)}`);
+  }
+  if (event.url) {
+    lines.push(`URL:${event.url}`);
+  }
+  lines.push('END:VEVENT');
+  return lines;
+};
+
+export const buildIcsContent = (
+  events: CalendarEvent[],
+  prodId: string = DEFAULT_PROD_ID,
+): string => {
+  const dtStamp = formatIcsDateTime(new Date());
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    `PRODID:${prodId}`,
+    'CALSCALE:GREGORIAN',
+  ];
+  for (const event of events) {
+    lines.push(...buildEventLines(event, dtStamp));
+  }
+  lines.push('END:VCALENDAR');
+  return lines.map(foldIcsLine).join('\r\n');
+};
+
+export const formatLocalDateStamp = (date: Date): string => {
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}`;
+};
+
+export const sanitizeIcsFilename = (input: string): string => {
+  const trimmed = input.trim().toLowerCase();
+  const collapsed = trimmed.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return collapsed.length > 0 ? collapsed : 'calendar';
+};
+
+export const downloadIcsFile = (filename: string, content: string): void => {
+  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+};
+
+const formatFieldAddress = (game: GameCardData): string => {
+  const details = game.fieldDetails;
+  if (!details) {
+    return game.fieldName ?? '';
+  }
+  const namePart = details.name ?? game.fieldName ?? '';
+  const cityState = [details.city, details.state]
+    .filter((part) => part && part.length > 0)
+    .join(', ');
+  const zip = details.zip ?? details.zipCode ?? '';
+  const cityStateZip = [cityState, zip].filter((part) => part && part.length > 0).join(' ');
+  const lineParts = [namePart, details.address ?? '', cityStateZip].filter(
+    (part) => part && part.length > 0,
+  );
+  return lineParts.join(', ');
+};
+
+export interface GameToCalendarEventOptions {
+  origin: string;
+  pageHref: string;
+}
+
+export const gameToCalendarEvent = (
+  game: GameCardData,
+  options: GameToCalendarEventOptions,
+): CalendarEvent => {
+  const start = new Date(game.date);
+  const end = new Date(game.date);
+  const baseTitle = `${game.visitorTeamName} @ ${game.homeTeamName}`;
+  const title = game.leagueName ? `${game.leagueName}: ${baseTitle}` : baseTitle;
+  const url = `${options.origin}${options.pageHref}`;
+  const descriptionParts = [
+    game.leagueName ? `League: ${game.leagueName}` : '',
+    game.comment ?? '',
+    url,
+  ].filter((part) => part.length > 0);
+  return {
+    uid: `game-${game.id}@draco`,
+    title,
+    start,
+    end,
+    location: formatFieldAddress(game),
+    description: descriptionParts.join('\n'),
+    url,
+  };
+};


### PR DESCRIPTION
Introduce iCalendar export support and UI hooks.

- Add utils/calendar.ts: CalendarEvent type, buildIcsContent (RFC 5545 line folding/escaping), downloadIcsFile, sanitizeIcsFilename, formatLocalDateStamp, and gameToCalendarEvent helper to convert GameCardData into calendar events.
- Add unit tests in utils/__tests__/calendar.test.ts covering ICS generation, escaping, line folding, filename sanitization, and game->event conversion.
- Update Schedule.tsx and TeamSchedulePage.tsx to import calendar utilities and add a "Download .ics" button (tooltip + disabled state when no games) that builds and downloads schedule .ics files with sanitized filenames.
- Update WorkoutDisplay.tsx to use shared calendar utilities for creating and downloading workout .ics files (simplifies previous inline ICS generation).

These changes enable exporting schedules and workouts as .ics files, ensure proper escaping/folding per spec, and add tests to validate behavior.