### PR TITLE
Search multiple paths for openapi.yaml

### DIFF
--- a/draco-nodejs/backend/src/openapi/openapi.ts
+++ b/draco-nodejs/backend/src/openapi/openapi.ts
@@ -12,7 +12,14 @@ const __dirname = path.dirname(__filename);
  */
 function loadOpenApiSpec() {
   try {
-    const yamlPath = path.resolve(__dirname, '../../openapi.yaml');
+    const candidates = [
+      path.resolve(__dirname, '../../openapi.yaml'),
+      path.resolve(__dirname, '../../../openapi.yaml'),
+    ];
+    const yamlPath = candidates.find((candidate) => fs.existsSync(candidate));
+    if (!yamlPath) {
+      throw new Error(`OpenAPI spec not found. Looked in: ${candidates.join(', ')}`);
+    }
     const yamlContent = fs.readFileSync(yamlPath, 'utf8');
     const spec = YAML.parse(yamlContent);
 


### PR DESCRIPTION
Make loading the OpenAPI spec resilient to different repo layouts by checking multiple candidate locations (../../openapi.yaml and ../../../openapi.yaml) and picking the first that exists. If none are found, throw a clear error listing the checked paths. Existing YAML read/parse logic is unchanged.