### PR TITLE
Limit SEQUENCE to RFC 5545 integer range

### DIFF
--- a/draco-nodejs/backend/src/utils/__tests__/icsBuilder.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/icsBuilder.test.ts
@@ -223,6 +223,25 @@ describe('buildVEvent', () => {
     expect(Number.isInteger(seq)).toBe(true);
   });
 
+  it('SEQUENCE always fits within the RFC 5545 INTEGER range across many game ids', () => {
+    const RFC_5545_INTEGER_MAX = 2147483647;
+    for (let i = 0; i < 500; i++) {
+      const game = makeGame({
+        id: BigInt(i + 1),
+        gamedate: new Date(Date.UTC(2025, i % 12, (i % 27) + 1, i % 24, i % 60, 0)),
+        hteamid: BigInt(100 + i),
+        vteamid: BigInt(200 + i),
+        comment: `comment-${i}`,
+      });
+      const event = buildVEvent(makeVEventInput(game));
+      const match = event.match(/SEQUENCE:(\d+)/);
+      expect(match).not.toBeNull();
+      const seq = parseInt(match![1], 10);
+      expect(seq).toBeGreaterThanOrEqual(0);
+      expect(seq).toBeLessThanOrEqual(RFC_5545_INTEGER_MAX);
+    }
+  });
+
   it('omits league name from SUMMARY when leagueName is null', () => {
     const game = makeGame();
     const event = buildVEvent(makeVEventInput(game, { leagueName: null }));

--- a/draco-nodejs/backend/src/utils/icsBuilder.ts
+++ b/draco-nodejs/backend/src/utils/icsBuilder.ts
@@ -4,6 +4,7 @@ import type { dbGameInfo } from '../repositories/index.js';
 
 const ICS_LINE_OCTET_LIMIT = 75;
 const PROD_ID = '-//Draco Sports Manager//Team Calendar Feed//EN';
+const RFC_5545_SEQUENCE_MASK = 0x7fffffff;
 
 export const escapeIcsText = (s: string): string =>
   s
@@ -71,7 +72,7 @@ const buildFieldLocation = (field: dbGameInfo['availablefields']): string | null
 const deriveSequence = (game: dbGameInfo): number => {
   const raw = `${game.id}|${game.gamedate.toISOString()}|${game.hscore ?? ''}|${game.vscore ?? ''}|${game.gamestatus}|${game.fieldid ?? ''}|${game.hteamid}|${game.vteamid}|${game.comment ?? ''}`;
   const hex = createHash('sha1').update(raw).digest('hex').slice(0, 8);
-  return parseInt(hex, 16) & 0x7fffffff;
+  return parseInt(hex, 16) & RFC_5545_SEQUENCE_MASK;
 };
 
 export interface IcsVEventInput {

--- a/draco-nodejs/backend/src/utils/icsBuilder.ts
+++ b/draco-nodejs/backend/src/utils/icsBuilder.ts
@@ -71,7 +71,7 @@ const buildFieldLocation = (field: dbGameInfo['availablefields']): string | null
 const deriveSequence = (game: dbGameInfo): number => {
   const raw = `${game.id}|${game.gamedate.toISOString()}|${game.hscore ?? ''}|${game.vscore ?? ''}|${game.gamestatus}|${game.fieldid ?? ''}|${game.hteamid}|${game.vteamid}|${game.comment ?? ''}`;
   const hex = createHash('sha1').update(raw).digest('hex').slice(0, 8);
-  return parseInt(hex, 16) >>> 0;
+  return parseInt(hex, 16) & 0x7fffffff;
 };
 
 export interface IcsVEventInput {


### PR DESCRIPTION
Mask the derived sequence with 0x7fffffff instead of using unsigned shift, ensuring the SEQUENCE value never exceeds RFC 5545's INTEGER max (2147483647). Also add a test that generates 500 game variations and asserts the SEQUENCE is between 0 and 2147483647 to prevent out-of-range values.