### PR TITLE
Add fullWidth prop to StatisticsTable

### DIFF
--- a/draco-nodejs/frontend-next/components/statistics/LeaderCategoryPanel.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/LeaderCategoryPanel.tsx
@@ -371,6 +371,7 @@ export default function LeaderCategoryPanel({
             emptyMessage={message}
             getRowKey={getRowKey}
             hideHeader={hideHeaderWhenCard && leaderForCard !== null}
+            fullWidth
           />
         </Box>
       )}

--- a/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
@@ -63,6 +63,7 @@ interface StatisticsTableBaseProps<T> {
   onSort?: (field: string) => void;
   hideHeader?: boolean;
   maxHeight?: string | number;
+  fullWidth?: boolean;
 }
 
 export const StatisticsTableBase = <T extends Record<string, unknown>>({
@@ -76,6 +77,7 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
   onSort,
   hideHeader = false,
   maxHeight,
+  fullWidth = false,
 }: StatisticsTableBaseProps<T>) => {
   const activeField = sortField !== undefined ? String(sortField) : undefined;
   const dataVersion = `${String(activeField)}-${sortOrder}-${data.length}`;
@@ -122,7 +124,7 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
       <TableContainer
         component={Paper}
         sx={{
-          width: 'fit-content',
+          width: fullWidth ? '100%' : 'fit-content',
           maxWidth: '100%',
           ...(maxHeight
             ? {
@@ -142,7 +144,7 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
           size="small"
           stickyHeader={!hideHeader}
           sx={{
-            width: 'auto',
+            width: fullWidth ? '100%' : 'auto',
             tableLayout: 'auto',
             '& .MuiTableCell-root': {
               py: 0.75,


### PR DESCRIPTION
Introduce a fullWidth boolean prop (default false) on StatisticsTableBase to allow tables to stretch to 100% width. The TableContainer and Table sx width now use fullWidth (100% when true, previous fit-content/auto otherwise). Pass fullWidth from LeaderCategoryPanel so leader card tables can render full width while preserving existing behavior when the prop is not set.