### PR TITLE
Expose contactId on public roster members

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -2727,6 +2727,10 @@
             "type": "string",
             "pattern": "^d+$"
           },
+          "contactId": {
+            "type": "string",
+            "pattern": "^d+$"
+          },
           "playerNumber": {
             "type": "number",
             "nullable": true,
@@ -2756,9 +2760,10 @@
           }
         },
         "required": [
-          "id"
+          "id",
+          "contactId"
         ],
-        "description": "Public-safe roster member payload exposing only jersey number, player name, and optional photo URL."
+        "description": "Public-safe roster member payload exposing jersey number, player name, optional photo URL, and the contact identifier needed to link to public player statistics."
       },
       "PublicTeamRosterResponse": {
         "type": "object",
@@ -2785,6 +2790,10 @@
               "type": "object",
               "properties": {
                 "id": {
+                  "type": "string",
+                  "pattern": "^d+$"
+                },
+                "contactId": {
                   "type": "string",
                   "pattern": "^d+$"
                 },
@@ -2817,9 +2826,10 @@
                 }
               },
               "required": [
-                "id"
+                "id",
+                "contactId"
               ],
-              "description": "Public-safe roster member payload exposing only jersey number, player name, and optional photo URL."
+              "description": "Public-safe roster member payload exposing jersey number, player name, optional photo URL, and the contact identifier needed to link to public player statistics."
             }
           }
         },

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -2037,6 +2037,9 @@ components:
         id:
           type: string
           pattern: ^d+$
+        contactId:
+          type: string
+          pattern: ^d+$
         playerNumber:
           type: number
           nullable: true
@@ -2060,8 +2063,10 @@ components:
           minimum: 0
       required:
         - id
-      description: Public-safe roster member payload exposing only jersey number,
-        player name, and optional photo URL.
+        - contactId
+      description: Public-safe roster member payload exposing jersey number, player
+        name, optional photo URL, and the contact identifier needed to link to
+        public player statistics.
     PublicTeamRosterResponse:
       type: object
       properties:
@@ -2082,6 +2087,9 @@ components:
             type: object
             properties:
               id:
+                type: string
+                pattern: ^d+$
+              contactId:
                 type: string
                 pattern: ^d+$
               playerNumber:
@@ -2107,8 +2115,10 @@ components:
                 minimum: 0
             required:
               - id
-            description: Public-safe roster member payload exposing only jersey number,
-              player name, and optional photo URL.
+              - contactId
+            description: Public-safe roster member payload exposing jersey number, player
+              name, optional photo URL, and the contact identifier needed to
+              link to public player statistics.
       required:
         - teamSeason
         - rosterMembers

--- a/draco-nodejs/backend/src/responseFormatters/RosterResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/RosterResponseFormatter.ts
@@ -77,6 +77,7 @@ export class RosterResponseFormatter {
         gamesPlayedMap !== undefined ? (gamesPlayedMap.get(member.id.toString()) ?? 0) : null;
       return {
         id: member.id.toString(),
+        contactId: contact.id.toString(),
         playerNumber: member.playernumber ?? null,
         firstName: contact.firstname ?? null,
         lastName: contact.lastname ?? null,

--- a/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
+++ b/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
@@ -466,6 +466,13 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
               lastName,
               photoUrl: member.photoUrl ?? undefined,
             };
+            const playerHref = buildPlayerStatisticsHref({
+              accountId,
+              contactId: member.contactId,
+              returnTo: currentLocation,
+              returnLabel: playerLinkLabel,
+            });
+            const playerLabel = displayName || firstName;
 
             return (
               <TableRow key={member.id} hover>
@@ -473,9 +480,26 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
                 <TableCell>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <UserAvatar user={user} size={32} />
-                    <Typography variant="body2" fontWeight={600}>
-                      {displayName || firstName}
-                    </Typography>
+                    {playerHref ? (
+                      <Typography
+                        component={NextLink}
+                        href={playerHref}
+                        prefetch={false}
+                        variant="body2"
+                        sx={{
+                          fontWeight: 600,
+                          color: 'primary.main',
+                          textDecoration: 'none',
+                          '&:hover': { textDecoration: 'underline' },
+                        }}
+                      >
+                        {playerLabel}
+                      </Typography>
+                    ) : (
+                      <Typography variant="body2" fontWeight={600}>
+                        {playerLabel}
+                      </Typography>
+                    )}
                   </Box>
                 </TableCell>
                 {showGamesPlayed && <TableCell>{member.gamesPlayed ?? '-'}</TableCell>}

--- a/draco-nodejs/shared/shared-schemas/roster.ts
+++ b/draco-nodejs/shared/shared-schemas/roster.ts
@@ -98,6 +98,7 @@ export const SignRosterMemberSchema = RosterMemberSchema.omit({
 export const PublicRosterMemberSchema = z
   .object({
     id: z.bigint().transform((val) => val.toString()),
+    contactId: z.bigint().transform((val) => val.toString()),
     playerNumber: z.number().min(0).max(99).nullable().optional(),
     firstName: z.string().trim().nullable().optional(),
     lastName: z.string().trim().nullable().optional(),
@@ -107,7 +108,7 @@ export const PublicRosterMemberSchema = z
   })
   .openapi({
     description:
-      'Public-safe roster member payload exposing only jersey number, player name, and optional photo URL.',
+      'Public-safe roster member payload exposing jersey number, player name, optional photo URL, and the contact identifier needed to link to public player statistics.',
   });
 
 export const PublicTeamRosterResponseSchema = z.object({


### PR DESCRIPTION
Add contactId to public-safe roster member payloads so consumers can link to public player statistics. Updates include: adding contactId to OpenAPI (JSON/YAML) and schema descriptions, adding contactId to the shared Zod PublicRosterMemberSchema, returning contactId from RosterResponseFormatter, and using contactId in TeamRosterWidget to build a player statistics link and render the player name as a link when available.