### PR TITLE
Feat/searchplayers

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -10913,6 +10913,149 @@
           "query"
         ]
       },
+      "PublicPlayerTeamAffiliation": {
+        "type": "object",
+        "properties": {
+          "teamSeasonId": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "example": "12345"
+          },
+          "teamId": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "example": "12345"
+          },
+          "seasonId": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "example": "12345"
+          },
+          "leagueSeasonId": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "example": "12345"
+          },
+          "leagueName": {
+            "type": "string"
+          },
+          "teamName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "teamSeasonId",
+          "teamId",
+          "seasonId",
+          "leagueSeasonId",
+          "leagueName",
+          "teamName"
+        ]
+      },
+      "PublicPlayerProfile": {
+        "type": "object",
+        "properties": {
+          "contact": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^\\d+$",
+                "example": "12345"
+              },
+              "firstName": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "lastName": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "photoUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "firstName",
+              "lastName"
+            ]
+          },
+          "currentSeason": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^\\d+$",
+                "example": "12345"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "teamSeasonId": {
+                  "type": "string",
+                  "pattern": "^\\d+$",
+                  "example": "12345"
+                },
+                "teamId": {
+                  "type": "string",
+                  "pattern": "^\\d+$",
+                  "example": "12345"
+                },
+                "seasonId": {
+                  "type": "string",
+                  "pattern": "^\\d+$",
+                  "example": "12345"
+                },
+                "leagueSeasonId": {
+                  "type": "string",
+                  "pattern": "^\\d+$",
+                  "example": "12345"
+                },
+                "leagueName": {
+                  "type": "string"
+                },
+                "teamName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "teamSeasonId",
+                "teamId",
+                "seasonId",
+                "leagueSeasonId",
+                "leagueName",
+                "teamName"
+              ]
+            }
+          },
+          "hasCareerStatistics": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "contact",
+          "currentSeason",
+          "teams",
+          "hasCareerStatistics"
+        ],
+        "title": "PublicPlayerProfile",
+        "description": "Public-safe player profile: identity, current-season team affiliations, and a flag indicating whether career statistics exist."
+      },
       "TeamStatsPlayerSummary": {
         "type": "object",
         "properties": {
@@ -44052,6 +44195,68 @@
                   "items": {
                     "$ref": "#/components/schemas/BaseContact"
                   }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/players/{contactId}/public-profile": {
+      "get": {
+        "operationId": "getAccountPlayerPublicProfile",
+        "summary": "Public player profile",
+        "description": "Public-safe player profile: identity, current-season team affiliations, and a flag indicating whether career statistics exist. No authentication required.",
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public player profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicPlayerProfile"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Contact not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
                 }
               }
             }

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -8070,6 +8070,115 @@ components:
           default: 15
       required:
         - query
+    PublicPlayerTeamAffiliation:
+      type: object
+      properties:
+        teamSeasonId:
+          type: string
+          pattern: ^\d+$
+          example: "12345"
+        teamId:
+          type: string
+          pattern: ^\d+$
+          example: "12345"
+        seasonId:
+          type: string
+          pattern: ^\d+$
+          example: "12345"
+        leagueSeasonId:
+          type: string
+          pattern: ^\d+$
+          example: "12345"
+        leagueName:
+          type: string
+        teamName:
+          type: string
+      required:
+        - teamSeasonId
+        - teamId
+        - seasonId
+        - leagueSeasonId
+        - leagueName
+        - teamName
+    PublicPlayerProfile:
+      type: object
+      properties:
+        contact:
+          type: object
+          properties:
+            id:
+              type: string
+              pattern: ^\d+$
+              example: "12345"
+            firstName:
+              type: string
+              minLength: 1
+              maxLength: 100
+            lastName:
+              type: string
+              minLength: 1
+              maxLength: 100
+            photoUrl:
+              type: string
+          required:
+            - id
+            - firstName
+            - lastName
+        currentSeason:
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+              pattern: ^\d+$
+              example: "12345"
+            name:
+              type: string
+          required:
+            - id
+            - name
+        teams:
+          type: array
+          items:
+            type: object
+            properties:
+              teamSeasonId:
+                type: string
+                pattern: ^\d+$
+                example: "12345"
+              teamId:
+                type: string
+                pattern: ^\d+$
+                example: "12345"
+              seasonId:
+                type: string
+                pattern: ^\d+$
+                example: "12345"
+              leagueSeasonId:
+                type: string
+                pattern: ^\d+$
+                example: "12345"
+              leagueName:
+                type: string
+              teamName:
+                type: string
+            required:
+              - teamSeasonId
+              - teamId
+              - seasonId
+              - leagueSeasonId
+              - leagueName
+              - teamName
+        hasCareerStatistics:
+          type: boolean
+      required:
+        - contact
+        - currentSeason
+        - teams
+        - hasCareerStatistics
+      title: PublicPlayerProfile
+      description: "Public-safe player profile: identity, current-season team
+        affiliations, and a flag indicating whether career statistics exist."
     TeamStatsPlayerSummary:
       type: object
       properties:
@@ -31556,6 +31665,47 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/BaseContact"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/players/{contactId}/public-profile:
+    get:
+      operationId: getAccountPlayerPublicProfile
+      summary: Public player profile
+      description: "Public-safe player profile: identity, current-season team
+        affiliations, and a flag indicating whether career statistics exist. No
+        authentication required."
+      tags:
+        - Contacts
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: contactId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: Public player profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicPlayerProfile"
+        "404":
+          description: Contact not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
         "500":
           description: Internal server error
           content:

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -90,6 +90,8 @@ import {
   PublicContactSummarySchema,
   PublicContactSearchResponseSchema,
   PublicContactSearchQuerySchema,
+  PublicPlayerProfileSchema,
+  PublicPlayerTeamAffiliationSchema,
   PlayerSurveyCategorySchema,
   PlayerSurveyDetailSchema,
   TeamStatsPlayerSummarySchema,
@@ -835,6 +837,14 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
   const PublicContactSearchQuerySchemaRef = registry.register(
     'PublicContactSearchQuery',
     PublicContactSearchQuerySchema,
+  );
+  const PublicPlayerTeamAffiliationSchemaRef = registry.register(
+    'PublicPlayerTeamAffiliation',
+    PublicPlayerTeamAffiliationSchema,
+  );
+  const PublicPlayerProfileSchemaRef = registry.register(
+    'PublicPlayerProfile',
+    PublicPlayerProfileSchema,
   );
   const TeamStatsPlayerSummarySchemaRef = registry.register(
     'TeamStatsPlayerSummary',
@@ -1880,6 +1890,8 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     PublicContactSummarySchemaRef,
     PublicContactSearchResponseSchemaRef,
     PublicContactSearchQuerySchemaRef,
+    PublicPlayerProfileSchemaRef,
+    PublicPlayerTeamAffiliationSchemaRef,
     TeamStatsPlayerSummarySchemaRef,
     GameBattingStatLineSchemaRef,
     GameBattingStatsSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/contacts/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/contacts/index.ts
@@ -20,6 +20,7 @@ export const registerContactsEndpoints = ({ registry, schemaRefs, z }: RegisterC
     ContactSearchParamsSchemaRef,
     PublicContactSearchResponseSchemaRef,
     PublicContactSearchQuerySchemaRef,
+    PublicPlayerProfileSchemaRef,
     AutoRegisterContactResponseSchemaRef,
     ContactIndividualGolfAccountSchemaRef,
   } = schemaRefs;
@@ -122,6 +123,62 @@ export const registerContactsEndpoints = ({ registry, schemaRefs, z }: RegisterC
         content: {
           'application/json': {
             schema: BaseContactSchemaRef.array(),
+          },
+        },
+      },
+      500: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/players/{contactId}/public-profile',
+    operationId: 'getAccountPlayerPublicProfile',
+    summary: 'Public player profile',
+    description:
+      'Public-safe player profile: identity, current-season team affiliations, and a flag indicating whether career statistics exist. No authentication required.',
+    tags: ['Contacts'],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'contactId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'Public player profile',
+        content: {
+          'application/json': {
+            schema: PublicPlayerProfileSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Contact not found',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
           },
         },
       },

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -11,6 +11,7 @@ import {
   dbContactWithRoleAndDetails,
   dbBirthdayContact,
   dbContactExportData,
+  dbPlayerCurrentSeasonTeam,
 } from '../types/dbTypes.js';
 import { RoleNamesType } from '../../types/roles.js';
 import { ROLE_IDS } from '../../config/roles.js';
@@ -777,5 +778,67 @@ export class PrismaContactRepository implements IContactRepository {
       ...contact,
       contactroles: Array.from(roleIds).map((roleid) => ({ roleid })),
     }));
+  }
+
+  async findCurrentSeasonTeamsForContact(
+    accountId: bigint,
+    contactId: bigint,
+    seasonId: bigint,
+  ): Promise<dbPlayerCurrentSeasonTeam[]> {
+    const rows = await this.prisma.rosterseason.findMany({
+      where: {
+        inactive: false,
+        roster: {
+          contactid: contactId,
+          contacts: { creatoraccountid: accountId },
+        },
+        teamsseason: {
+          leagueseason: {
+            seasonid: seasonId,
+            league: { accountid: accountId },
+          },
+        },
+      },
+      select: {
+        teamsseason: {
+          select: {
+            id: true,
+            teamid: true,
+            name: true,
+            leagueseason: {
+              select: {
+                id: true,
+                seasonid: true,
+                league: { select: { name: true } },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { teamsseason: { name: 'asc' } },
+    });
+
+    return rows.map((row) => ({
+      teamSeasonId: row.teamsseason.id,
+      teamId: row.teamsseason.teamid,
+      seasonId: row.teamsseason.leagueseason.seasonid,
+      leagueSeasonId: row.teamsseason.leagueseason.id,
+      leagueName: row.teamsseason.leagueseason.league.name,
+      teamName: row.teamsseason.name,
+    }));
+  }
+
+  async hasCareerStatistics(accountId: bigint, contactId: bigint): Promise<boolean> {
+    const match = await this.prisma.rosterseason.findFirst({
+      where: {
+        roster: {
+          contactid: contactId,
+          contacts: { creatoraccountid: accountId },
+        },
+        OR: [{ batstatsum: { some: {} } }, { pitchstatsum: { some: {} } }],
+      },
+      select: { id: true },
+    });
+    return match !== null;
   }
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
@@ -7,6 +7,7 @@ import {
   dbRosterPlayer,
   dbBirthdayContact,
   dbContactExportData,
+  dbPlayerCurrentSeasonTeam,
 } from '../types/dbTypes.js';
 import { ContactQueryOptions, AdvancedFilterOptions } from '../../interfaces/contactInterfaces.js';
 
@@ -58,4 +59,10 @@ export interface IContactRepository extends IBaseRepository<contacts> {
     accountId: bigint,
     options: ContactExportOptions,
   ): Promise<dbContactExportData[]>;
+  findCurrentSeasonTeamsForContact(
+    accountId: bigint,
+    contactId: bigint,
+    seasonId: bigint,
+  ): Promise<dbPlayerCurrentSeasonTeam[]>;
+  hasCareerStatistics(accountId: bigint, contactId: bigint): Promise<boolean>;
 }

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -30,6 +30,15 @@ export interface dbPlayerTeamAssignment {
   teamName?: string | null;
 }
 
+export interface dbPlayerCurrentSeasonTeam {
+  teamSeasonId: bigint;
+  teamId: bigint;
+  seasonId: bigint;
+  leagueSeasonId: bigint;
+  leagueName: string;
+  teamName: string;
+}
+
 export type dbWelcomeMessage = Prisma.accountwelcomeGetPayload<{
   select: {
     id: true;

--- a/draco-nodejs/backend/src/responseFormatters/PublicPlayerProfileResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/PublicPlayerProfileResponseFormatter.ts
@@ -1,0 +1,37 @@
+import { PublicPlayerProfileType, PublicPlayerTeamAffiliationType } from '@draco/shared-schemas';
+import {
+  dbBaseContact,
+  dbPlayerCurrentSeasonTeam,
+  dbSeason,
+} from '../repositories/types/dbTypes.js';
+import { ContactResponseFormatter } from './responseFormatters.js';
+
+export class PublicPlayerProfileResponseFormatter {
+  static formatTeam(team: dbPlayerCurrentSeasonTeam): PublicPlayerTeamAffiliationType {
+    return {
+      teamSeasonId: team.teamSeasonId.toString(),
+      teamId: team.teamId.toString(),
+      seasonId: team.seasonId.toString(),
+      leagueSeasonId: team.leagueSeasonId.toString(),
+      leagueName: team.leagueName,
+      teamName: team.teamName,
+    };
+  }
+
+  static format(
+    accountId: bigint,
+    contact: dbBaseContact,
+    currentSeason: dbSeason | null,
+    teams: dbPlayerCurrentSeasonTeam[],
+    hasCareerStatistics: boolean,
+  ): PublicPlayerProfileType {
+    return {
+      contact: ContactResponseFormatter.formatPublicContactSummary(accountId, contact),
+      currentSeason: currentSeason
+        ? { id: currentSeason.id.toString(), name: currentSeason.name }
+        : null,
+      teams: teams.map((team) => this.formatTeam(team)),
+      hasCareerStatistics,
+    };
+  }
+}

--- a/draco-nodejs/backend/src/responseFormatters/index.ts
+++ b/draco-nodejs/backend/src/responseFormatters/index.ts
@@ -1,5 +1,6 @@
 export * from './AccountResponseFormatter.js';
 export * from './responseFormatters.js';
+export * from './PublicPlayerProfileResponseFormatter.js';
 export * from './playerSurveyResponseFormatter.js';
 export * from './RosterResponseFormatter.js';
 export * from './roleResponseFormatter.js';

--- a/draco-nodejs/backend/src/routes/accounts-contacts.ts
+++ b/draco-nodejs/backend/src/routes/accounts-contacts.ts
@@ -24,6 +24,7 @@ import {
   ContactValidationSchema,
   PublicContactSearchQuerySchema,
   PublicContactSummaryType,
+  PublicPlayerProfileType,
   ContactFilterFieldSchema,
   ContactFilterOpSchema,
   ContactFilterFieldType,
@@ -98,6 +99,24 @@ router.get(
     );
 
     res.json({ results });
+  }),
+);
+
+/**
+ * GET /api/accounts/:accountId/players/:contactId/public-profile
+ * Public-safe player profile (identity + current-season teams + has-stats flag).
+ */
+router.get(
+  '/:accountId/players/:contactId/public-profile',
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, contactId } = extractContactParams(req.params);
+
+    const profile: PublicPlayerProfileType = await contactService.getPublicPlayerProfile(
+      accountId,
+      contactId,
+    );
+
+    res.json(profile);
   }),
 );
 

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -71,6 +71,9 @@ class ContactRepositoryStub implements IContactRepository {
   searchContactsByName = vi.fn<IContactRepository['searchContactsByName']>();
   findAvailableContacts = vi.fn<IContactRepository['findAvailableContacts']>();
   findContactsForExport = vi.fn<IContactRepository['findContactsForExport']>();
+  findCurrentSeasonTeamsForContact =
+    vi.fn<IContactRepository['findCurrentSeasonTeamsForContact']>();
+  hasCareerStatistics = vi.fn<IContactRepository['hasCareerStatistics']>();
 }
 
 class RoleRepositoryStub implements IRoleRepository {

--- a/draco-nodejs/backend/src/services/contactService.ts
+++ b/draco-nodejs/backend/src/services/contactService.ts
@@ -11,9 +11,14 @@ import {
   ContactValidationType,
   NamedContactType,
   PublicContactSummaryType,
+  PublicPlayerProfileType,
 } from '@draco/shared-schemas';
 import { ConflictError, NotFoundError, ValidationError } from '../utils/customErrors.js';
-import { ContactResponseFormatter, TeamResponseFormatter } from '../responseFormatters/index.js';
+import {
+  ContactResponseFormatter,
+  PublicPlayerProfileResponseFormatter,
+  TeamResponseFormatter,
+} from '../responseFormatters/index.js';
 import {
   RepositoryFactory,
   IContactRepository,
@@ -309,6 +314,39 @@ export class ContactService {
       pagination,
     );
     return response;
+  }
+
+  async getPublicPlayerProfile(
+    accountId: bigint,
+    contactId: bigint,
+  ): Promise<PublicPlayerProfileType> {
+    const dbContact = await this.contactRepository.findContactInAccount(contactId, accountId);
+    if (!dbContact) {
+      throw new NotFoundError('Contact not found');
+    }
+
+    const currentSeason = await this.seasonRepository.findCurrentSeason(accountId);
+
+    const teams = currentSeason
+      ? await this.contactRepository.findCurrentSeasonTeamsForContact(
+          accountId,
+          contactId,
+          currentSeason.id,
+        )
+      : [];
+
+    const hasCareerStatistics = await this.contactRepository.hasCareerStatistics(
+      accountId,
+      contactId,
+    );
+
+    return PublicPlayerProfileResponseFormatter.format(
+      accountId,
+      dbContact,
+      currentSeason,
+      teams,
+      hasCareerStatistics,
+    );
   }
 
   async searchContactsPublic(

--- a/draco-nodejs/frontend-next/AGENTS.md
+++ b/draco-nodejs/frontend-next/AGENTS.md
@@ -444,9 +444,116 @@ export function useServiceHook(accountId: string) {
 }
 ```
 
+### Page Composition Pattern (page → ClientWrapper → Component)
+
+**Every account-scoped page must be split into exactly three files**, with strict
+responsibilities. Do not collapse them, and do not put layout or data fetching
+in the wrong file.
+
+```
+app/account/[accountId]/foo/[fooId]/
+├── page.tsx                  # Server component — metadata + delegate ONLY
+├── FooClientWrapper.tsx      # Client shim — useParams + (optional) ProtectedRoute
+└── FooClient.tsx             # Real component — owns <main>/AccountPageHeader/data
+```
+
+**1. `page.tsx` — server component.** No `'use client'`. Exports
+`generateMetadata` (via `buildSeoMetadata` + `getAccountBranding`) and a default
+component whose body is exactly `return <FooClientWrapper />`. **Never** read
+params here for rendering, **never** render `<main>`, `AccountPageHeader`, or
+data — the wrapper handles that.
+
+```tsx
+// page.tsx
+import { getAccountBranding } from '.../lib/metadataFetchers';
+import { buildSeoMetadata } from '.../lib/seoMetadata';
+import { resolveRouteParams, type MetadataParams } from '.../lib/metadataParams';
+import FooClientWrapper from './FooClientWrapper';
+
+export async function generateMetadata({
+  params,
+}: { params: MetadataParams<{ accountId: string; fooId: string }> }) {
+  const { accountId } = await resolveRouteParams(params);
+  const { name, iconUrl } = await getAccountBranding(accountId);
+  return buildSeoMetadata({
+    title: `${name} Foo`,
+    description: `…`,
+    path: `/account/${accountId}/foo`,
+    icon: iconUrl,
+  });
+}
+
+export default function FooPage() {
+  return <FooClientWrapper />;
+}
+```
+
+**2. `FooClientWrapper.tsx` — thin client shim.** Marked `'use client'`. Reads
+route params via `useParams`, and wraps with `<ProtectedRoute>` only if the
+page requires auth. Delegates to the real component with typed `string` props.
+This file should be ~10 lines. **No layout, no fetching, no business logic.**
+
+```tsx
+// FooClientWrapper.tsx
+'use client';
+
+import { useParams } from 'next/navigation';
+// import ProtectedRoute from '@/components/auth/ProtectedRoute'; // only if auth required
+import FooClient from './FooClient';
+
+export default function FooClientWrapper() {
+  const params = useParams();
+  const accountId = Array.isArray(params.accountId) ? params.accountId[0] : params.accountId;
+  const fooId = Array.isArray(params.fooId) ? params.fooId[0] : params.fooId;
+
+  return <FooClient accountId={accountId ?? ''} fooId={fooId ?? ''} />;
+}
+```
+
+**3. `FooClient.tsx` — the real component.** Marked `'use client'`. Receives
+`accountId` and other ids as props (do **not** call `useParams` here). Owns the
+`<main>` + `AccountPageHeader` + `Container` shell, the data-fetching effect
+(with `AbortController`), and renders the body. This is where the size lives.
+
+```tsx
+// FooClient.tsx
+'use client';
+
+import { Box, Container, Typography } from '@mui/material';
+import AccountPageHeader from '.../components/AccountPageHeader';
+
+interface FooClientProps { accountId: string; fooId: string; }
+
+export default function FooClient({ accountId, fooId }: FooClientProps) {
+  // useEffect + AbortController data fetching here
+  return (
+    <main className="min-h-screen bg-background">
+      <AccountPageHeader accountId={accountId}>
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography variant="h4">Foo</Typography>
+        </Box>
+      </AccountPageHeader>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {/* body */}
+      </Container>
+    </main>
+  );
+}
+```
+
+**Reference implementations:**
+- `app/account/[accountId]/statistics/{page.tsx, StatisticsClientWrapper.tsx, Statistics.tsx}`
+- `app/profile/{page.tsx, ProfilePageClientWrapper.tsx, ProfilePageClient.tsx}` (uses `ProtectedRoute`)
+
+**Common mistakes to avoid:**
+- ❌ `page.tsx` marked `'use client'`, or rendering `<main>` / `AccountPageHeader` directly.
+- ❌ ClientWrapper containing data-fetching, layout JSX, or more than ~15 lines.
+- ❌ Real client component calling `useParams` instead of accepting `accountId` as a prop.
+- ❌ Skipping the wrapper layer and pointing `page.tsx` directly at the real component.
+
 ### Account & Team Page Layout Pattern
 
-Account-scoped and team-scoped management pages must wrap their content with a semantic `<main>` element immediately followed by `AccountPageHeader`:
+Account-scoped and team-scoped management pages must wrap their content with a semantic `<main>` element immediately followed by `AccountPageHeader`. This layout lives **inside the real client component** (the third file in the Page Composition Pattern above), never in `page.tsx` or the ClientWrapper:
 
 ```tsx
 return (

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import NextLink from 'next/link';
+import { useParams } from 'next/navigation';
+import { Alert, Box, Button, Container, Stack, Typography } from '@mui/material';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import type { BaseContactType, PublicPlayerProfileType } from '@draco/shared-schemas';
+import AccountPageHeader from '../../../../../components/AccountPageHeader';
+import ContactInfoCard from '../../../../../components/profile/ContactInfoCard';
+import CurrentSeasonTeamsCard from '../../../../../components/profile/CurrentSeasonTeamsCard';
+import { useApiClient } from '../../../../../hooks/useApiClient';
+import { fetchPublicPlayerProfile } from '../../../../../services/publicPlayerProfileService';
+import { useAccount } from '../../../../../context/AccountContext';
+
+const buildSyntheticContact = (profile: PublicPlayerProfileType | null): BaseContactType | null => {
+  if (!profile) return null;
+  return {
+    id: profile.contact.id,
+    firstName: profile.contact.firstName,
+    lastName: profile.contact.lastName,
+    photoUrl: profile.contact.photoUrl,
+  } as BaseContactType;
+};
+
+const PublicPlayerProfileClient: React.FC = () => {
+  const params = useParams();
+  const apiClient = useApiClient();
+  const { currentAccount } = useAccount();
+
+  const rawAccountId = Array.isArray(params.accountId) ? params.accountId[0] : params.accountId;
+  const rawPlayerId = Array.isArray(params.playerId) ? params.playerId[0] : params.playerId;
+
+  const accountId = rawAccountId ?? '';
+  const contactId = rawPlayerId ?? '';
+
+  const [profile, setProfile] = useState<PublicPlayerProfileType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!accountId || !contactId) return;
+
+    const controller = new AbortController();
+
+    const loadProfile = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchPublicPlayerProfile(accountId, contactId, {
+          client: apiClient,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) return;
+        setProfile(result);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : 'Failed to load player profile';
+        setError(message);
+        setProfile(null);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    void loadProfile();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, contactId, apiClient]);
+
+  const contactCardContact = buildSyntheticContact(profile);
+  const accountName = typeof currentAccount?.name === 'string' ? currentAccount.name : undefined;
+  const seasonName = profile?.currentSeason?.name ?? null;
+
+  const statisticsHref = profile?.hasCareerStatistics
+    ? `/account/${accountId}/players/${contactId}/statistics?returnTo=${encodeURIComponent(
+        `/account/${accountId}/players/${contactId}`,
+      )}&returnLabel=Player%20Profile`
+    : null;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <AccountPageHeader accountId={accountId}>
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography variant="h4" color="text.primary" sx={{ fontWeight: 'bold' }}>
+            Player Profile
+          </Typography>
+        </Box>
+      </AccountPageHeader>
+
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {error ? (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {error}
+          </Alert>
+        ) : null}
+
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 3,
+            gridTemplateColumns: { xs: '1fr', md: '1fr 2fr' },
+          }}
+        >
+          <ContactInfoCard
+            contact={contactCardContact}
+            loading={loading}
+            error={error ?? undefined}
+            accountName={accountName}
+            hideDetails
+          />
+          <Stack spacing={3}>
+            <CurrentSeasonTeamsCard
+              accountId={accountId}
+              seasonName={seasonName}
+              teams={profile?.teams ?? []}
+              loading={loading}
+              error={error ?? undefined}
+            />
+            {statisticsHref ? (
+              <Box>
+                <Button
+                  component={NextLink}
+                  href={statisticsHref}
+                  variant="contained"
+                  color="primary"
+                  startIcon={<BarChartIcon />}
+                >
+                  View Career Statistics
+                </Button>
+              </Box>
+            ) : null}
+          </Stack>
+        </Box>
+      </Container>
+    </main>
+  );
+};
+
+export default PublicPlayerProfileClient;

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
@@ -19,12 +19,13 @@ interface PublicPlayerProfileClientProps {
 
 const buildSyntheticContact = (profile: PublicPlayerProfileType | null): BaseContactType | null => {
   if (!profile) return null;
-  return {
+  const synthetic: BaseContactType = {
     id: profile.contact.id,
     firstName: profile.contact.firstName,
     lastName: profile.contact.lastName,
     photoUrl: profile.contact.photoUrl,
-  } as BaseContactType;
+  };
+  return synthetic;
 };
 
 export default function PublicPlayerProfileClient({

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClient.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from 'react';
 import NextLink from 'next/link';
-import { useParams } from 'next/navigation';
 import { Alert, Box, Button, Container, Stack, Typography } from '@mui/material';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import type { BaseContactType, PublicPlayerProfileType } from '@draco/shared-schemas';
@@ -12,6 +11,11 @@ import CurrentSeasonTeamsCard from '../../../../../components/profile/CurrentSea
 import { useApiClient } from '../../../../../hooks/useApiClient';
 import { fetchPublicPlayerProfile } from '../../../../../services/publicPlayerProfileService';
 import { useAccount } from '../../../../../context/AccountContext';
+
+interface PublicPlayerProfileClientProps {
+  accountId: string;
+  contactId: string;
+}
 
 const buildSyntheticContact = (profile: PublicPlayerProfileType | null): BaseContactType | null => {
   if (!profile) return null;
@@ -23,16 +27,12 @@ const buildSyntheticContact = (profile: PublicPlayerProfileType | null): BaseCon
   } as BaseContactType;
 };
 
-const PublicPlayerProfileClient: React.FC = () => {
-  const params = useParams();
+export default function PublicPlayerProfileClient({
+  accountId,
+  contactId,
+}: PublicPlayerProfileClientProps) {
   const apiClient = useApiClient();
   const { currentAccount } = useAccount();
-
-  const rawAccountId = Array.isArray(params.accountId) ? params.accountId[0] : params.accountId;
-  const rawPlayerId = Array.isArray(params.playerId) ? params.playerId[0] : params.playerId;
-
-  const accountId = rawAccountId ?? '';
-  const contactId = rawPlayerId ?? '';
 
   const [profile, setProfile] = useState<PublicPlayerProfileType | null>(null);
   const [loading, setLoading] = useState(true);
@@ -137,6 +137,4 @@ const PublicPlayerProfileClient: React.FC = () => {
       </Container>
     </main>
   );
-};
-
-export default PublicPlayerProfileClient;
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/PublicPlayerProfileClientWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import PublicPlayerProfileClient from './PublicPlayerProfileClient';
+
+export default function PublicPlayerProfileClientWrapper() {
+  const params = useParams();
+  const accountId = Array.isArray(params.accountId) ? params.accountId[0] : params.accountId;
+  const playerId = Array.isArray(params.playerId) ? params.playerId[0] : params.playerId;
+
+  return <PublicPlayerProfileClient accountId={accountId ?? ''} contactId={playerId ?? ''} />;
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
@@ -8,13 +8,13 @@ export async function generateMetadata({
 }: {
   params: MetadataParams<{ accountId: string; playerId: string }>;
 }) {
-  const { accountId } = await resolveRouteParams(params);
+  const { accountId, playerId } = await resolveRouteParams(params);
   const { name: accountName, iconUrl } = await getAccountBranding(accountId);
 
   return buildSeoMetadata({
     title: `${accountName} Player Profile`,
     description: `Player profile and current-season team affiliations for ${accountName}.`,
-    path: `/account/${accountId}/players`,
+    path: `/account/${accountId}/players/${playerId}`,
     icon: iconUrl,
   });
 }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
@@ -1,7 +1,7 @@
 import { getAccountBranding } from '../../../../../lib/metadataFetchers';
 import { buildSeoMetadata } from '../../../../../lib/seoMetadata';
 import { resolveRouteParams, type MetadataParams } from '../../../../../lib/metadataParams';
-import PublicPlayerProfileClient from './PublicPlayerProfileClient';
+import PublicPlayerProfileClientWrapper from './PublicPlayerProfileClientWrapper';
 
 export async function generateMetadata({
   params,
@@ -20,5 +20,5 @@ export async function generateMetadata({
 }
 
 export default function PublicPlayerProfilePage() {
-  return <PublicPlayerProfileClient />;
+  return <PublicPlayerProfileClientWrapper />;
 }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/page.tsx
@@ -1,0 +1,24 @@
+import { getAccountBranding } from '../../../../../lib/metadataFetchers';
+import { buildSeoMetadata } from '../../../../../lib/seoMetadata';
+import { resolveRouteParams, type MetadataParams } from '../../../../../lib/metadataParams';
+import PublicPlayerProfileClient from './PublicPlayerProfileClient';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: MetadataParams<{ accountId: string; playerId: string }>;
+}) {
+  const { accountId } = await resolveRouteParams(params);
+  const { name: accountName, iconUrl } = await getAccountBranding(accountId);
+
+  return buildSeoMetadata({
+    title: `${accountName} Player Profile`,
+    description: `Player profile and current-season team affiliations for ${accountName}.`,
+    path: `/account/${accountId}/players`,
+    icon: iconUrl,
+  });
+}
+
+export default function PublicPlayerProfilePage() {
+  return <PublicPlayerProfileClient />;
+}

--- a/draco-nodejs/frontend-next/app/profile/ProfilePageClient.tsx
+++ b/draco-nodejs/frontend-next/app/profile/ProfilePageClient.tsx
@@ -12,7 +12,9 @@ import {
   Typography,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import BarChartIcon from '@mui/icons-material/BarChart';
 import Grid from '@mui/material/Grid';
+import NextLink from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
   getAccountUserTeams,
@@ -537,6 +539,17 @@ const ProfilePageClient: React.FC = () => {
               surveyAccountId={currentAccountId}
               hideDetails={hideContactDetails}
             />
+            {currentAccountId && contact?.id ? (
+              <Button
+                component={NextLink}
+                href={`/account/${currentAccountId}/players/${contact.id}/statistics?returnTo=/profile&returnLabel=Your%20Profile`}
+                variant="outlined"
+                color="primary"
+                startIcon={<BarChartIcon />}
+              >
+                View Career Statistics
+              </Button>
+            ) : null}
             <AccountOptional
               accountId={currentAccount?.id ? String(currentAccount.id) : null}
               componentId="profile.memberBusiness.card"

--- a/draco-nodejs/frontend-next/components/Layout.tsx
+++ b/draco-nodejs/frontend-next/components/Layout.tsx
@@ -36,6 +36,7 @@ import { useLogout } from '../hooks/useLogout';
 import BaseballMenu from './BaseballMenu';
 import { useAccountMembership } from '../hooks/useAccountMembership';
 import RegistrationDialog from './account/RegistrationDialog';
+import GlobalPlayerSearch from './layout/GlobalPlayerSearch';
 const TopBarQuickActions = dynamic(() => import('./TopBarQuickActions'), {
   ssr: false,
 });
@@ -423,6 +424,7 @@ const Layout: React.FC<LayoutProps> = ({ children, accountId: propAccountId }) =
 
           {/* Right side - User info and actions */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <GlobalPlayerSearch />
             {/* Hamburger menu for overflow items */}
             {(sportOverflowItems.length > 0 ||
               (isSmallScreen && authMenuItems.length > 0) ||

--- a/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
+++ b/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
@@ -173,21 +173,26 @@ const GlobalPlayerSearch: React.FC = () => {
         noOptionsText={
           hasActiveQuery ? (error ?? 'No players found') : 'Start typing a player name'
         }
-        renderOption={(props, option) => (
-          <Box component="li" {...props} key={option.id}>
-            <Box display="flex" alignItems="center" width="100%" gap={1}>
-              <Avatar
-                src={option.photoUrl}
-                alt={formatDisplayName(option)}
-                sx={{ width: 28, height: 28 }}
-              >
-                {option.firstName?.[0]}
-                {option.lastName?.[0]}
-              </Avatar>
-              <Typography variant="body2">{formatDisplayName(option)}</Typography>
+        renderOption={(props, option) => {
+          const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+            key?: React.Key;
+          };
+          return (
+            <Box component="li" key={key ?? option.id} {...liProps}>
+              <Box display="flex" alignItems="center" width="100%" gap={1}>
+                <Avatar
+                  src={option.photoUrl}
+                  alt={formatDisplayName(option)}
+                  sx={{ width: 28, height: 28 }}
+                >
+                  {option.firstName?.[0]}
+                  {option.lastName?.[0]}
+                </Avatar>
+                <Typography variant="body2">{formatDisplayName(option)}</Typography>
+              </Box>
             </Box>
-          </Box>
-        )}
+          );
+        }}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
+++ b/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  Autocomplete,
+  Avatar,
+  Box,
+  CircularProgress,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import CloseIcon from '@mui/icons-material/Close';
+import { useApiClient } from '../../hooks/useApiClient';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { searchPublicContacts } from '../../services/statisticsService';
+
+interface GlobalPlayerSearchOption {
+  id: string;
+  firstName: string;
+  lastName: string;
+  photoUrl?: string;
+}
+
+const ACCOUNT_PATH_PATTERN = /^\/account\/(\d+)(?:\/|$)/;
+
+const resolveAccountId = (pathname: string | null): string | null => {
+  if (!pathname) return null;
+  const match = pathname.match(ACCOUNT_PATH_PATTERN);
+  return match ? match[1] : null;
+};
+
+const formatDisplayName = (option: GlobalPlayerSearchOption) =>
+  `${option.firstName} ${option.lastName}`.trim();
+
+const GlobalPlayerSearch: React.FC = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const apiClient = useApiClient();
+  const accountId = resolveAccountId(pathname);
+
+  const [expanded, setExpanded] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState<GlobalPlayerSearchOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const debouncedQuery = useDebouncedValue(inputValue, 350);
+  const trimmedQuery = debouncedQuery.trim();
+  const hasActiveQuery = trimmedQuery.length > 0;
+
+  useEffect(() => {
+    if (!expanded) {
+      setInputValue('');
+      setOptions([]);
+      setError(null);
+      return;
+    }
+    inputRef.current?.focus();
+  }, [expanded]);
+
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (containerRef.current && containerRef.current.contains(target)) return;
+      if (target.closest('.MuiAutocomplete-popper')) return;
+      setExpanded(false);
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [expanded]);
+
+  useEffect(() => {
+    if (!expanded || !accountId || !hasActiveQuery) {
+      setOptions([]);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const performSearch = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await searchPublicContacts(
+          accountId,
+          { query: trimmedQuery, limit: 10 },
+          { client: apiClient, signal: controller.signal },
+        );
+        if (controller.signal.aborted) return;
+        const next: GlobalPlayerSearchOption[] =
+          response.results?.map((contact) => ({
+            id: contact.id,
+            firstName: contact.firstName,
+            lastName: contact.lastName,
+            photoUrl: contact.photoUrl ?? undefined,
+          })) ?? [];
+        setOptions(next);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to search players');
+        setOptions([]);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    void performSearch();
+
+    return () => {
+      controller.abort();
+    };
+  }, [expanded, accountId, hasActiveQuery, trimmedQuery, apiClient]);
+
+  if (!accountId) {
+    return null;
+  }
+
+  const handleOpen = () => {
+    setExpanded(true);
+  };
+
+  const handleClose = () => {
+    setExpanded(false);
+  };
+
+  const handleSelect = (option: GlobalPlayerSearchOption | null) => {
+    if (!option) return;
+    setExpanded(false);
+    router.push(`/account/${accountId}/players/${option.id}`);
+  };
+
+  if (!expanded) {
+    return (
+      <Tooltip title="Search players">
+        <IconButton color="inherit" aria-label="Search players" onClick={handleOpen} size="large">
+          <SearchIcon />
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{ display: 'flex', alignItems: 'center', width: { xs: 220, sm: 300, md: 340 } }}
+    >
+      <Autocomplete<GlobalPlayerSearchOption, false, false, false>
+        fullWidth
+        size="small"
+        options={options}
+        loading={loading}
+        filterOptions={(opts) => opts}
+        getOptionLabel={(option) => formatDisplayName(option)}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        inputValue={inputValue}
+        onInputChange={(_event, value) => setInputValue(value)}
+        onChange={(_event, value) => handleSelect(value)}
+        noOptionsText={
+          hasActiveQuery ? (error ?? 'No players found') : 'Start typing a player name'
+        }
+        renderOption={(props, option) => (
+          <Box component="li" {...props} key={option.id}>
+            <Box display="flex" alignItems="center" width="100%" gap={1}>
+              <Avatar
+                src={option.photoUrl}
+                alt={formatDisplayName(option)}
+                sx={{ width: 28, height: 28 }}
+              >
+                {option.firstName?.[0]}
+                {option.lastName?.[0]}
+              </Avatar>
+              <Typography variant="body2">{formatDisplayName(option)}</Typography>
+            </Box>
+          </Box>
+        )}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            inputRef={inputRef}
+            placeholder="Search players"
+            variant="outlined"
+            sx={{
+              backgroundColor: 'background.paper',
+              borderRadius: 1,
+            }}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading ? <CircularProgress color="inherit" size={18} /> : null}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            }}
+          />
+        )}
+      />
+      <IconButton
+        color="inherit"
+        aria-label="Close player search"
+        onClick={handleClose}
+        size="small"
+        sx={{ ml: 0.5 }}
+      >
+        <CloseIcon />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default GlobalPlayerSearch;

--- a/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
+++ b/draco-nodejs/frontend-next/components/layout/GlobalPlayerSearch.tsx
@@ -85,6 +85,7 @@ const GlobalPlayerSearch: React.FC = () => {
   useEffect(() => {
     if (!expanded || !accountId || !hasActiveQuery) {
       setOptions([]);
+      setLoading(false);
       return;
     }
 

--- a/draco-nodejs/frontend-next/components/profile/CurrentSeasonTeamsCard.tsx
+++ b/draco-nodejs/frontend-next/components/profile/CurrentSeasonTeamsCard.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import NextLink from 'next/link';
+import { Alert, Box, Divider, Skeleton, Stack, Typography } from '@mui/material';
+import GroupsIcon from '@mui/icons-material/Groups';
+import type { PublicPlayerTeamAffiliationType } from '@draco/shared-schemas';
+import WidgetShell from '../ui/WidgetShell';
+
+interface CurrentSeasonTeamsCardProps {
+  accountId: string;
+  seasonName: string | null;
+  teams: PublicPlayerTeamAffiliationType[];
+  loading: boolean;
+  error?: string | null;
+}
+
+const CurrentSeasonTeamsCard: React.FC<CurrentSeasonTeamsCardProps> = ({
+  accountId,
+  seasonName,
+  teams,
+  loading,
+  error,
+}) => {
+  const widgetSx = { p: 4 };
+  const title = seasonName ? `${seasonName} Teams` : 'Current Season Teams';
+
+  if (loading) {
+    return (
+      <WidgetShell title={title} accent="primary" sx={widgetSx}>
+        <Stack spacing={1.5}>
+          <Skeleton variant="rectangular" height={48} />
+          <Skeleton variant="rectangular" height={48} />
+        </Stack>
+      </WidgetShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <WidgetShell title={title} accent="primary" sx={widgetSx}>
+        <Alert severity="error">{error}</Alert>
+      </WidgetShell>
+    );
+  }
+
+  if (!seasonName) {
+    return (
+      <WidgetShell title={title} accent="primary" sx={widgetSx}>
+        <Alert severity="info">No current season is configured for this account.</Alert>
+      </WidgetShell>
+    );
+  }
+
+  if (teams.length === 0) {
+    return (
+      <WidgetShell title={title} accent="primary" sx={widgetSx}>
+        <Alert severity="info">Not rostered on any team this season.</Alert>
+      </WidgetShell>
+    );
+  }
+
+  return (
+    <WidgetShell title={title} accent="primary" sx={widgetSx}>
+      <Stack spacing={1.5} divider={<Divider flexItem />}>
+        {teams.map((team) => (
+          <Box
+            key={team.teamSeasonId}
+            component={NextLink}
+            href={`/account/${accountId}/seasons/${team.seasonId}/teams/${team.teamSeasonId}`}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              textDecoration: 'none',
+              color: 'inherit',
+              py: 1,
+              '&:hover .team-name': {
+                textDecoration: 'underline',
+              },
+            }}
+          >
+            <GroupsIcon color="primary" />
+            <Box>
+              <Typography
+                variant="body1"
+                className="team-name"
+                sx={{ fontWeight: 600 }}
+                color="text.primary"
+              >
+                {team.teamName}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {team.leagueName}
+              </Typography>
+            </Box>
+          </Box>
+        ))}
+      </Stack>
+    </WidgetShell>
+  );
+};
+
+export default CurrentSeasonTeamsCard;

--- a/draco-nodejs/frontend-next/services/__tests__/publicPlayerProfileService.test.ts
+++ b/draco-nodejs/frontend-next/services/__tests__/publicPlayerProfileService.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { getAccountPlayerPublicProfile } from '@draco/shared-api-client';
+import { ApiClientError } from '../../utils/apiResult';
+import { fetchPublicPlayerProfile } from '../publicPlayerProfileService';
+import type { Client } from '@draco/shared-api-client/generated/client';
+
+vi.mock('@draco/shared-api-client', () => ({
+  getAccountPlayerPublicProfile: vi.fn(),
+}));
+
+vi.mock('../../lib/apiClientFactory', () => ({
+  createApiClient: vi.fn(() => ({}) as Client),
+}));
+
+const mockClient = {} as Client;
+
+const makeOkResult = <T>(data: T) =>
+  ({
+    data,
+    request: {} as Request,
+    response: {} as Response,
+  }) as never;
+
+const makeErrorResult = (message: string) =>
+  ({
+    data: undefined,
+    error: { message, statusCode: 404 },
+    request: {} as Request,
+    response: { status: 404 } as Response,
+  }) as never;
+
+describe('publicPlayerProfileService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchPublicPlayerProfile', () => {
+    it('forwards accountId, contactId, signal, and provided client to the OpenAPI op and returns its data', async () => {
+      const profile = {
+        contact: { id: 'c-1', firstName: 'Jane', lastName: 'Smith', photoUrl: undefined },
+        currentSeason: { id: 's-1', name: '2026' },
+        teams: [],
+        hasCareerStatistics: false,
+      };
+      vi.mocked(getAccountPlayerPublicProfile).mockResolvedValue(makeOkResult(profile));
+      const controller = new AbortController();
+
+      const result = await fetchPublicPlayerProfile('acct-1', 'c-1', {
+        client: mockClient,
+        signal: controller.signal,
+      });
+
+      expect(getAccountPlayerPublicProfile).toHaveBeenCalledTimes(1);
+      expect(getAccountPlayerPublicProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client: mockClient,
+          path: { accountId: 'acct-1', contactId: 'c-1' },
+          signal: controller.signal,
+          throwOnError: false,
+        }),
+      );
+      expect(result).toEqual(profile);
+    });
+
+    it('throws ApiClientError when the API returns an error result', async () => {
+      vi.mocked(getAccountPlayerPublicProfile).mockResolvedValue(
+        makeErrorResult('Contact not found'),
+      );
+
+      await expect(
+        fetchPublicPlayerProfile('acct-1', 'c-1', { client: mockClient }),
+      ).rejects.toBeInstanceOf(ApiClientError);
+    });
+  });
+});

--- a/draco-nodejs/frontend-next/services/publicPlayerProfileService.ts
+++ b/draco-nodejs/frontend-next/services/publicPlayerProfileService.ts
@@ -1,0 +1,37 @@
+import { getAccountPlayerPublicProfile } from '@draco/shared-api-client';
+import type { Client } from '@draco/shared-api-client/generated/client';
+import type { PublicPlayerProfileType } from '@draco/shared-schemas';
+
+import { createApiClient } from '../lib/apiClientFactory';
+import { unwrapApiResult } from '../utils/apiResult';
+
+interface ClientOptions {
+  client?: Client;
+  token?: string | null;
+  signal?: AbortSignal;
+}
+
+const resolveClient = ({ client, token }: ClientOptions = {}): Client => {
+  if (client) {
+    return client;
+  }
+
+  return createApiClient({ token: token ?? undefined });
+};
+
+export async function fetchPublicPlayerProfile(
+  accountId: string,
+  contactId: string,
+  options?: ClientOptions,
+): Promise<PublicPlayerProfileType> {
+  const client = resolveClient(options);
+
+  const result = await getAccountPlayerPublicProfile({
+    client,
+    path: { accountId, contactId },
+    signal: options?.signal,
+    throwOnError: false,
+  });
+
+  return unwrapApiResult(result, 'Failed to load player profile');
+}

--- a/draco-nodejs/shared/shared-schemas/contact.ts
+++ b/draco-nodejs/shared/shared-schemas/contact.ts
@@ -157,6 +157,33 @@ export const PublicContactSearchQuerySchema = z.object({
     .default(15),
 });
 
+export const PublicPlayerTeamAffiliationSchema = z.object({
+  teamSeasonId: bigintToStringSchema,
+  teamId: bigintToStringSchema,
+  seasonId: bigintToStringSchema,
+  leagueSeasonId: bigintToStringSchema,
+  leagueName: z.string(),
+  teamName: z.string(),
+});
+
+export const PublicPlayerProfileSchema = z
+  .object({
+    contact: PublicContactSummarySchema,
+    currentSeason: z
+      .object({
+        id: bigintToStringSchema,
+        name: z.string(),
+      })
+      .nullable(),
+    teams: PublicPlayerTeamAffiliationSchema.array(),
+    hasCareerStatistics: z.boolean(),
+  })
+  .openapi({
+    title: 'PublicPlayerProfile',
+    description:
+      'Public-safe player profile: identity, current-season team affiliations, and a flag indicating whether career statistics exist.',
+  });
+
 export const TeamWithNameSchema = z.object({
   teamSeasonId: z.string(),
   teamName: z.string(),
@@ -366,6 +393,8 @@ export type PagedContactType = z.infer<typeof PagedContactSchema>;
 export type PublicContactSummaryType = z.infer<typeof PublicContactSummarySchema>;
 export type PublicContactSearchResponseType = z.infer<typeof PublicContactSearchResponseSchema>;
 export type PublicContactSearchQueryType = z.infer<typeof PublicContactSearchQuerySchema>;
+export type PublicPlayerTeamAffiliationType = z.infer<typeof PublicPlayerTeamAffiliationSchema>;
+export type PublicPlayerProfileType = z.infer<typeof PublicPlayerProfileSchema>;
 export type TeamWithNameType = z.infer<typeof TeamWithNameSchema>;
 export type TeamManagerWithTeamsType = z.infer<typeof TeamManagerWithTeamsSchema>;
 export type AutomaticRoleHoldersType = z.infer<typeof AutomaticRoleHoldersSchema>;


### PR DESCRIPTION
## Summary
- Adds a global player search to the menu bar (expandable icon → debounced autocomplete) that navigates to a new public player profile page at `/account/[accountId]/players/[playerId]`.
- Public profile page shows the player's identity, current-season team affiliations, and a "View Career Statistics" link (only when stats exist).
- Adds a "View Career Statistics" link to the existing self `/profile` page.
- New public endpoint `GET /api/accounts/:accountId/players/:contactId/public-profile` shaped for both UI consumption and a future MCP tool.

## Maintainer-Approved Schema Changes
This PR edits `draco-nodejs/shared/shared-schemas/contact.ts`, which is a restricted directory. **Maintainer approval was given during the planning conversation** for adding:
- `PublicPlayerTeamAffiliationSchema`
- `PublicPlayerProfileSchema` (includes `contact`, `currentSeason`, `teams[]`, `hasCareerStatistics`)

No new permissions were introduced; no role-metadata version bump required.

## Test plan
- [ ] On any `/account/[accountId]/...` page, click the search icon, type a partial name — autocomplete shows matches.
- [ ] Selecting a result navigates to the public profile and shows photo/name and current-season teams.
- [ ] Player with stats: "View Career Statistics" button is shown and links to the existing stats page.
- [ ] Player without stats: button is hidden.
- [ ] Self `/profile` page shows the new "View Career Statistics" link.
- [ ] `pnpm lint`, `pnpm backend:type-check`, `pnpm frontend:type-check` clean.
- [ ] `pnpm backend:test` and `pnpm --filter @draco/frontend-next test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)