### PR TITLE
Use webcal:// scheme for Google cid

### DIFF
--- a/draco-nodejs/frontend-next/utils/__tests__/calendarSubscribe.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/calendarSubscribe.test.ts
@@ -6,17 +6,20 @@ const TEAM_NAME = 'Hawks';
 
 describe('buildCalendarSubscribeUrls', () => {
   describe('google', () => {
-    it('percent-encodes the icsUrl in the cid parameter', () => {
+    const webcalEquivalent = (url: string) => url.replace(/^https?:\/\//, 'webcal://');
+
+    it('encodes a webcal:// URL in the cid parameter so Google prompts to subscribe', () => {
       const urls = buildCalendarSubscribeUrls(BASE_URL, TEAM_NAME);
       expect(urls.google).toContain('cid=');
       const cid = new URL(urls.google).searchParams.get('cid');
-      expect(cid).toBe(BASE_URL);
+      expect(cid).toBe(webcalEquivalent(BASE_URL));
+      expect(cid?.startsWith('webcal://')).toBe(true);
     });
 
-    it('round-trips decodeURIComponent back to original icsUrl', () => {
+    it('round-trips decodeURIComponent back to the webcal:// URL', () => {
       const urls = buildCalendarSubscribeUrls(BASE_URL, TEAM_NAME);
       const rawCid = urls.google.split('cid=')[1];
-      expect(decodeURIComponent(rawCid)).toBe(BASE_URL);
+      expect(decodeURIComponent(rawCid)).toBe(webcalEquivalent(BASE_URL));
     });
   });
 
@@ -90,7 +93,7 @@ describe('buildCalendarSubscribeUrls', () => {
       expect(outlookParsed.searchParams.get('url')).toBe(urlWithQuery);
 
       const googleCid = new URL(urls.google).searchParams.get('cid');
-      expect(googleCid).toBe(urlWithQuery);
+      expect(googleCid).toBe(urlWithQuery.replace(/^https?:\/\//, 'webcal://'));
     });
 
     it('spaces in name round-trip correctly', () => {

--- a/draco-nodejs/frontend-next/utils/calendarSubscribe.ts
+++ b/draco-nodejs/frontend-next/utils/calendarSubscribe.ts
@@ -12,10 +12,11 @@ export function buildCalendarSubscribeUrls(icsUrl: string, name: string): Calend
 
   const apple = icsUrl.replace(/^https?:\/\//, 'webcal://');
   const encodedUrl = encodeURIComponent(icsUrl);
+  const encodedWebcalUrl = encodeURIComponent(apple);
   const encodedName = encodeURIComponent(name);
 
   return {
-    google: `https://calendar.google.com/calendar/r?cid=${encodedUrl}`,
+    google: `https://calendar.google.com/calendar/r?cid=${encodedWebcalUrl}`,
     apple,
     outlookCom: `https://outlook.live.com/calendar/0/addfromweb?url=${encodedUrl}&name=${encodedName}`,
     office365: `https://outlook.office.com/calendar/0/addfromweb?url=${encodedUrl}&name=${encodedName}`,

--- a/draco-nodejs/frontend-next/utils/calendarSubscribe.ts
+++ b/draco-nodejs/frontend-next/utils/calendarSubscribe.ts
@@ -10,14 +10,14 @@ export function buildCalendarSubscribeUrls(icsUrl: string, name: string): Calend
     throw new TypeError(`icsUrl must start with http:// or https://, got: ${icsUrl}`);
   }
 
-  const apple = icsUrl.replace(/^https?:\/\//, 'webcal://');
+  const webcalUrl = icsUrl.replace(/^https?:\/\//, 'webcal://');
   const encodedUrl = encodeURIComponent(icsUrl);
-  const encodedWebcalUrl = encodeURIComponent(apple);
+  const encodedWebcalUrl = encodeURIComponent(webcalUrl);
   const encodedName = encodeURIComponent(name);
 
   return {
     google: `https://calendar.google.com/calendar/r?cid=${encodedWebcalUrl}`,
-    apple,
+    apple: webcalUrl,
     outlookCom: `https://outlook.live.com/calendar/0/addfromweb?url=${encodedUrl}&name=${encodedName}`,
     office365: `https://outlook.office.com/calendar/0/addfromweb?url=${encodedUrl}&name=${encodedName}`,
   };


### PR DESCRIPTION
Google calendar subscribe links should use the webcal:// scheme so the client prompts to subscribe. Replace the previous encoded https URL with an encoded webcal URL for the Google cid parameter in buildCalendarSubscribeUrls, and add encodedWebcalUrl. Update tests to expect webcal:// in the cid (including round-trip decodeURIComponent checks) and adjust related assertions. Affects calendarSubscribe.ts and its tests.