### PR TITLE
Validate Facebook URL and refactor SEO URL utilities

### DIFF
--- a/draco-nodejs/backend/src/config/facebookOAuth.ts
+++ b/draco-nodejs/backend/src/config/facebookOAuth.ts
@@ -10,7 +10,5 @@ export const facebookOAuthConfig = {
     'instagram_basic',
     'instagram_content_publish',
   ].join(','),
-  resultUrlTemplate:
-    process.env.FACEBOOK_RESULT_URL_TEMPLATE ??
-    'http://localhost:3000/account/{accountId}/social-media?facebookAuth=',
+  resultUrlTemplate: process.env.FACEBOOK_RESULT_URL_TEMPLATE,
 };

--- a/draco-nodejs/backend/src/services/facebookIntegrationService.ts
+++ b/draco-nodejs/backend/src/services/facebookIntegrationService.ts
@@ -634,6 +634,9 @@ export class FacebookIntegrationService {
     message?: string,
     returnUrl?: string | null,
   ): string {
+    if (!facebookOAuthConfig.resultUrlTemplate) {
+      throw new ValidationError('Facebook OAuth result URL template is not configured.');
+    }
     const base =
       returnUrl?.trim() ||
       facebookOAuthConfig.resultUrlTemplate.replace('{accountId}', accountId.toString());

--- a/draco-nodejs/frontend-next/app/global-error.tsx
+++ b/draco-nodejs/frontend-next/app/global-error.tsx
@@ -6,23 +6,6 @@ import { DEFAULT_SITE_NAME } from '../lib/seoConstants';
 const CRAWLER_USER_AGENT_REGEX =
   /googlebot|bingbot|slurp|duckduckbot|baiduspider|yandexbot|sogou|facebot|ia_archiver/i;
 
-const FALLBACK_ORIGIN =
-  process.env.NEXT_PUBLIC_SITE_URL ??
-  process.env.NEXT_PUBLIC_APP_URL ??
-  process.env.NEXT_PUBLIC_FALLBACK_URL ??
-  'http://localhost:3000';
-
-function buildCanonical(pathname?: string, originOverride?: string): string {
-  const origin = (originOverride ?? FALLBACK_ORIGIN).replace(/\/$/, '');
-  const normalizedPath =
-    !pathname || pathname === '/' ? '/' : pathname.startsWith('/') ? pathname : `/${pathname}`;
-  try {
-    return new URL(normalizedPath, origin).toString();
-  } catch {
-    return `${origin}${normalizedPath}`;
-  }
-}
-
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   console.error('Global application error captured by Next.js boundary', {
     message: error.message,
@@ -33,11 +16,11 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
   const isCrawler = CRAWLER_USER_AGENT_REGEX.test(detectedUserAgent);
   const canonical =
     typeof window === 'object'
-      ? buildCanonical(
-          `${window.location.pathname}${window.location.search}`,
+      ? new URL(
+          `${window.location.pathname}${window.location.search}` || '/',
           window.location.origin,
-        )
-      : buildCanonical('/');
+        ).toString()
+      : null;
 
   if (isCrawler) {
     return (
@@ -52,7 +35,7 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
             name="robots"
             content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1"
           />
-          <link rel="canonical" href={canonical} />
+          {canonical && <link rel="canonical" href={canonical} />}
           <style>{`
             body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f4f6f8;color:#101828;}
             main{max-width:720px;margin:0 auto;padding:72px 24px;text-align:center;}

--- a/draco-nodejs/frontend-next/app/robots.txt/route.ts
+++ b/draco-nodejs/frontend-next/app/robots.txt/route.ts
@@ -18,12 +18,23 @@ const DISALLOWED_PATHS = [
   '/account/*/workouts*',
 ] as const;
 
-function resolveOrigin(requestUrl: URL): string {
+function parseConfiguredOrigin(): string | null {
   const configuredOrigin =
     process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? null;
+  if (!configuredOrigin) {
+    return null;
+  }
+  try {
+    return new URL(configuredOrigin).origin;
+  } catch {
+    return null;
+  }
+}
 
+function resolveOrigin(requestUrl: URL): string {
+  const configuredOrigin = parseConfiguredOrigin();
   if (configuredOrigin) {
-    return configuredOrigin.replace(/\/$/, '');
+    return configuredOrigin;
   }
 
   const hostname = requestUrl.hostname === '0.0.0.0' ? 'localhost' : requestUrl.hostname;

--- a/draco-nodejs/frontend-next/app/robots.txt/route.ts
+++ b/draco-nodejs/frontend-next/app/robots.txt/route.ts
@@ -1,5 +1,3 @@
-import { buildCanonicalUrl } from '../../lib/seoMetadata';
-
 const DISALLOWED_PATHS = [
   '/account-management*',
   '/admin*',
@@ -40,7 +38,7 @@ export async function GET(request: Request): Promise<Response> {
   const lines = [
     'User-agent: *',
     ...DISALLOWED_PATHS.map((path) => `Disallow: ${path}`),
-    `Sitemap: ${buildCanonicalUrl('/sitemap.xml', { origin })}`,
+    `Sitemap: ${new URL('/sitemap.xml', origin).toString()}`,
   ];
 
   const body = `${lines.join('\n')}\n`;

--- a/draco-nodejs/frontend-next/app/sitemap.xml/route.ts
+++ b/draco-nodejs/frontend-next/app/sitemap.xml/route.ts
@@ -16,20 +16,23 @@ const PRIORITIES: Record<(typeof STATIC_ROUTES)[number], number> = {
   '/signup': 0.6,
 };
 
+function parseConfiguredOrigin(configuredOrigin: string | undefined): URL | null {
+  if (!configuredOrigin) {
+    return null;
+  }
+  try {
+    return new URL(configuredOrigin);
+  } catch {
+    return null;
+  }
+}
+
 export async function GET(request: Request): Promise<Response> {
   const requestUrl = new URL(request.url);
   const configuredOrigin = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_APP_URL;
+  const configuredOriginUrl = parseConfiguredOrigin(configuredOrigin);
   const requestHost = requestUrl.hostname.replace(/^www\./, '');
-  const configuredHost = (() => {
-    if (!configuredOrigin) {
-      return null;
-    }
-    try {
-      return new URL(configuredOrigin).hostname.replace(/^www\./, '');
-    } catch {
-      return null;
-    }
-  })();
+  const configuredHost = configuredOriginUrl?.hostname.replace(/^www\./, '') ?? null;
 
   const shouldEnforcePrimaryHost =
     process.env.NODE_ENV === 'production' && configuredHost !== null && configuredHost.length > 0;
@@ -38,14 +41,16 @@ export async function GET(request: Request): Promise<Response> {
     return new Response('Not Found', { status: 404 });
   }
 
-  let requestOrigin = configuredOrigin?.replace(/\/$/, '') ?? requestUrl.origin;
+  let requestOrigin: string;
 
-  if (!configuredOrigin) {
+  if (configuredOriginUrl) {
+    requestOrigin = configuredOriginUrl.origin;
+  } else {
     const hostname = requestUrl.hostname === '0.0.0.0' ? 'localhost' : requestUrl.hostname;
     const portSegment = requestUrl.port ? `:${requestUrl.port}` : '';
     requestOrigin = `${requestUrl.protocol}//${hostname}${portSegment}`;
   }
-  const shouldCache = Boolean(configuredOrigin);
+  const shouldCache = configuredOriginUrl !== null;
   const lastModified = new Date().toISOString();
 
   const urlEntries = STATIC_ROUTES.map((path) => {

--- a/draco-nodejs/frontend-next/app/sitemap.xml/route.ts
+++ b/draco-nodejs/frontend-next/app/sitemap.xml/route.ts
@@ -1,7 +1,5 @@
 import type { MetadataRoute } from 'next';
 
-import { buildCanonicalUrl } from '../../lib/seoMetadata';
-
 const STATIC_ROUTES = ['/', '/accounts', '/signup'] as const;
 
 type ChangeFrequency = NonNullable<MetadataRoute.Sitemap[number]['changeFrequency']>;
@@ -51,7 +49,7 @@ export async function GET(request: Request): Promise<Response> {
   const lastModified = new Date().toISOString();
 
   const urlEntries = STATIC_ROUTES.map((path) => {
-    const url = buildCanonicalUrl(path, { origin: requestOrigin });
+    const url = new URL(path, requestOrigin).toString();
     const changeFrequency = CHANGE_FREQUENCIES[path];
     const priority = PRIORITIES[path];
     return [

--- a/draco-nodejs/frontend-next/components/NotFoundPage.tsx
+++ b/draco-nodejs/frontend-next/components/NotFoundPage.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { Box, Button, Stack, Typography } from '@mui/material';
-import { DEFAULT_SITE_NAME } from '@/lib/seoMetadata';
+import { DEFAULT_SITE_NAME } from '@/lib/seoConstants';
 
 const NotFoundPage: React.FC = () => {
   return (

--- a/draco-nodejs/frontend-next/lib/seoMetadata.ts
+++ b/draco-nodejs/frontend-next/lib/seoMetadata.ts
@@ -1,11 +1,9 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 
 import { DEFAULT_ACCOUNT_FAVICON_PATH } from './metadataFetchers';
 import { DEFAULT_KEYWORDS, DEFAULT_SITE_NAME } from './seoConstants';
 export { DEFAULT_DESCRIPTION, DEFAULT_KEYWORDS, DEFAULT_SITE_NAME } from './seoConstants';
-
-const PUBLIC_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_APP_URL;
-const FALLBACK_ORIGIN = process.env.NEXT_PUBLIC_FALLBACK_URL ?? 'http://localhost:3000';
 
 function normalizePath(path?: string): string {
   if (!path || path === '/') {
@@ -14,26 +12,18 @@ function normalizePath(path?: string): string {
   return path.startsWith('/') ? path : `/${path}`;
 }
 
-function resolveOrigin(): string {
-  if (PUBLIC_SITE_URL) {
-    try {
-      const url = new URL(PUBLIC_SITE_URL);
-      url.pathname = '/';
-      return url.toString().replace(/\/$/, '');
-    } catch {
-      // Fall back to environment-based resolution
-    }
+async function resolveOrigin(): Promise<string> {
+  const requestHeaders = await headers();
+  const host = requestHeaders.get('host');
+  if (!host) {
+    throw new Error('seoMetadata.resolveOrigin: missing "host" header on request');
   }
-
-  return FALLBACK_ORIGIN.replace(/\/$/, '');
+  const proto = requestHeaders.get('x-forwarded-proto') ?? 'https';
+  return `${proto}://${host}`;
 }
 
-interface BuildCanonicalOptions {
-  origin?: string;
-}
-
-export function buildCanonicalUrl(path?: string, options?: BuildCanonicalOptions): string {
-  const origin = options?.origin ?? resolveOrigin();
+export async function buildCanonicalUrl(path?: string): Promise<string> {
+  const origin = await resolveOrigin();
   const pathname = normalizePath(path);
   try {
     return new URL(pathname, origin).toString();
@@ -75,7 +65,7 @@ interface BuildSeoMetadataOptions {
   siteName?: string;
 }
 
-export function buildSeoMetadata({
+export async function buildSeoMetadata({
   title,
   description,
   path,
@@ -84,8 +74,8 @@ export function buildSeoMetadata({
   index = true,
   keywords,
   siteName,
-}: BuildSeoMetadataOptions): Metadata {
-  const canonicalUrl = buildCanonicalUrl(path);
+}: BuildSeoMetadataOptions): Promise<Metadata> {
+  const canonicalUrl = await buildCanonicalUrl(path);
   const resolvedKeywords = resolveKeywords(keywords);
   const openGraphImages = image ? [image] : undefined;
   const twitterImages = image ? [image] : undefined;

--- a/draco-nodejs/frontend-next/lib/seoMetadata.ts
+++ b/draco-nodejs/frontend-next/lib/seoMetadata.ts
@@ -14,7 +14,7 @@ function normalizePath(path?: string): string {
 
 async function resolveOrigin(): Promise<string> {
   const requestHeaders = await headers();
-  const host = requestHeaders.get('host');
+  const host = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host');
   if (!host) {
     throw new Error('seoMetadata.resolveOrigin: missing "host" header on request');
   }


### PR DESCRIPTION
Require an explicit FACEBOOK_RESULT_URL_TEMPLATE and throw a ValidationError if it's missing in FacebookIntegrationService; remove the previous default fallback. Refactor canonical URL handling across the Next frontend: simplify GlobalError to build canonical URLs with the URL API and only render canonical link when available; replace buildCanonicalUrl usages in robots.txt and sitemap routes with new URL-based resolution. Convert seoMetadata utilities to async, resolve origin from next/headers (x-forwarded-proto + host) and throw if host header is missing, removing reliance on environment fallback URLs. Also fix an import in NotFoundPage to use seoConstants. These changes improve correctness of absolute URL generation in server/app-router contexts and avoid silent defaults for critical configuration.