### PR TITLE
Always emit SEQUENCE:0 in VEVENT

### DIFF
--- a/draco-nodejs/backend/src/utils/__tests__/icsBuilder.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/icsBuilder.test.ts
@@ -213,32 +213,15 @@ describe('buildVEvent', () => {
     expect(buildVEvent(makeVEventInput(game))).toContain('STATUS:CONFIRMED');
   });
 
-  it('SEQUENCE is a non-negative integer', () => {
-    const game = makeGame();
-    const event = buildVEvent(makeVEventInput(game));
-    const match = event.match(/SEQUENCE:(\d+)/);
-    expect(match).not.toBeNull();
-    const seq = parseInt(match![1], 10);
-    expect(seq).toBeGreaterThanOrEqual(0);
-    expect(Number.isInteger(seq)).toBe(true);
-  });
-
-  it('SEQUENCE always fits within the RFC 5545 INTEGER range across many game ids', () => {
-    const RFC_5545_INTEGER_MAX = 2147483647;
-    for (let i = 0; i < 500; i++) {
-      const game = makeGame({
-        id: BigInt(i + 1),
-        gamedate: new Date(Date.UTC(2025, i % 12, (i % 27) + 1, i % 24, i % 60, 0)),
-        hteamid: BigInt(100 + i),
-        vteamid: BigInt(200 + i),
-        comment: `comment-${i}`,
-      });
+  it('emits SEQUENCE:0 regardless of game data', () => {
+    const games: dbGameInfo[] = [
+      makeGame(),
+      makeGame({ id: 999n, hscore: 5, vscore: 2, gamestatus: GameStatus.Completed }),
+      makeGame({ id: 1234567890n, comment: 'rescheduled twice' }),
+    ];
+    for (const game of games) {
       const event = buildVEvent(makeVEventInput(game));
-      const match = event.match(/SEQUENCE:(\d+)/);
-      expect(match).not.toBeNull();
-      const seq = parseInt(match![1], 10);
-      expect(seq).toBeGreaterThanOrEqual(0);
-      expect(seq).toBeLessThanOrEqual(RFC_5545_INTEGER_MAX);
+      expect(event).toContain('SEQUENCE:0');
     }
   });
 

--- a/draco-nodejs/backend/src/utils/icsBuilder.ts
+++ b/draco-nodejs/backend/src/utils/icsBuilder.ts
@@ -1,10 +1,8 @@
-import { createHash } from 'crypto';
 import { GameStatus } from '../types/gameEnums.js';
 import type { dbGameInfo } from '../repositories/index.js';
 
 const ICS_LINE_OCTET_LIMIT = 75;
 const PROD_ID = '-//Draco Sports Manager//Team Calendar Feed//EN';
-const RFC_5545_SEQUENCE_MASK = 0x7fffffff;
 
 export const escapeIcsText = (s: string): string =>
   s
@@ -69,12 +67,6 @@ const buildFieldLocation = (field: dbGameInfo['availablefields']): string | null
   return parts.length > 0 ? parts.join(', ') : null;
 };
 
-const deriveSequence = (game: dbGameInfo): number => {
-  const raw = `${game.id}|${game.gamedate.toISOString()}|${game.hscore ?? ''}|${game.vscore ?? ''}|${game.gamestatus}|${game.fieldid ?? ''}|${game.hteamid}|${game.vteamid}|${game.comment ?? ''}`;
-  const hex = createHash('sha1').update(raw).digest('hex').slice(0, 8);
-  return parseInt(hex, 16) & RFC_5545_SEQUENCE_MASK;
-};
-
 export interface IcsVEventInput {
   game: dbGameInfo;
   dtstamp: string;
@@ -97,7 +89,6 @@ export const buildVEvent = ({
   const baseTitle = `${visitorName} @ ${homeName}`;
   const summary = leagueName ? `${leagueName}: ${baseTitle}` : baseTitle;
   const location = buildFieldLocation(game.availablefields);
-  const sequence = deriveSequence(game);
 
   const lines: string[] = [
     'BEGIN:VEVENT',
@@ -113,7 +104,7 @@ export const buildVEvent = ({
   }
 
   lines.push(`STATUS:${mapGameStatusToIcsStatus(game.gamestatus)}`);
-  lines.push(`SEQUENCE:${sequence}`);
+  lines.push('SEQUENCE:0');
   lines.push('END:VEVENT');
 
   return lines.join('\r\n');


### PR DESCRIPTION
Replace the derived SHA-1 based SEQUENCE value with a constant SEQUENCE:0. Removed the crypto import, RFC_5545_SEQUENCE_MASK constant, and the deriveSequence() helper from icsBuilder.ts. Updated tests to assert SEQUENCE:0 across multiple game inputs instead of validating a hashed integer range. This simplifies sequence handling and avoids generating large/inconsistent integers.