### PR TITLE
Add request logging to calendar route

### DIFF
--- a/draco-nodejs/backend/src/routes/calendar.ts
+++ b/draco-nodejs/backend/src/routes/calendar.ts
@@ -23,6 +23,15 @@ const firstHeaderValue = (header: string | string[] | undefined): string | undef
 router.get(
   '/team-season/:teamSeasonId.ics',
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    console.log(
+      `[calendar] ${req.method} ${req.originalUrl} ` +
+        `ua="${req.headers['user-agent'] ?? ''}" ` +
+        `ip=${req.ip ?? ''} ` +
+        `xff="${req.headers['x-forwarded-for'] ?? ''}" ` +
+        `ifNoneMatch="${req.headers['if-none-match'] ?? ''}" ` +
+        `ifModifiedSince="${req.headers['if-modified-since'] ?? ''}"`,
+    );
+
     const rawId = req.params['teamSeasonId'];
     const rawIdStr = Array.isArray(rawId) ? rawId[0] : rawId;
 


### PR DESCRIPTION
Log incoming requests to the /team-season/:teamSeasonId.ics endpoint for debugging and diagnosing caching/conditional GET behavior. The added console.log emits method, originalUrl, user-agent, client IP, x-forwarded-for, If-None-Match and If-Modified-Since header values to help trace requests and client caching interactions.