### PR TITLE
Skip calendar routes in frontend middleware

### DIFF
--- a/draco-nodejs/backend/src/middleware/__tests__/frontendBaseUrlMiddleware.test.ts
+++ b/draco-nodejs/backend/src/middleware/__tests__/frontendBaseUrlMiddleware.test.ts
@@ -54,6 +54,22 @@ describe('frontendBaseUrlMiddleware', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it('skips calendar subscription routes regardless of origin', async () => {
+    process.env.NODE_ENV = 'production';
+    (originAllowList.isAllowed as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const middleware = createFrontendBaseUrlMiddleware({ originAllowList });
+    const { req, res } = buildReqRes('/api/calendar/team-season/2411.ics', {
+      origin: 'https://0.0.0.0:8080',
+    });
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((req as Request).frontendBaseUrl).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+    expect(originAllowList.isAllowed).not.toHaveBeenCalled();
+  });
+
   it('allows missing base URL header without error', async () => {
     const middleware = createFrontendBaseUrlMiddleware({ originAllowList });
     const { req, res } = buildReqRes('/api/test');

--- a/draco-nodejs/backend/src/middleware/__tests__/frontendBaseUrlMiddleware.test.ts
+++ b/draco-nodejs/backend/src/middleware/__tests__/frontendBaseUrlMiddleware.test.ts
@@ -56,7 +56,7 @@ describe('frontendBaseUrlMiddleware', () => {
 
   it('skips calendar subscription routes regardless of origin', async () => {
     process.env.NODE_ENV = 'production';
-    (originAllowList.isAllowed as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    vi.mocked(originAllowList.isAllowed).mockResolvedValue(false);
     const middleware = createFrontendBaseUrlMiddleware({ originAllowList });
     const { req, res } = buildReqRes('/api/calendar/team-season/2411.ics', {
       origin: 'https://0.0.0.0:8080',

--- a/draco-nodejs/backend/src/middleware/frontendBaseUrlMiddleware.ts
+++ b/draco-nodejs/backend/src/middleware/frontendBaseUrlMiddleware.ts
@@ -40,6 +40,11 @@ export const createFrontendBaseUrlMiddleware =
       return;
     }
 
+    if (req.path.startsWith('/api/calendar/')) {
+      runWithFrontendBaseUrl(null, next);
+      return;
+    }
+
     const headerBaseUrl = extractBaseUrlHeader(req);
     const normalized = AccountBaseUrlResolver.normalizeBaseUrl(headerBaseUrl);
 


### PR DESCRIPTION
Make frontendBaseUrl middleware bypass base-URL resolution for requests under /api/calendar/ by calling runWithFrontendBaseUrl(null, next). Add a test ensuring calendar subscription routes are skipped regardless of origin (origin allow list is not invoked) and that no frontendBaseUrl is set on the request.