### PR TITLE
Add season/team links and pass IDs to schedule

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -532,6 +532,17 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     setPlayersWantedInitialData(undefined);
   };
 
+  const fullScheduleButton = (
+    <Button
+      component={NextLink}
+      href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`}
+      variant="outlined"
+      size="small"
+    >
+      Full Schedule
+    </Button>
+  );
+
   return (
     <main className="min-h-screen bg-background">
       {/* Account Header with Team Information */}
@@ -792,16 +803,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                       timeZone={timeZone}
                       accountId={accountId}
                       currentTeamSeasonId={teamSeasonId}
-                      headerAction={
-                        <Button
-                          component={NextLink}
-                          href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`}
-                          variant="outlined"
-                          size="small"
-                        >
-                          Full Schedule
-                        </Button>
-                      }
+                      headerAction={fullScheduleButton}
                     />
                   ) : null}
                   <GameListDisplay
@@ -813,16 +815,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                     timeZone={timeZone}
                     accountId={accountId}
                     currentTeamSeasonId={teamSeasonId}
-                    headerAction={
-                      <Button
-                        component={NextLink}
-                        href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`}
-                        variant="outlined"
-                        size="small"
-                      >
-                        Full Schedule
-                      </Button>
-                    }
+                    headerAction={fullScheduleButton}
                   />
                 </>
               )

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -343,6 +343,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     const transformGame = (game: ApiGame): Game => ({
       id: game.id,
       date: game.gameDate,
+      seasonId,
       homeTeamId: game.homeTeam.id ?? '',
       visitorTeamId: game.visitorTeam.id ?? '',
       homeTeamName: game.homeTeam.name ?? '',
@@ -789,6 +790,18 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                       sections={upcomingSections}
                       emptyMessage="No upcoming games."
                       timeZone={timeZone}
+                      accountId={accountId}
+                      currentTeamSeasonId={teamSeasonId}
+                      headerAction={
+                        <Button
+                          component={NextLink}
+                          href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/schedule`}
+                          variant="outlined"
+                          size="small"
+                        >
+                          Full Schedule
+                        </Button>
+                      }
                     />
                   ) : null}
                   <GameListDisplay
@@ -798,6 +811,8 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                     onEditRecap={handleOpenEditRecap}
                     onViewRecap={handleOpenViewRecap}
                     timeZone={timeZone}
+                    accountId={accountId}
+                    currentTeamSeasonId={teamSeasonId}
                     headerAction={
                       <Button
                         component={NextLink}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -287,6 +287,7 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
   return (
     <ScheduleLayout
       accountId={accountId}
+      currentTeamSeasonId={teamSeasonId}
       title={teamName ?? 'Team Schedule'}
       titleExtra={
         seasonName ? (

--- a/draco-nodejs/frontend-next/components/GameCard.tsx
+++ b/draco-nodejs/frontend-next/components/GameCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
+import Link from 'next/link';
 import {
   Box,
   Typography,
@@ -52,6 +53,7 @@ export interface BaseballGameExtras {
 export interface GameCardData {
   id: string;
   date: string;
+  seasonId?: string;
   homeTeamId: string;
   visitorTeamId: string;
   homeTeamName: string;
@@ -100,6 +102,7 @@ export interface GameCardProps {
   onStartLiveScoring?: (game: GameCardData) => void;
   onWatchLiveScoring?: (game: GameCardData) => void;
   accountId?: string;
+  currentTeamSeasonId?: string;
 }
 
 const GameCard: React.FC<GameCardProps> = ({
@@ -122,6 +125,7 @@ const GameCard: React.FC<GameCardProps> = ({
   onStartLiveScoring,
   onWatchLiveScoring,
   accountId,
+  currentTeamSeasonId,
 }) => {
   const { user } = useAuth();
   const isAuthenticated = !!user;
@@ -364,6 +368,50 @@ const GameCard: React.FC<GameCardProps> = ({
 
   const hasGolfExtras = game.golfExtras !== undefined;
 
+  const buildTeamHref = (teamSeasonId: string): string | null => {
+    if (!accountId || !game.seasonId || !teamSeasonId) {
+      return null;
+    }
+    if (currentTeamSeasonId && teamSeasonId === currentTeamSeasonId) {
+      return null;
+    }
+    const segment = hasGolfExtras ? 'golf/teams' : 'teams';
+    return `/account/${accountId}/seasons/${game.seasonId}/${segment}/${teamSeasonId}`;
+  };
+
+  const renderTeamName = (teamSeasonId: string, teamName: string, prefix?: string) => {
+    const href = buildTeamHref(teamSeasonId);
+    const label = prefix ? `${prefix}${teamName}` : teamName;
+
+    if (!href) {
+      return (
+        <Typography variant="body1" fontWeight={700} sx={{ color: 'text.primary' }} noWrap>
+          {label}
+        </Typography>
+      );
+    }
+
+    return (
+      <Typography
+        component={Link}
+        href={href}
+        onClick={(event: React.MouseEvent) => event.stopPropagation()}
+        variant="body1"
+        fontWeight={700}
+        noWrap
+        sx={{
+          color: 'primary.main',
+          textDecoration: 'none',
+          '&:hover': {
+            textDecoration: 'underline',
+          },
+        }}
+      >
+        {label}
+      </Typography>
+    );
+  };
+
   const renderHandicapBadge = (handicap: number | undefined) => {
     if (handicap === undefined) return null;
     return (
@@ -548,26 +596,12 @@ const GameCard: React.FC<GameCardProps> = ({
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight={700}
-                    sx={{ color: 'text.primary' }}
-                    noWrap
-                  >
-                    {game.visitorTeamName}
-                  </Typography>
+                  {renderTeamName(game.visitorTeamId, game.visitorTeamName)}
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.visitorCourseHandicap)}
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight={700}
-                    sx={{ color: 'text.primary' }}
-                    noWrap
-                  >
-                    @ {game.homeTeamName}
-                  </Typography>
+                  {renderTeamName(game.homeTeamId, game.homeTeamName, '@ ')}
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.homeCourseHandicap)}
                 </Box>
@@ -698,26 +732,12 @@ const GameCard: React.FC<GameCardProps> = ({
               </Box>
               <Box sx={{ minWidth: 0 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight={700}
-                    sx={{ color: 'text.primary' }}
-                    noWrap
-                  >
-                    {game.visitorTeamName}
-                  </Typography>
+                  {renderTeamName(game.visitorTeamId, game.visitorTeamName)}
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.visitorCourseHandicap)}
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight={700}
-                    sx={{ color: 'text.primary' }}
-                    noWrap
-                  >
-                    @ {game.homeTeamName}
-                  </Typography>
+                  {renderTeamName(game.homeTeamId, game.homeTeamName, '@ ')}
                   {game.gameStatus !== GameStatus.Completed &&
                     renderHandicapBadge(game.golfExtras?.homeCourseHandicap)}
                 </Box>

--- a/draco-nodejs/frontend-next/components/GameListDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/GameListDisplay.tsx
@@ -38,6 +38,7 @@ export interface GameListDisplayProps {
   onStartLiveScoring?: (game: Game) => void;
   onWatchLiveScoring?: (game: Game) => void;
   accountId?: string;
+  currentTeamSeasonId?: string;
   headerAction?: React.ReactNode;
 }
 
@@ -57,6 +58,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
   onStartLiveScoring,
   onWatchLiveScoring,
   accountId,
+  currentTeamSeasonId,
   headerAction,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -235,6 +237,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
                           onStartLiveScoring={onStartLiveScoring}
                           onWatchLiveScoring={onWatchLiveScoring}
                           accountId={accountId}
+                          currentTeamSeasonId={currentTeamSeasonId}
                         />
                       ))
                     : section.games.map((game, index) => (
@@ -253,6 +256,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
                             onStartLiveScoring={onStartLiveScoring}
                             onWatchLiveScoring={onWatchLiveScoring}
                             accountId={accountId}
+                            currentTeamSeasonId={currentTeamSeasonId}
                           />
                         </Box>
                       ))}

--- a/draco-nodejs/frontend-next/components/GolfMatchesWidget.tsx
+++ b/draco-nodejs/frontend-next/components/GolfMatchesWidget.tsx
@@ -344,6 +344,7 @@ export default function GolfMatchesWidget({
     return {
       id: match.id,
       date: match.matchDateTime,
+      seasonId,
       homeTeamId: match.team1.id,
       visitorTeamId: match.team2.id,
       homeTeamName: getTeamName(match.team1.id, match.team1.name),
@@ -429,6 +430,7 @@ export default function GolfMatchesWidget({
                   canEditGames={false}
                   timeZone={timeZone}
                   onClick={handleMatchClick}
+                  accountId={accountId}
                 />
                 {isAuthenticated && hasActiveSession && isParticipant && (
                   <Box sx={{ mt: 0.5, display: 'flex', justifyContent: 'flex-end' }}>

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -26,6 +26,7 @@ import { Game, League, FilterType, ViewMode, NavigationDirection } from '@/types
 
 export interface ScheduleLayoutProps {
   accountId: string;
+  currentTeamSeasonId?: string;
   title: string;
   subtitle?: string;
   titleExtra?: React.ReactNode;
@@ -74,6 +75,7 @@ export interface ScheduleLayoutProps {
 
 const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
   accountId,
+  currentTeamSeasonId,
   title,
   subtitle,
   titleExtra,
@@ -261,6 +263,8 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
           <ViewFactory
             viewMode={viewMode}
             filterType={filterType}
+            accountId={accountId}
+            currentTeamSeasonId={currentTeamSeasonId}
             loadingGames={loadingGames}
             filteredGames={filteredGames}
             timeZone={timeZone}

--- a/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
@@ -12,6 +12,9 @@ import {
 import { alpha, useTheme } from '@mui/material/styles';
 
 export interface CalendarGridProps {
+  accountId?: string;
+  currentTeamSeasonId?: string;
+
   // Grid configuration
   gridType: 'week' | 'month';
   showZoomColumn?: boolean;
@@ -58,6 +61,8 @@ function buildGamesByDateKey(games: Game[], tz: string): Map<string, Game[]> {
 }
 
 const CalendarGrid: React.FC<CalendarGridProps> = ({
+  accountId,
+  currentTeamSeasonId,
   gridType: _gridType,
   showZoomColumn = false,
   currentMonthDate,
@@ -376,6 +381,8 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                                     showActions={showActions}
                                     onClick={() => onGameClick?.(game)}
                                     timeZone={timeZone}
+                                    accountId={accountId}
+                                    currentTeamSeasonId={currentTeamSeasonId}
                                   />
                                 </Box>
                               );
@@ -513,6 +520,8 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                               showActions={showActions}
                               onClick={() => onGameClick?.(game)}
                               timeZone={timeZone}
+                              accountId={accountId}
+                              currentTeamSeasonId={currentTeamSeasonId}
                             />
                           </Box>
                         );

--- a/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
@@ -17,6 +17,8 @@ interface DayListViewProps extends ViewComponentProps {
 }
 
 const DayListView: React.FC<DayListViewProps> = ({
+  accountId,
+  currentTeamSeasonId,
   filteredGames,
   canEditSchedule,
   onEditGame: _onEditGame,
@@ -154,6 +156,8 @@ const DayListView: React.FC<DayListViewProps> = ({
               }
               showActions={showActions}
               timeZone={timeZone}
+              accountId={accountId}
+              currentTeamSeasonId={currentTeamSeasonId}
             />
           );
         })}
@@ -259,6 +263,8 @@ const DayListView: React.FC<DayListViewProps> = ({
                       }
                       showActions={showActions}
                       timeZone={timeZone}
+                      accountId={accountId}
+                      currentTeamSeasonId={currentTeamSeasonId}
                     />
                   );
                 })}

--- a/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
@@ -14,6 +14,8 @@ import HierarchicalHeader from '../components/HierarchicalHeader';
 import WidgetShell from '../../ui/WidgetShell';
 
 const MonthView: React.FC<ViewComponentProps> = ({
+  accountId,
+  currentTeamSeasonId,
   filteredGames,
   canEditSchedule,
   onEditGame: _onEditGame,
@@ -85,6 +87,8 @@ const MonthView: React.FC<ViewComponentProps> = ({
 
       {/* Calendar Grid */}
       <CalendarGrid
+        accountId={accountId}
+        currentTeamSeasonId={currentTeamSeasonId}
         gridType="month"
         showZoomColumn={true}
         days={monthDays}

--- a/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
@@ -6,6 +6,8 @@ import HierarchicalHeader from '../components/HierarchicalHeader';
 import WidgetShell from '../../ui/WidgetShell';
 
 const WeekView: React.FC<ViewComponentProps> = ({
+  accountId,
+  currentTeamSeasonId,
   filteredGames,
   canEditSchedule,
   onEditGame,
@@ -76,6 +78,8 @@ const WeekView: React.FC<ViewComponentProps> = ({
 
       {/* Calendar Grid */}
       <CalendarGrid
+        accountId={accountId}
+        currentTeamSeasonId={currentTeamSeasonId}
         gridType="week"
         showZoomColumn={false}
         days={weekDays}

--- a/draco-nodejs/frontend-next/types/schedule.ts
+++ b/draco-nodejs/frontend-next/types/schedule.ts
@@ -161,6 +161,8 @@ export interface ScheduleManagementProps {
 }
 
 export interface ViewComponentProps {
+  accountId: string;
+  currentTeamSeasonId?: string;
   filteredGames: Game[];
   canEditSchedule: boolean;
   onEditGame: (game: Game) => void;

--- a/draco-nodejs/frontend-next/utils/gameTransformers.ts
+++ b/draco-nodejs/frontend-next/utils/gameTransformers.ts
@@ -149,9 +149,12 @@ const mapApiGameToGameCard = (game: ApiGame): Game => {
   const parsedGameType = normalizeGameType(game.gameType);
   const fieldDetails = field.id || field.name || field.shortName ? field : null;
 
+  const seasonId = game.season?.id ? String(game.season.id) : undefined;
+
   return {
     id: String(game.id),
     date: game.gameDate,
+    seasonId,
     homeTeamId: String(game.homeTeam?.id ?? ''),
     visitorTeamId: String(game.visitorTeam?.id ?? ''),
     homeTeamName: game.homeTeam?.name ?? 'Unknown Team',
@@ -351,6 +354,7 @@ export function convertGameToGameCardData(
   return {
     id: game.id,
     date: game.gameDate,
+    seasonId: game.season?.id ? String(game.season.id) : undefined,
     homeTeamId: game.homeTeamId,
     visitorTeamId: game.visitorTeamId,
     homeTeamName: homeTeam?.name || game.homeTeamName || 'Unknown Team',


### PR DESCRIPTION
Thread accountId, seasonId and currentTeamSeasonId through schedule and list components and map season IDs on game objects. GameCard now imports next/link and renders team names as links (excluding the current teamSeason) using a constructed team URL; handicap badges and behavior unchanged. ScheduleLayout, CalendarGrid, DayListView, MonthView, WeekView, GameListDisplay, GolfMatchesWidget and Team pages updated to accept/forward the new props, and gameTransformers now include seasonId. Also add a "Full Schedule" button on TeamPage header to link to the team's schedule.