### PR TITLE
Add team roster waiver summaries & UI

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -2780,6 +2780,486 @@
           "rosterMembers"
         ]
       },
+      "RosterMemberSeasonTeamWaiver": {
+        "type": "object",
+        "properties": {
+          "teamSeasonId": {
+            "type": "string",
+            "pattern": "^d+$"
+          },
+          "teamId": {
+            "type": "string",
+            "pattern": "^d+$"
+          },
+          "teamName": {
+            "type": "string"
+          },
+          "leagueSeasonId": {
+            "type": "string",
+            "pattern": "^d+$"
+          },
+          "leagueName": {
+            "type": "string"
+          },
+          "submittedWaiver": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "teamSeasonId",
+          "teamId",
+          "teamName",
+          "leagueSeasonId",
+          "leagueName",
+          "submittedWaiver"
+        ],
+        "description": "Per-team waiver status for one of a player’s season teams. Admin-only data."
+      },
+      "RosterMemberWaiverSummary": {
+        "type": "object",
+        "properties": {
+          "rosterMember": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^d+$"
+              },
+              "playerNumber": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 99
+              },
+              "inactive": {
+                "type": "boolean",
+                "default": false
+              },
+              "submittedWaiver": {
+                "type": "boolean"
+              },
+              "dateAdded": {
+                "type": "string",
+                "nullable": true,
+                "format": "date-time",
+                "default": null
+              },
+              "gamesPlayed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "player": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^d+$"
+                  },
+                  "submittedDriversLicense": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "firstYear": {
+                    "type": "number",
+                    "minimum": 1900,
+                    "maximum": 2026
+                  },
+                  "contact": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "^\\d+$",
+                        "example": "12345"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                      },
+                      "middleName": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "email": {
+                        "type": "string",
+                        "maxLength": 100,
+                        "format": "email"
+                      },
+                      "userId": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "loginEmail": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "format": "email"
+                      },
+                      "photoUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "contactDetails": {
+                        "type": "object",
+                        "properties": {
+                          "phone1": {
+                            "type": "string",
+                            "nullable": true,
+                            "default": ""
+                          },
+                          "phone2": {
+                            "type": "string",
+                            "nullable": true,
+                            "default": ""
+                          },
+                          "phone3": {
+                            "type": "string",
+                            "nullable": true,
+                            "default": ""
+                          },
+                          "streetAddress": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 100,
+                            "default": ""
+                          },
+                          "city": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 50,
+                            "default": ""
+                          },
+                          "state": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 50,
+                            "default": ""
+                          },
+                          "zip": {
+                            "type": "string",
+                            "nullable": true,
+                            "maxLength": 10,
+                            "default": ""
+                          },
+                          "dateOfBirth": {
+                            "type": "string",
+                            "nullable": true,
+                            "default": ""
+                          },
+                          "firstYear": {
+                            "type": "number",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "firstName",
+                      "lastName"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "firstYear",
+                  "contact"
+                ],
+                "description": "Schema for a player who is or was on a team roster. This contains details that only ever need to be supplied once"
+              }
+            },
+            "required": [
+              "id",
+              "player"
+            ],
+            "description": "Schema for a roster member including player details"
+          },
+          "seasonTeams": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "teamSeasonId": {
+                  "type": "string",
+                  "pattern": "^d+$"
+                },
+                "teamId": {
+                  "type": "string",
+                  "pattern": "^d+$"
+                },
+                "teamName": {
+                  "type": "string"
+                },
+                "leagueSeasonId": {
+                  "type": "string",
+                  "pattern": "^d+$"
+                },
+                "leagueName": {
+                  "type": "string"
+                },
+                "submittedWaiver": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "teamSeasonId",
+                "teamId",
+                "teamName",
+                "leagueSeasonId",
+                "leagueName",
+                "submittedWaiver"
+              ],
+              "description": "Per-team waiver status for one of a player’s season teams. Admin-only data."
+            }
+          }
+        },
+        "required": [
+          "rosterMember",
+          "seasonTeams"
+        ],
+        "description": "Roster member augmented with the set of teams in the current season where the player has a roster row, including the submittedWaiver flag for each. Admin-only."
+      },
+      "TeamRosterWaiverSummaries": {
+        "type": "object",
+        "properties": {
+          "teamSeason": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^d+$"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "rosterMember": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^d+$"
+                    },
+                    "playerNumber": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 99
+                    },
+                    "inactive": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "submittedWaiver": {
+                      "type": "boolean"
+                    },
+                    "dateAdded": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time",
+                      "default": null
+                    },
+                    "gamesPlayed": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "player": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^d+$"
+                        },
+                        "submittedDriversLicense": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "firstYear": {
+                          "type": "number",
+                          "minimum": 1900,
+                          "maximum": 2026
+                        },
+                        "contact": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "pattern": "^\\d+$",
+                              "example": "12345"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 100
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 100
+                            },
+                            "middleName": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "email": {
+                              "type": "string",
+                              "maxLength": 100,
+                              "format": "email"
+                            },
+                            "userId": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "loginEmail": {
+                              "type": "string",
+                              "maxLength": 256,
+                              "format": "email"
+                            },
+                            "photoUrl": {
+                              "type": "string",
+                              "format": "uri"
+                            },
+                            "contactDetails": {
+                              "type": "object",
+                              "properties": {
+                                "phone1": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "default": ""
+                                },
+                                "phone2": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "default": ""
+                                },
+                                "phone3": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "default": ""
+                                },
+                                "streetAddress": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 100,
+                                  "default": ""
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 50,
+                                  "default": ""
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 50,
+                                  "default": ""
+                                },
+                                "zip": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 10,
+                                  "default": ""
+                                },
+                                "dateOfBirth": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "default": ""
+                                },
+                                "firstYear": {
+                                  "type": "number",
+                                  "nullable": true
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "firstName",
+                            "lastName"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "firstYear",
+                        "contact"
+                      ],
+                      "description": "Schema for a player who is or was on a team roster. This contains details that only ever need to be supplied once"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "player"
+                  ],
+                  "description": "Schema for a roster member including player details"
+                },
+                "seasonTeams": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "teamSeasonId": {
+                        "type": "string",
+                        "pattern": "^d+$"
+                      },
+                      "teamId": {
+                        "type": "string",
+                        "pattern": "^d+$"
+                      },
+                      "teamName": {
+                        "type": "string"
+                      },
+                      "leagueSeasonId": {
+                        "type": "string",
+                        "pattern": "^d+$"
+                      },
+                      "leagueName": {
+                        "type": "string"
+                      },
+                      "submittedWaiver": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "teamSeasonId",
+                      "teamId",
+                      "teamName",
+                      "leagueSeasonId",
+                      "leagueName",
+                      "submittedWaiver"
+                    ],
+                    "description": "Per-team waiver status for one of a player’s season teams. Admin-only data."
+                  }
+                }
+              },
+              "required": [
+                "rosterMember",
+                "seasonTeams"
+              ],
+              "description": "Roster member augmented with the set of teams in the current season where the player has a roster row, including the submittedWaiver flag for each. Admin-only."
+            }
+          }
+        },
+        "required": [
+          "teamSeason",
+          "members"
+        ],
+        "description": "Admin view of a team roster including cross-team waiver status per player for the current season."
+      },
       "PublicRosterMember": {
         "type": "object",
         "properties": {
@@ -65677,6 +66157,102 @@
           },
           "404": {
             "description": "Contact not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers": {
+      "get": {
+        "description": "Get roster members for a team season augmented with per-team waiver status for every team the player is on in the current season. Admin only.",
+        "summary": "Get team roster waiver summaries",
+        "operationId": "getTeamRosterWaiverSummaries",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Rosters"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Roster members with waiver summaries returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamRosterWaiverSummaries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied - Account admin required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team season not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -2079,6 +2079,378 @@ components:
       required:
         - teamSeason
         - rosterMembers
+    RosterMemberSeasonTeamWaiver:
+      type: object
+      properties:
+        teamSeasonId:
+          type: string
+          pattern: ^d+$
+        teamId:
+          type: string
+          pattern: ^d+$
+        teamName:
+          type: string
+        leagueSeasonId:
+          type: string
+          pattern: ^d+$
+        leagueName:
+          type: string
+        submittedWaiver:
+          type: boolean
+      required:
+        - teamSeasonId
+        - teamId
+        - teamName
+        - leagueSeasonId
+        - leagueName
+        - submittedWaiver
+      description: Per-team waiver status for one of a player’s season teams.
+        Admin-only data.
+    RosterMemberWaiverSummary:
+      type: object
+      properties:
+        rosterMember:
+          type: object
+          properties:
+            id:
+              type: string
+              pattern: ^d+$
+            playerNumber:
+              type: number
+              minimum: 0
+              maximum: 99
+            inactive:
+              type: boolean
+              default: false
+            submittedWaiver:
+              type: boolean
+            dateAdded:
+              type: string
+              nullable: true
+              format: date-time
+              default: null
+            gamesPlayed:
+              type: integer
+              minimum: 0
+            player:
+              type: object
+              properties:
+                id:
+                  type: string
+                  pattern: ^d+$
+                submittedDriversLicense:
+                  type: boolean
+                  default: false
+                firstYear:
+                  type: number
+                  minimum: 1900
+                  maximum: 2026
+                contact:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      pattern: ^\d+$
+                      example: "12345"
+                    firstName:
+                      type: string
+                      minLength: 1
+                      maxLength: 100
+                    lastName:
+                      type: string
+                      minLength: 1
+                      maxLength: 100
+                    middleName:
+                      type: string
+                      maxLength: 50
+                    email:
+                      type: string
+                      maxLength: 100
+                      format: email
+                    userId:
+                      type: string
+                      maxLength: 50
+                    loginEmail:
+                      type: string
+                      maxLength: 256
+                      format: email
+                    photoUrl:
+                      type: string
+                      format: uri
+                    contactDetails:
+                      type: object
+                      properties:
+                        phone1:
+                          type: string
+                          nullable: true
+                          default: ""
+                        phone2:
+                          type: string
+                          nullable: true
+                          default: ""
+                        phone3:
+                          type: string
+                          nullable: true
+                          default: ""
+                        streetAddress:
+                          type: string
+                          nullable: true
+                          maxLength: 100
+                          default: ""
+                        city:
+                          type: string
+                          nullable: true
+                          maxLength: 50
+                          default: ""
+                        state:
+                          type: string
+                          nullable: true
+                          maxLength: 50
+                          default: ""
+                        zip:
+                          type: string
+                          nullable: true
+                          maxLength: 10
+                          default: ""
+                        dateOfBirth:
+                          type: string
+                          nullable: true
+                          default: ""
+                        firstYear:
+                          type: number
+                          nullable: true
+                  required:
+                    - id
+                    - firstName
+                    - lastName
+              required:
+                - id
+                - firstYear
+                - contact
+              description: Schema for a player who is or was on a team roster. This contains
+                details that only ever need to be supplied once
+          required:
+            - id
+            - player
+          description: Schema for a roster member including player details
+        seasonTeams:
+          type: array
+          items:
+            type: object
+            properties:
+              teamSeasonId:
+                type: string
+                pattern: ^d+$
+              teamId:
+                type: string
+                pattern: ^d+$
+              teamName:
+                type: string
+              leagueSeasonId:
+                type: string
+                pattern: ^d+$
+              leagueName:
+                type: string
+              submittedWaiver:
+                type: boolean
+            required:
+              - teamSeasonId
+              - teamId
+              - teamName
+              - leagueSeasonId
+              - leagueName
+              - submittedWaiver
+            description: Per-team waiver status for one of a player’s season teams.
+              Admin-only data.
+      required:
+        - rosterMember
+        - seasonTeams
+      description: Roster member augmented with the set of teams in the current season
+        where the player has a roster row, including the submittedWaiver flag
+        for each. Admin-only.
+    TeamRosterWaiverSummaries:
+      type: object
+      properties:
+        teamSeason:
+          type: object
+          properties:
+            id:
+              type: string
+              pattern: ^d+$
+            name:
+              type: string
+          required:
+            - id
+            - name
+        members:
+          type: array
+          items:
+            type: object
+            properties:
+              rosterMember:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    pattern: ^d+$
+                  playerNumber:
+                    type: number
+                    minimum: 0
+                    maximum: 99
+                  inactive:
+                    type: boolean
+                    default: false
+                  submittedWaiver:
+                    type: boolean
+                  dateAdded:
+                    type: string
+                    nullable: true
+                    format: date-time
+                    default: null
+                  gamesPlayed:
+                    type: integer
+                    minimum: 0
+                  player:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        pattern: ^d+$
+                      submittedDriversLicense:
+                        type: boolean
+                        default: false
+                      firstYear:
+                        type: number
+                        minimum: 1900
+                        maximum: 2026
+                      contact:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            pattern: ^\d+$
+                            example: "12345"
+                          firstName:
+                            type: string
+                            minLength: 1
+                            maxLength: 100
+                          lastName:
+                            type: string
+                            minLength: 1
+                            maxLength: 100
+                          middleName:
+                            type: string
+                            maxLength: 50
+                          email:
+                            type: string
+                            maxLength: 100
+                            format: email
+                          userId:
+                            type: string
+                            maxLength: 50
+                          loginEmail:
+                            type: string
+                            maxLength: 256
+                            format: email
+                          photoUrl:
+                            type: string
+                            format: uri
+                          contactDetails:
+                            type: object
+                            properties:
+                              phone1:
+                                type: string
+                                nullable: true
+                                default: ""
+                              phone2:
+                                type: string
+                                nullable: true
+                                default: ""
+                              phone3:
+                                type: string
+                                nullable: true
+                                default: ""
+                              streetAddress:
+                                type: string
+                                nullable: true
+                                maxLength: 100
+                                default: ""
+                              city:
+                                type: string
+                                nullable: true
+                                maxLength: 50
+                                default: ""
+                              state:
+                                type: string
+                                nullable: true
+                                maxLength: 50
+                                default: ""
+                              zip:
+                                type: string
+                                nullable: true
+                                maxLength: 10
+                                default: ""
+                              dateOfBirth:
+                                type: string
+                                nullable: true
+                                default: ""
+                              firstYear:
+                                type: number
+                                nullable: true
+                        required:
+                          - id
+                          - firstName
+                          - lastName
+                    required:
+                      - id
+                      - firstYear
+                      - contact
+                    description: Schema for a player who is or was on a team roster. This contains
+                      details that only ever need to be supplied once
+                required:
+                  - id
+                  - player
+                description: Schema for a roster member including player details
+              seasonTeams:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    teamSeasonId:
+                      type: string
+                      pattern: ^d+$
+                    teamId:
+                      type: string
+                      pattern: ^d+$
+                    teamName:
+                      type: string
+                    leagueSeasonId:
+                      type: string
+                      pattern: ^d+$
+                    leagueName:
+                      type: string
+                    submittedWaiver:
+                      type: boolean
+                  required:
+                    - teamSeasonId
+                    - teamId
+                    - teamName
+                    - leagueSeasonId
+                    - leagueName
+                    - submittedWaiver
+                  description: Per-team waiver status for one of a player’s season teams.
+                    Admin-only data.
+            required:
+              - rosterMember
+              - seasonTeams
+            description: Roster member augmented with the set of teams in the current season
+              where the player has a roster row, including the submittedWaiver
+              flag for each. Admin-only.
+      required:
+        - teamSeason
+        - members
+      description: Admin view of a team roster including cross-team waiver status per
+        player for the current season.
     PublicRosterMember:
       type: object
       properties:
@@ -44739,6 +45111,67 @@ paths:
                 $ref: "#/components/schemas/AuthorizationError"
         "404":
           description: Contact not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers:
+    get:
+      description: Get roster members for a team season augmented with per-team waiver
+        status for every team the player is on in the current season. Admin
+        only.
+      summary: Get team roster waiver summaries
+      operationId: getTeamRosterWaiverSummaries
+      security:
+        - bearerAuth: []
+      tags:
+        - Rosters
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: teamSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: Roster members with waiver summaries returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamRosterWaiverSummaries"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied - Account admin required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Team season not found
           content:
             application/json:
               schema:

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -147,6 +147,9 @@ import {
   UpdateScheduleVisibilitySchema,
   TeamManagerSchema,
   TeamRosterMembersSchema,
+  RosterMemberSeasonTeamWaiverSchema,
+  RosterMemberWaiverSummarySchema,
+  TeamRosterWaiverSummariesSchema,
   TeamSeasonSchema,
   TeamsWantedAccessCodeSchema,
   TeamsWantedContactInfoSchema,
@@ -483,6 +486,18 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
   const TeamRosterMembersSchemaRef = registry.register(
     'TeamRosterMembers',
     TeamRosterMembersSchema,
+  );
+  const RosterMemberSeasonTeamWaiverSchemaRef = registry.register(
+    'RosterMemberSeasonTeamWaiver',
+    RosterMemberSeasonTeamWaiverSchema,
+  );
+  const RosterMemberWaiverSummarySchemaRef = registry.register(
+    'RosterMemberWaiverSummary',
+    RosterMemberWaiverSummarySchema,
+  );
+  const TeamRosterWaiverSummariesSchemaRef = registry.register(
+    'TeamRosterWaiverSummaries',
+    TeamRosterWaiverSummariesSchema,
   );
   const PublicRosterMemberSchemaRef = registry.register(
     'PublicRosterMember',
@@ -1655,6 +1670,9 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     SeasonParticipantCountDataSchemaRef,
     TeamManagerSchemaRef,
     TeamRosterMembersSchemaRef,
+    RosterMemberSeasonTeamWaiverSchemaRef,
+    RosterMemberWaiverSummarySchemaRef,
+    TeamRosterWaiverSummariesSchemaRef,
     PublicRosterMemberSchemaRef,
     PublicTeamRosterResponseSchemaRef,
     RosterCardPlayerSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
@@ -12,6 +12,7 @@ export const registerRostersEndpoints = ({ registry, schemaRefs, z }: RegisterCo
     SignRosterMemberSchemaRef,
     UpdateRosterMemberSchemaRef,
     TeamRosterMembersSchemaRef,
+    TeamRosterWaiverSummariesSchemaRef,
     PublicTeamRosterResponseSchemaRef,
     TeamRosterCardSchemaRef,
   } = schemaRefs;
@@ -60,6 +61,89 @@ export const registerRostersEndpoints = ({ registry, schemaRefs, z }: RegisterCo
         content: {
           'application/json': {
             schema: TeamRosterMembersSchemaRef,
+          },
+        },
+      },
+      401: {
+        description: 'Authentication required',
+        content: {
+          'application/json': {
+            schema: AuthenticationErrorSchemaRef,
+          },
+        },
+      },
+      403: {
+        description: 'Access denied - Account admin required',
+        content: {
+          'application/json': {
+            schema: AuthorizationErrorSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Team season not found',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
+          },
+        },
+      },
+      500: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
+
+  // GET /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers',
+    description:
+      'Get roster members for a team season augmented with per-team waiver status for every team the player is on in the current season. Admin only.',
+    summary: 'Get team roster waiver summaries',
+    operationId: 'getTeamRosterWaiverSummaries',
+    security: [{ bearerAuth: [] }],
+    tags: ['Rosters'],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'teamSeasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'Roster members with waiver summaries returned successfully.',
+        content: {
+          'application/json': {
+            schema: TeamRosterWaiverSummariesSchemaRef,
           },
         },
       },

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaContactRepository.ts
@@ -12,6 +12,7 @@ import {
   dbBirthdayContact,
   dbContactExportData,
   dbPlayerCurrentSeasonTeam,
+  dbContactSeasonTeamWaiver,
 } from '../types/dbTypes.js';
 import { RoleNamesType } from '../../types/roles.js';
 import { ROLE_IDS } from '../../config/roles.js';
@@ -825,6 +826,60 @@ export class PrismaContactRepository implements IContactRepository {
       leagueSeasonId: row.teamsseason.leagueseason.id,
       leagueName: row.teamsseason.leagueseason.league.name,
       teamName: row.teamsseason.name,
+    }));
+  }
+
+  async findSeasonTeamWaiversForContacts(
+    accountId: bigint,
+    seasonId: bigint,
+    contactIds: bigint[],
+  ): Promise<dbContactSeasonTeamWaiver[]> {
+    if (contactIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.prisma.rosterseason.findMany({
+      where: {
+        inactive: false,
+        roster: {
+          contactid: { in: contactIds },
+          contacts: { creatoraccountid: accountId },
+        },
+        teamsseason: {
+          leagueseason: {
+            seasonid: seasonId,
+            league: { accountid: accountId },
+          },
+        },
+      },
+      select: {
+        submittedwaiver: true,
+        roster: { select: { contactid: true } },
+        teamsseason: {
+          select: {
+            id: true,
+            teamid: true,
+            name: true,
+            leagueseason: {
+              select: {
+                id: true,
+                league: { select: { name: true } },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { teamsseason: { name: 'asc' } },
+    });
+
+    return rows.map((row) => ({
+      contactId: row.roster.contactid,
+      teamSeasonId: row.teamsseason.id,
+      teamId: row.teamsseason.teamid,
+      leagueSeasonId: row.teamsseason.leagueseason.id,
+      leagueName: row.teamsseason.leagueseason.league.name,
+      teamName: row.teamsseason.name,
+      submittedWaiver: row.submittedwaiver,
     }));
   }
 

--- a/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IContactRepository.ts
@@ -8,6 +8,7 @@ import {
   dbBirthdayContact,
   dbContactExportData,
   dbPlayerCurrentSeasonTeam,
+  dbContactSeasonTeamWaiver,
 } from '../types/dbTypes.js';
 import { ContactQueryOptions, AdvancedFilterOptions } from '../../interfaces/contactInterfaces.js';
 
@@ -64,5 +65,10 @@ export interface IContactRepository extends IBaseRepository<contacts> {
     contactId: bigint,
     seasonId: bigint,
   ): Promise<dbPlayerCurrentSeasonTeam[]>;
+  findSeasonTeamWaiversForContacts(
+    accountId: bigint,
+    seasonId: bigint,
+    contactIds: bigint[],
+  ): Promise<dbContactSeasonTeamWaiver[]>;
   hasCareerStatistics(accountId: bigint, contactId: bigint): Promise<boolean>;
 }

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -39,6 +39,16 @@ export interface dbPlayerCurrentSeasonTeam {
   teamName: string;
 }
 
+export interface dbContactSeasonTeamWaiver {
+  contactId: bigint;
+  teamSeasonId: bigint;
+  teamId: bigint;
+  leagueSeasonId: bigint;
+  leagueName: string;
+  teamName: string;
+  submittedWaiver: boolean;
+}
+
 export type dbWelcomeMessage = Prisma.accountwelcomeGetPayload<{
   select: {
     id: true;

--- a/draco-nodejs/backend/src/responseFormatters/RosterResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/RosterResponseFormatter.ts
@@ -5,11 +5,14 @@ import {
   PublicTeamRosterResponseType,
   RosterCardPlayerType,
   RosterMemberType,
+  RosterMemberWaiverSummaryType,
   TeamRosterCardType,
   TeamRosterMembersType,
+  TeamRosterWaiverSummariesType,
 } from '@draco/shared-schemas';
 import {
   dbBaseContact,
+  dbContactSeasonTeamWaiver,
   dbRosterMember,
   dbRosterSeason,
   dbTeamSeason,
@@ -93,6 +96,49 @@ export class RosterResponseFormatter {
         name: dbTeamSeason.name,
       },
       rosterMembers,
+    };
+  }
+
+  static formatTeamRosterWaiverSummariesResponse(
+    dbTeamSeason: dbTeamSeason,
+    dbRosterMembers: dbRosterMember[],
+    waiverRows: dbContactSeasonTeamWaiver[],
+    gamesPlayedMap?: Map<string, number>,
+  ): TeamRosterWaiverSummariesType {
+    const waiverByContact = new Map<string, dbContactSeasonTeamWaiver[]>();
+    for (const row of waiverRows) {
+      const key = row.contactId.toString();
+      const list = waiverByContact.get(key);
+      if (list) {
+        list.push(row);
+      } else {
+        waiverByContact.set(key, [row]);
+      }
+    }
+
+    const members: RosterMemberWaiverSummaryType[] = dbRosterMembers.map((member) => {
+      const rosterMember = this.formatRosterMemberResponse(member, gamesPlayedMap);
+      const contactKey = member.roster.contacts.id.toString();
+      const teams = waiverByContact.get(contactKey) ?? [];
+      return {
+        rosterMember,
+        seasonTeams: teams.map((row) => ({
+          teamSeasonId: row.teamSeasonId.toString(),
+          teamId: row.teamId.toString(),
+          teamName: row.teamName,
+          leagueSeasonId: row.leagueSeasonId.toString(),
+          leagueName: row.leagueName,
+          submittedWaiver: row.submittedWaiver,
+        })),
+      };
+    });
+
+    return {
+      teamSeason: {
+        id: dbTeamSeason.id.toString(),
+        name: dbTeamSeason.name,
+      },
+      members,
     };
   }
 

--- a/draco-nodejs/backend/src/routes/team-roster.ts
+++ b/draco-nodejs/backend/src/routes/team-roster.ts
@@ -58,6 +58,33 @@ router.get(
 );
 
 /**
+ * GET /api/accounts/:accountId/seasons/:seasonId/teams/:teamSeasonId/roster/waivers
+ * Admin-only: roster members with per-team waiver status across the season
+ */
+router.get(
+  '/:teamSeasonId/roster/waivers',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requireAccountAdmin(),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId } = extractTeamParams(req.params);
+
+    const accountSettings = await accountSettingsService.getAccountSettings(accountId);
+    const trackGamesPlayed = isTrackGamesPlayedEnabled(accountSettings);
+
+    const summaries = await rosterService.getTeamRosterWaiverSummaries(
+      teamSeasonId,
+      seasonId,
+      accountId,
+      trackGamesPlayed,
+      true,
+    );
+
+    res.json(summaries);
+  }),
+);
+
+/**
  * GET /api/accounts/:accountId/seasons/:seasonId/teams/:teamSeasonId/roster-public
  * Get public-safe roster members (names, jersey numbers, photos only)
  */

--- a/draco-nodejs/backend/src/routes/team-roster.ts
+++ b/draco-nodejs/backend/src/routes/team-roster.ts
@@ -77,7 +77,7 @@ router.get(
       seasonId,
       accountId,
       trackGamesPlayed,
-      true,
+      false,
     );
 
     res.json(summaries);

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -73,6 +73,8 @@ class ContactRepositoryStub implements IContactRepository {
   findContactsForExport = vi.fn<IContactRepository['findContactsForExport']>();
   findCurrentSeasonTeamsForContact =
     vi.fn<IContactRepository['findCurrentSeasonTeamsForContact']>();
+  findSeasonTeamWaiversForContacts =
+    vi.fn<IContactRepository['findSeasonTeamWaiversForContacts']>();
   hasCareerStatistics = vi.fn<IContactRepository['hasCareerStatistics']>();
 }
 

--- a/draco-nodejs/backend/src/services/rosterService.ts
+++ b/draco-nodejs/backend/src/services/rosterService.ts
@@ -6,6 +6,7 @@ import {
   SignRosterMemberType,
   TeamRosterCardType,
   TeamRosterMembersType,
+  TeamRosterWaiverSummariesType,
   UpdateRosterMemberType,
 } from '@draco/shared-schemas';
 import { RosterResponseFormatter, ContactResponseFormatter } from '../responseFormatters/index.js';
@@ -69,6 +70,52 @@ export class RosterService {
     return RosterResponseFormatter.formatRosterMembersResponse(
       teamSeason,
       rosterMembers,
+      gamesPlayedMap,
+    );
+  }
+
+  async getTeamRosterWaiverSummaries(
+    teamSeasonId: bigint,
+    seasonId: bigint,
+    accountId: bigint,
+    includeGamesPlayed = false,
+    includeInactive = false,
+  ): Promise<TeamRosterWaiverSummariesType> {
+    const teamSeason: dbTeamSeason | null = await this.teamRepository.findTeamSeasonSummary(
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+
+    if (!teamSeason) {
+      throw new NotFoundError('Team season not found');
+    }
+
+    const rosterMembers = await this.rosterRepository.findRosterMembersByTeamSeason(
+      teamSeasonId,
+      includeInactive,
+    );
+
+    let gamesPlayedMap: Map<string, number> | undefined;
+    if (includeGamesPlayed) {
+      const gamesPlayedCounts =
+        await this.rosterRepository.countGamesPlayedByTeamSeason(teamSeasonId);
+      gamesPlayedMap = new Map(
+        gamesPlayedCounts.map((row) => [row.rosterSeasonId.toString(), row.gamesPlayed]),
+      );
+    }
+
+    const contactIds = rosterMembers.map((member) => member.roster.contacts.id);
+    const waiverRows = await this.contactRepository.findSeasonTeamWaiversForContacts(
+      accountId,
+      seasonId,
+      contactIds,
+    );
+
+    return RosterResponseFormatter.formatTeamRosterWaiverSummariesResponse(
+      teamSeason,
+      rosterMembers,
+      waiverRows,
       gamesPlayedMap,
     );
   }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
@@ -9,6 +9,7 @@ import StadiumIcon from '@mui/icons-material/Stadium';
 import SportsBaseballIcon from '@mui/icons-material/SportsBaseball';
 import FitnessCenterIcon from '@mui/icons-material/FitnessCenter';
 import ScheduleIcon from '@mui/icons-material/Schedule';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import AccountPageHeader from '../../../../../components/AccountPageHeader';
 import {
   AdminBreadcrumbs,
@@ -77,6 +78,13 @@ const BaseballSeasonAdminPage: React.FC = () => {
       href: `/account/${accountId}/workouts`,
       getMetrics: (data) =>
         data ? [{ value: data.season.upcomingWorkouts, label: 'upcoming' }] : [],
+    },
+    {
+      title: 'Player Waivers',
+      description: 'Track submitted player waivers across teams in the current season.',
+      icon: <AssignmentTurnedInIcon />,
+      href: `/account/${accountId}/waivers`,
+      getMetrics: () => [],
     },
   ];
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -229,46 +229,63 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
           <Alert severity="info">There is no current season configured for this account.</Alert>
         ) : (
           <Stack spacing={3}>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-              <FormControl size="small" sx={{ minWidth: 220 }} disabled={leaguesLoading}>
-                <Select
-                  value={selectedLeagueSeasonId}
-                  onChange={(e) => setSelectedLeagueSeasonId(e.target.value)}
-                  displayEmpty
-                  inputProps={{ 'aria-label': 'League' }}
-                >
-                  <MenuItem value="">
-                    <em>Select a league</em>
-                  </MenuItem>
-                  {leagues.map((league) => (
-                    <MenuItem key={league.leagueSeasonId} value={league.leagueSeasonId}>
-                      {league.leagueName}
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={2}
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography component="label" htmlFor="waivers-league-select">
+                  League:
+                </Typography>
+                <FormControl size="small" sx={{ minWidth: 220 }} disabled={leaguesLoading}>
+                  <Select
+                    id="waivers-league-select"
+                    value={selectedLeagueSeasonId}
+                    onChange={(e) => setSelectedLeagueSeasonId(e.target.value)}
+                    displayEmpty
+                    inputProps={{ 'aria-label': 'League' }}
+                  >
+                    <MenuItem value="">
+                      <em>Select a league</em>
                     </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+                    {leagues.map((league) => (
+                      <MenuItem key={league.leagueSeasonId} value={league.leagueSeasonId}>
+                        {league.leagueName}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
 
-              <FormControl
-                size="small"
-                sx={{ minWidth: 220 }}
-                disabled={!selectedLeagueSeasonId || leaguesLoading}
-              >
-                <Select
-                  value={selectedTeamSeasonId}
-                  onChange={(e) => setSelectedTeamSeasonId(e.target.value)}
-                  displayEmpty
-                  inputProps={{ 'aria-label': 'Team' }}
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography component="label" htmlFor="waivers-team-select">
+                  Team:
+                </Typography>
+                <FormControl
+                  size="small"
+                  sx={{ minWidth: 220 }}
+                  disabled={!selectedLeagueSeasonId || leaguesLoading}
                 >
-                  <MenuItem value="">
-                    <em>Select a team</em>
-                  </MenuItem>
-                  {teamsForSelectedLeague.map((team) => (
-                    <MenuItem key={team.teamSeasonId} value={team.teamSeasonId}>
-                      {team.teamName}
+                  <Select
+                    id="waivers-team-select"
+                    value={selectedTeamSeasonId}
+                    onChange={(e) => setSelectedTeamSeasonId(e.target.value)}
+                    displayEmpty
+                    inputProps={{ 'aria-label': 'Team' }}
+                  >
+                    <MenuItem value="">
+                      <em>Select a team</em>
                     </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+                    {teamsForSelectedLeague.map((team) => (
+                      <MenuItem key={team.teamSeasonId} value={team.teamSeasonId}>
+                        {team.teamName}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
             </Stack>
 
             {selectedTeamSeasonId && (

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Container,
+  FormControl,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import {
+  getTeamRosterWaiverSummaries,
+  updateRosterMember,
+  type TeamRosterWaiverSummaries,
+} from '@draco/shared-api-client';
+import AccountPageHeader from '../../../../components/AccountPageHeader';
+import { useApiClient } from '../../../../hooks/useApiClient';
+import { useCurrentSeason } from '../../../../hooks/useCurrentSeason';
+import { unwrapApiResult } from '../../../../utils/apiResult';
+import { useSeasonLeaguesAndTeams } from './useSeasonLeaguesAndTeams';
+
+interface WaiversClientProps {
+  accountId: string;
+}
+
+type WaiverMember = TeamRosterWaiverSummaries['members'][number];
+
+export default function WaiversClient({ accountId }: WaiversClientProps) {
+  const apiClient = useApiClient();
+  const {
+    currentSeasonId,
+    currentSeasonName,
+    loading: seasonLoading,
+    error: seasonError,
+    fetchCurrentSeason,
+  } = useCurrentSeason(accountId);
+
+  useEffect(() => {
+    if (accountId) {
+      void fetchCurrentSeason().catch(() => undefined);
+    }
+  }, [accountId, fetchCurrentSeason]);
+
+  const {
+    leagues,
+    teamsByLeague,
+    loading: leaguesLoading,
+    error: leaguesError,
+  } = useSeasonLeaguesAndTeams(accountId, currentSeasonId);
+
+  const [selectedLeagueSeasonId, setSelectedLeagueSeasonId] = useState<string>('');
+  const [selectedTeamSeasonId, setSelectedTeamSeasonId] = useState<string>('');
+  const [members, setMembers] = useState<WaiverMember[]>([]);
+  const [rosterLoading, setRosterLoading] = useState(false);
+  const [rosterError, setRosterError] = useState<string | null>(null);
+  const [updatingMemberIds, setUpdatingMemberIds] = useState<Set<string>>(() => new Set());
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedTeamSeasonId('');
+    setMembers([]);
+    setRosterError(null);
+  }, [selectedLeagueSeasonId, currentSeasonId]);
+
+  useEffect(() => {
+    if (!currentSeasonId || !selectedTeamSeasonId) {
+      setMembers([]);
+      setRosterError(null);
+      setRosterLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      setRosterLoading(true);
+      setRosterError(null);
+      try {
+        const result = await getTeamRosterWaiverSummaries({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: currentSeasonId,
+            teamSeasonId: selectedTeamSeasonId,
+          },
+          signal: controller.signal,
+          throwOnError: false,
+        });
+
+        if (controller.signal.aborted) return;
+        const data = unwrapApiResult(result, 'Failed to load roster');
+        setMembers(data.members);
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return;
+        setRosterError(err instanceof Error ? err.message : 'Failed to load roster');
+        setMembers([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setRosterLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, currentSeasonId, selectedTeamSeasonId, apiClient]);
+
+  const handleToggleWaiver = async (member: WaiverMember) => {
+    if (!currentSeasonId || !selectedTeamSeasonId) return;
+    const rosterMemberId = member.rosterMember.id;
+    const nextValue = !member.rosterMember.submittedWaiver;
+
+    setUpdatingMemberIds((prev) => {
+      const next = new Set(prev);
+      next.add(rosterMemberId);
+      return next;
+    });
+    setUpdateError(null);
+
+    try {
+      const result = await updateRosterMember({
+        client: apiClient,
+        path: {
+          accountId,
+          seasonId: currentSeasonId,
+          teamSeasonId: selectedTeamSeasonId,
+          rosterMemberId,
+        },
+        body: { submittedWaiver: nextValue },
+        throwOnError: false,
+      });
+
+      const updated = unwrapApiResult(result, 'Failed to update waiver status');
+
+      setMembers((prev) =>
+        prev.map((m) => {
+          if (m.rosterMember.id !== rosterMemberId) return m;
+          const newWaiver = updated.submittedWaiver ?? nextValue;
+          const updatedSeasonTeams = m.seasonTeams.map((team) =>
+            team.teamSeasonId === selectedTeamSeasonId
+              ? { ...team, submittedWaiver: newWaiver }
+              : team,
+          );
+          return {
+            ...m,
+            rosterMember: { ...m.rosterMember, ...updated },
+            seasonTeams: updatedSeasonTeams,
+          };
+        }),
+      );
+    } catch (err: unknown) {
+      setUpdateError(err instanceof Error ? err.message : 'Failed to update waiver status');
+    } finally {
+      setUpdatingMemberIds((prev) => {
+        const next = new Set(prev);
+        next.delete(rosterMemberId);
+        return next;
+      });
+    }
+  };
+
+  const teamsForSelectedLeague = selectedLeagueSeasonId
+    ? (teamsByLeague.get(selectedLeagueSeasonId) ?? [])
+    : [];
+
+  const sortedMembers = [...members].sort((a, b) => {
+    const lastA = a.rosterMember.player.contact.lastName ?? '';
+    const lastB = b.rosterMember.player.contact.lastName ?? '';
+    const lastCompare = lastA.localeCompare(lastB);
+    if (lastCompare !== 0) return lastCompare;
+    const firstA = a.rosterMember.player.contact.firstName ?? '';
+    const firstB = b.rosterMember.player.contact.firstName ?? '';
+    return firstA.localeCompare(firstB);
+  });
+
+  return (
+    <main className="min-h-screen bg-background">
+      <AccountPageHeader accountId={accountId}>
+        <Box sx={{ textAlign: 'center' }}>
+          <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
+            Player Waivers
+          </Typography>
+          <Typography variant="body1" sx={{ mt: 1, color: 'text.secondary' }}>
+            {currentSeasonName
+              ? `Manage submitted waiver status for ${currentSeasonName}`
+              : 'Manage submitted waiver status for the current season'}
+          </Typography>
+        </Box>
+      </AccountPageHeader>
+
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {seasonError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {seasonError}
+          </Alert>
+        )}
+        {leaguesError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {leaguesError}
+          </Alert>
+        )}
+        {updateError && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setUpdateError(null)}>
+            {updateError}
+          </Alert>
+        )}
+
+        {seasonLoading && !currentSeasonId ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        ) : !currentSeasonId ? (
+          <Alert severity="info">There is no current season configured for this account.</Alert>
+        ) : (
+          <Stack spacing={3}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <FormControl size="small" sx={{ minWidth: 220 }} disabled={leaguesLoading}>
+                <Select
+                  value={selectedLeagueSeasonId}
+                  onChange={(e) => setSelectedLeagueSeasonId(e.target.value)}
+                  displayEmpty
+                  inputProps={{ 'aria-label': 'League' }}
+                >
+                  <MenuItem value="">
+                    <em>Select a league</em>
+                  </MenuItem>
+                  {leagues.map((league) => (
+                    <MenuItem key={league.leagueSeasonId} value={league.leagueSeasonId}>
+                      {league.leagueName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl
+                size="small"
+                sx={{ minWidth: 220 }}
+                disabled={!selectedLeagueSeasonId || leaguesLoading}
+              >
+                <Select
+                  value={selectedTeamSeasonId}
+                  onChange={(e) => setSelectedTeamSeasonId(e.target.value)}
+                  displayEmpty
+                  inputProps={{ 'aria-label': 'Team' }}
+                >
+                  <MenuItem value="">
+                    <em>Select a team</em>
+                  </MenuItem>
+                  {teamsForSelectedLeague.map((team) => (
+                    <MenuItem key={team.teamSeasonId} value={team.teamSeasonId}>
+                      {team.teamName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+
+            {selectedTeamSeasonId && (
+              <Paper variant="outlined">
+                {rosterLoading ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                    <CircularProgress />
+                  </Box>
+                ) : rosterError ? (
+                  <Box sx={{ p: 3 }}>
+                    <Alert severity="error">{rosterError}</Alert>
+                  </Box>
+                ) : sortedMembers.length === 0 ? (
+                  <Box sx={{ p: 3 }}>
+                    <Typography color="text.secondary">No players on this team.</Typography>
+                  </Box>
+                ) : (
+                  <TableContainer>
+                    <Table>
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Player</TableCell>
+                          <TableCell sx={{ width: 200 }}>Waiver for This Team</TableCell>
+                          <TableCell>All Teams Waiver Submitted</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {sortedMembers.map((member) => {
+                          const rosterMemberId = member.rosterMember.id;
+                          const contact = member.rosterMember.player.contact;
+                          const fullName =
+                            `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() ||
+                            'Unknown';
+                          const teamsWithWaiver = member.seasonTeams.filter(
+                            (team) => team.submittedWaiver,
+                          );
+                          const isUpdating = updatingMemberIds.has(rosterMemberId);
+                          return (
+                            <TableRow key={rosterMemberId} hover>
+                              <TableCell>{fullName}</TableCell>
+                              <TableCell>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                  <Switch
+                                    checked={Boolean(member.rosterMember.submittedWaiver)}
+                                    onChange={() => handleToggleWaiver(member)}
+                                    disabled={isUpdating}
+                                    inputProps={{
+                                      'aria-label': `Toggle waiver for ${fullName}`,
+                                    }}
+                                  />
+                                  {isUpdating && <CircularProgress size={16} />}
+                                </Stack>
+                              </TableCell>
+                              <TableCell>
+                                {teamsWithWaiver.length === 0 ? (
+                                  <Typography variant="body2" color="text.secondary">
+                                    —
+                                  </Typography>
+                                ) : (
+                                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                                    {teamsWithWaiver.map((team) => (
+                                      <Chip
+                                        key={team.teamSeasonId}
+                                        size="small"
+                                        color={
+                                          team.teamSeasonId === selectedTeamSeasonId
+                                            ? 'primary'
+                                            : 'default'
+                                        }
+                                        variant={
+                                          team.teamSeasonId === selectedTeamSeasonId
+                                            ? 'filled'
+                                            : 'outlined'
+                                        }
+                                        label={`${team.leagueName} / ${team.teamName}`}
+                                      />
+                                    ))}
+                                  </Stack>
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                )}
+              </Paper>
+            )}
+          </Stack>
+        )}
+      </Container>
+    </main>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClientWrapper.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
+import WaiversClient from './WaiversClient';
+
+export default function WaiversClientWrapper() {
+  const params = useParams();
+  const accountId = Array.isArray(params?.accountId) ? params?.accountId[0] : params?.accountId;
+
+  if (!accountId) {
+    return <div>Invalid route parameters</div>;
+  }
+
+  return (
+    <ProtectedRoute requiredRole="AccountAdmin" checkAccountBoundary={true}>
+      <WaiversClient accountId={accountId} />
+    </ProtectedRoute>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/page.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/page.tsx
@@ -1,0 +1,24 @@
+import { getAccountBranding } from '../../../../lib/metadataFetchers';
+import { buildSeoMetadata } from '../../../../lib/seoMetadata';
+import { resolveRouteParams, type MetadataParams } from '../../../../lib/metadataParams';
+import WaiversClientWrapper from './WaiversClientWrapper';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: MetadataParams<{ accountId: string }>;
+}) {
+  const { accountId } = await resolveRouteParams(params);
+  const { name, iconUrl } = await getAccountBranding(accountId);
+  return buildSeoMetadata({
+    title: `${name} Player Waivers`,
+    description: `Manage submitted waiver status for players across teams in the current season for ${name}.`,
+    path: `/account/${accountId}/waivers`,
+    icon: iconUrl,
+    index: false,
+  });
+}
+
+export default function PlayerWaiversPage() {
+  return <WaiversClientWrapper />;
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/useSeasonLeaguesAndTeams.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/useSeasonLeaguesAndTeams.ts
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { listSeasonLeagueSeasons } from '@draco/shared-api-client';
+import { useApiClient } from '../../../../hooks/useApiClient';
+import { unwrapApiResult } from '../../../../utils/apiResult';
+
+export interface LeagueOption {
+  leagueSeasonId: string;
+  leagueName: string;
+}
+
+export interface TeamOption {
+  teamSeasonId: string;
+  teamName: string;
+  leagueSeasonId: string;
+}
+
+interface UseSeasonLeaguesAndTeamsResult {
+  leagues: LeagueOption[];
+  teamsByLeague: Map<string, TeamOption[]>;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useSeasonLeaguesAndTeams(
+  accountId: string,
+  seasonId: string | null,
+): UseSeasonLeaguesAndTeamsResult {
+  const apiClient = useApiClient();
+  const [leagues, setLeagues] = useState<LeagueOption[]>([]);
+  const [teamsByLeague, setTeamsByLeague] = useState<Map<string, TeamOption[]>>(() => new Map());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!accountId || !seasonId) {
+      setLeagues([]);
+      setTeamsByLeague(new Map());
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await listSeasonLeagueSeasons({
+          client: apiClient,
+          path: { accountId, seasonId },
+          query: { includeTeams: true },
+          signal: controller.signal,
+          throwOnError: false,
+        });
+
+        if (controller.signal.aborted) return;
+        const data = unwrapApiResult(result, 'Failed to load leagues');
+
+        const leagueOptions: LeagueOption[] = [];
+        const teamsMap = new Map<string, TeamOption[]>();
+
+        for (const leagueSeason of data.leagueSeasons ?? []) {
+          leagueOptions.push({
+            leagueSeasonId: leagueSeason.id,
+            leagueName: leagueSeason.league.name,
+          });
+          const teams: TeamOption[] = [];
+          for (const division of leagueSeason.divisions ?? []) {
+            for (const team of division.teams) {
+              teams.push({
+                teamSeasonId: team.id,
+                teamName: team.name ?? 'Unknown Team',
+                leagueSeasonId: leagueSeason.id,
+              });
+            }
+          }
+          for (const team of leagueSeason.unassignedTeams ?? []) {
+            teams.push({
+              teamSeasonId: team.id,
+              teamName: team.name ?? 'Unknown Team',
+              leagueSeasonId: leagueSeason.id,
+            });
+          }
+          teams.sort((a, b) => a.teamName.localeCompare(b.teamName));
+          teamsMap.set(leagueSeason.id, teams);
+        }
+
+        leagueOptions.sort((a, b) => a.leagueName.localeCompare(b.leagueName));
+
+        setLeagues(leagueOptions);
+        setTeamsByLeague(teamsMap);
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load leagues');
+        setLeagues([]);
+        setTeamsByLeague(new Map());
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, seasonId, apiClient]);
+
+  return { leagues, teamsByLeague, loading, error };
+}

--- a/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
+++ b/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
@@ -23,6 +23,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import GolfCourseIcon from '@mui/icons-material/GolfCourse';
 import SportsGolfIcon from '@mui/icons-material/SportsGolf';
 import PersonOffIcon from '@mui/icons-material/PersonOff';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 
 export interface AdminSearchItem {
   id: string;
@@ -166,6 +167,15 @@ export function getBaseballAdminItems(): AdminSearchItem[] {
       getHref: (accountId) => `/account/${accountId}/workouts`,
       category: 'Season',
       keywords: ['workouts', 'training', 'practice', 'fitness', 'sessions'],
+    },
+    {
+      id: 'player-waivers',
+      title: 'Player Waivers',
+      description: 'Track submitted player waivers across teams in the current season.',
+      icon: <AssignmentTurnedInIcon />,
+      getHref: (accountId) => `/account/${accountId}/waivers`,
+      category: 'Season',
+      keywords: ['waivers', 'waiver', 'player', 'roster', 'signed', 'consent'],
     },
     {
       id: 'announcements',

--- a/draco-nodejs/shared/shared-schemas/roster.ts
+++ b/draco-nodejs/shared/shared-schemas/roster.ts
@@ -49,6 +49,42 @@ export const TeamRosterMembersSchema = z.object({
   rosterMembers: RosterMemberSchema.array(),
 });
 
+export const RosterMemberSeasonTeamWaiverSchema = z
+  .object({
+    teamSeasonId: z.bigint().transform((val) => val.toString()),
+    teamId: z.bigint().transform((val) => val.toString()),
+    teamName: z.string().trim(),
+    leagueSeasonId: z.bigint().transform((val) => val.toString()),
+    leagueName: z.string().trim(),
+    submittedWaiver: z.boolean(),
+  })
+  .openapi({
+    description: 'Per-team waiver status for one of a player’s season teams. Admin-only data.',
+  });
+
+export const RosterMemberWaiverSummarySchema = z
+  .object({
+    rosterMember: RosterMemberSchema,
+    seasonTeams: RosterMemberSeasonTeamWaiverSchema.array(),
+  })
+  .openapi({
+    description:
+      'Roster member augmented with the set of teams in the current season where the player has a roster row, including the submittedWaiver flag for each. Admin-only.',
+  });
+
+export const TeamRosterWaiverSummariesSchema = z
+  .object({
+    teamSeason: z.object({
+      id: z.bigint().transform((val) => val.toString()),
+      name: z.string().trim(),
+    }),
+    members: RosterMemberWaiverSummarySchema.array(),
+  })
+  .openapi({
+    description:
+      'Admin view of a team roster including cross-team waiver status per player for the current season.',
+  });
+
 export const CreateRosterMemberSchema = RosterMemberSchema.omit({
   id: true,
   inactive: true,
@@ -144,6 +180,9 @@ export type CreateRosterMemberType = z.infer<typeof CreateRosterMemberSchema>;
 export type UpdateRosterMemberType = z.infer<typeof UpdateRosterMemberSchema>;
 export type SignRosterMemberType = z.infer<typeof SignRosterMemberSchema>;
 export type TeamRosterMembersType = z.infer<typeof TeamRosterMembersSchema>;
+export type RosterMemberSeasonTeamWaiverType = z.infer<typeof RosterMemberSeasonTeamWaiverSchema>;
+export type RosterMemberWaiverSummaryType = z.infer<typeof RosterMemberWaiverSummarySchema>;
+export type TeamRosterWaiverSummariesType = z.infer<typeof TeamRosterWaiverSummariesSchema>;
 export type PublicRosterMemberType = z.infer<typeof PublicRosterMemberSchema>;
 export type PublicTeamRosterResponseType = z.infer<typeof PublicTeamRosterResponseSchema>;
 export type RosterCardPlayerType = z.infer<typeof RosterCardPlayerSchema>;


### PR DESCRIPTION
Add admin-only support for viewing and managing player waiver submissions across teams in a season.

Changes include:
- OpenAPI: new schemas (RosterMemberSeasonTeamWaiver, RosterMemberWaiverSummary, TeamRosterWaiverSummaries) and new GET path /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers.
- Backend types: added dbContactSeasonTeamWaiver type and registered new OpenAPI schema refs.
- Repository: implemented PrismaContactRepository.findSeasonTeamWaiversForContacts and exposed it via IContactRepository.
- Service & formatter: rosterService.getTeamRosterWaiverSummaries added; RosterResponseFormatter.formatTeamRosterWaiverSummariesResponse formats results (optionally includes gamesPlayed).
- Routes: registered new OpenAPI path and added Express route /:teamSeasonId/roster/waivers with admin protection.
- Frontend: added admin navigation link and new WaiversClient (with supporting wrapper/hook files) to fetch summaries, display per-team waiver status, and toggle submittedWaiver via updateRosterMember.
- Tests: updated csvExportService test stub to include the new repository method.

This enables account admins to inspect cross-team waiver status per player and update waiver submission state for roster members.