### PR TITLE
Remove request logging in calendar route

### DIFF
--- a/draco-nodejs/backend/src/routes/calendar.ts
+++ b/draco-nodejs/backend/src/routes/calendar.ts
@@ -23,15 +23,6 @@ const firstHeaderValue = (header: string | string[] | undefined): string | undef
 router.get(
   '/team-season/:teamSeasonId.ics',
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
-    console.log(
-      `[calendar] ${req.method} ${req.originalUrl} ` +
-        `ua="${req.headers['user-agent'] ?? ''}" ` +
-        `ip=${req.ip ?? ''} ` +
-        `xff="${req.headers['x-forwarded-for'] ?? ''}" ` +
-        `ifNoneMatch="${req.headers['if-none-match'] ?? ''}" ` +
-        `ifModifiedSince="${req.headers['if-modified-since'] ?? ''}"`,
-    );
-
     const rawId = req.params['teamSeasonId'];
     const rawIdStr = Array.isArray(rawId) ? rawId[0] : rawId;
 


### PR DESCRIPTION
Remove a verbose console.log call from the /team-season/:teamSeasonId.ics handler that previously printed method, URL, user-agent, IP, X-Forwarded-For, If-None-Match and If-Modified-Since headers. This reduces noisy/sensitive logging; no functional behavior of the route is changed.