### PR TITLE
Improve image cropper zoom and output handling

### DIFF
--- a/draco-nodejs/frontend-next/components/common/ImageCropDialog.tsx
+++ b/draco-nodejs/frontend-next/components/common/ImageCropDialog.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Cropper, { Area, Point } from 'react-easy-crop';
+import Cropper, { Area, MediaSize, Point } from 'react-easy-crop';
 import { ImageCropPreset } from '../../config/imageCropPresets';
 import { buildCroppedFile, cropImageToBlob } from '../../utils/imageCrop';
 
@@ -26,9 +26,19 @@ interface ImageCropDialogProps {
   onCropConfirm: (croppedFile: File) => void;
 }
 
-const MIN_ZOOM = 1;
+const DEFAULT_ZOOM = 1;
 const MAX_ZOOM = 4;
 const ZOOM_STEP = 0.05;
+const ABSOLUTE_MIN_ZOOM = 0.1;
+
+const computeContainZoom = (mediaSize: MediaSize, cropAspect: number): number => {
+  if (!mediaSize.naturalWidth || !mediaSize.naturalHeight || !cropAspect) {
+    return DEFAULT_ZOOM;
+  }
+  const imageAspect = mediaSize.naturalWidth / mediaSize.naturalHeight;
+  const ratio = Math.min(imageAspect, cropAspect) / Math.max(imageAspect, cropAspect);
+  return Math.max(ABSOLUTE_MIN_ZOOM, Math.min(DEFAULT_ZOOM, ratio));
+};
 
 const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
   open,
@@ -40,7 +50,8 @@ const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
 }) => {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [minZoom, setMinZoom] = useState(DEFAULT_ZOOM);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +65,8 @@ const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
     const objectUrl = URL.createObjectURL(sourceFile);
     setImageSrc(objectUrl);
     setCrop({ x: 0, y: 0 });
-    setZoom(1);
+    setZoom(DEFAULT_ZOOM);
+    setMinZoom(DEFAULT_ZOOM);
     setCroppedAreaPixels(null);
     setError(null);
 
@@ -62,6 +74,12 @@ const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
       URL.revokeObjectURL(objectUrl);
     };
   }, [open, sourceFile]);
+
+  const handleMediaLoaded = (mediaSize: MediaSize) => {
+    const nextMinZoom = computeContainZoom(mediaSize, preset.aspect);
+    setMinZoom(nextMinZoom);
+    setZoom((current) => Math.max(current, nextMinZoom));
+  };
 
   const handleCropComplete = (_area: Area, areaPixels: Area) => {
     setCroppedAreaPixels(areaPixels);
@@ -113,13 +131,14 @@ const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
                 crop={crop}
                 zoom={zoom}
                 aspect={preset.aspect}
-                minZoom={MIN_ZOOM}
+                minZoom={minZoom}
                 maxZoom={MAX_ZOOM}
-                restrictPosition
+                restrictPosition={false}
                 showGrid
                 onCropChange={setCrop}
                 onZoomChange={setZoom}
                 onCropComplete={handleCropComplete}
+                onMediaLoaded={handleMediaLoaded}
               />
             )}
           </Box>
@@ -129,12 +148,15 @@ const ImageCropDialog: React.FC<ImageCropDialogProps> = ({
             </Typography>
             <Slider
               value={zoom}
-              min={MIN_ZOOM}
+              min={minZoom}
               max={MAX_ZOOM}
               step={ZOOM_STEP}
               onChange={(_event, value) => setZoom(typeof value === 'number' ? value : value[0])}
               aria-label="Zoom"
             />
+            <Typography variant="caption" color="text.secondary">
+              Drag to reposition. Zoom out to fit the entire image, or zoom in to crop a detail.
+            </Typography>
           </Box>
           <Typography variant="caption" color="text.secondary">
             Output: {preset.outputWidth}×{preset.outputHeight} pixels

--- a/draco-nodejs/frontend-next/utils/imageCrop.ts
+++ b/draco-nodejs/frontend-next/utils/imageCrop.ts
@@ -53,23 +53,36 @@ export async function cropImageToBlob(
     context.imageSmoothingEnabled = true;
     context.imageSmoothingQuality = 'high';
 
-    context.drawImage(
-      image,
-      croppedAreaPixels.x,
-      croppedAreaPixels.y,
-      croppedAreaPixels.width,
-      croppedAreaPixels.height,
-      0,
-      0,
-      output.width,
-      output.height,
-    );
-
     const requestedMimeType = output.mimeType ?? DEFAULT_MIME_TYPE;
     const mimeType = SUPPORTED_OUTPUT_MIME_TYPES.has(requestedMimeType)
       ? requestedMimeType
       : DEFAULT_MIME_TYPE;
     const quality = output.quality ?? DEFAULT_QUALITY;
+
+    if (mimeType === 'image/jpeg') {
+      context.fillStyle = '#000000';
+      context.fillRect(0, 0, output.width, output.height);
+    }
+
+    if (croppedAreaPixels.width > 0 && croppedAreaPixels.height > 0) {
+      const scaleX = output.width / croppedAreaPixels.width;
+      const scaleY = output.height / croppedAreaPixels.height;
+
+      const sx = Math.max(0, croppedAreaPixels.x);
+      const sy = Math.max(0, croppedAreaPixels.y);
+      const sxEnd = Math.min(image.naturalWidth, croppedAreaPixels.x + croppedAreaPixels.width);
+      const syEnd = Math.min(image.naturalHeight, croppedAreaPixels.y + croppedAreaPixels.height);
+      const sw = Math.max(0, sxEnd - sx);
+      const sh = Math.max(0, syEnd - sy);
+
+      if (sw > 0 && sh > 0) {
+        const dx = (sx - croppedAreaPixels.x) * scaleX;
+        const dy = (sy - croppedAreaPixels.y) * scaleY;
+        const dw = sw * scaleX;
+        const dh = sh * scaleY;
+        context.drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
+      }
+    }
 
     const blob = await new Promise<Blob | null>((resolve) => {
       canvas.toBlob((result) => resolve(result), mimeType, quality);


### PR DESCRIPTION
Set a dynamic minZoom based on the loaded media and target aspect ratio, introduce constants for default/absolute zoom, and update the Cropper usage to respect the computed minZoom and call onMediaLoaded. Allow repositioning when zoomed out, adjust slider min, and add UI hint about dragging/zooming. In image cropping logic, fill JPEG backgrounds to avoid transparency, clamp source coordinates to image bounds, scale/copy only the valid source region to the output canvas, and keep existing toBlob behavior—preventing drawing outside image bounds and producing correct scaled outputs.