### PR TITLE
Gate waiver features by account setting

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
@@ -39,7 +39,7 @@ const BaseballAdminHubPage: React.FC = () => {
   const enabledSettings = new Set<AccountSettingKey>(
     (accountSettings ?? [])
       .filter((setting) => Boolean(setting.effectiveValue ?? setting.value))
-      .map((setting) => setting.definition.key as AccountSettingKey),
+      .map((setting) => setting.definition.key),
   );
 
   const isGlobalAdmin = hasRole('Administrator');

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
@@ -34,7 +34,11 @@ const BaseballAdminHubPage: React.FC = () => {
   const { hasRole } = useRole();
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
-  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
+  const {
+    settings: accountSettings,
+    loading: settingsLoading,
+    error: settingsError,
+  } = useAccountSettings(accountId);
 
   const enabledSettings = new Set<AccountSettingKey>(
     (accountSettings ?? [])
@@ -136,11 +140,16 @@ const BaseballAdminHubPage: React.FC = () => {
       </AccountPageHeader>
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
+        {settingsError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Unable to load account settings: {settingsError}
+          </Alert>
+        )}
         {settingsLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
-        ) : (
+        ) : settingsError ? null : (
           <AdminHubSearch
             items={baseballItems}
             accountId={accountId}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
@@ -13,7 +13,9 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import CampaignIcon from '@mui/icons-material/Campaign';
 import AccountPageHeader from '../../../../components/AccountPageHeader';
 import { AdminCategoryCard, AdminHubSearch, type AdminMetric } from '../../../../components/admin';
+import { AccountSettingKey } from '@draco/shared-schemas';
 import { useAdminDashboardSummary } from '../../../../hooks/useAdminDashboardSummary';
+import { useAccountSettings } from '../../../../hooks/useAccountSettings';
 import { useRole } from '../../../../context/RoleContext';
 import { getBaseballAdminItems } from '../../../../lib/admin-hub-registry';
 
@@ -32,6 +34,13 @@ const BaseballAdminHubPage: React.FC = () => {
   const { hasRole } = useRole();
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
+  const { settings: accountSettings } = useAccountSettings(accountId);
+
+  const enabledSettings = new Set<AccountSettingKey>(
+    (accountSettings ?? [])
+      .filter((setting) => Boolean(setting.effectiveValue ?? setting.value))
+      .map((setting) => setting.definition.key as AccountSettingKey),
+  );
 
   const isGlobalAdmin = hasRole('Administrator');
   const [searchTerm, setSearchTerm] = useState('');
@@ -133,6 +142,7 @@ const BaseballAdminHubPage: React.FC = () => {
           isGlobalAdmin={isGlobalAdmin}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
+          enabledSettings={enabledSettings}
         />
 
         {!isSearching && (

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/BaseballAdminHubPage.tsx
@@ -34,7 +34,7 @@ const BaseballAdminHubPage: React.FC = () => {
   const { hasRole } = useRole();
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
-  const { settings: accountSettings } = useAccountSettings(accountId);
+  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
 
   const enabledSettings = new Set<AccountSettingKey>(
     (accountSettings ?? [])
@@ -136,14 +136,20 @@ const BaseballAdminHubPage: React.FC = () => {
       </AccountPageHeader>
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
-        <AdminHubSearch
-          items={baseballItems}
-          accountId={accountId}
-          isGlobalAdmin={isGlobalAdmin}
-          searchTerm={searchTerm}
-          onSearchChange={setSearchTerm}
-          enabledSettings={enabledSettings}
-        />
+        {settingsLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <AdminHubSearch
+            items={baseballItems}
+            accountId={accountId}
+            isGlobalAdmin={isGlobalAdmin}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            enabledSettings={enabledSettings}
+          />
+        )}
 
         {!isSearching && (
           <>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import { Container, Typography, Divider } from '@mui/material';
+import { Box, CircularProgress, Container, Divider, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
@@ -37,7 +37,7 @@ const GolfAdminHubPage: React.FC = () => {
   const isGlobalAdmin = hasRole('Administrator');
   const [searchTerm, setSearchTerm] = useState('');
   const [currentSeasonId, setCurrentSeasonId] = useState<string | undefined>(undefined);
-  const { settings: accountSettings } = useAccountSettings(accountId);
+  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
 
   const enabledSettings = new Set<AccountSettingKey>(
     (accountSettings ?? [])
@@ -120,14 +120,20 @@ const GolfAdminHubPage: React.FC = () => {
       </AccountPageHeader>
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
-        <AdminHubSearch
-          items={golfItems}
-          accountId={accountId}
-          isGlobalAdmin={isGlobalAdmin}
-          searchTerm={searchTerm}
-          onSearchChange={setSearchTerm}
-          enabledSettings={enabledSettings}
-        />
+        {settingsLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <AdminHubSearch
+            items={golfItems}
+            accountId={accountId}
+            isGlobalAdmin={isGlobalAdmin}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            enabledSettings={enabledSettings}
+          />
+        )}
 
         {!isSearching && (
           <>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
@@ -11,9 +11,11 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import CampaignIcon from '@mui/icons-material/Campaign';
 import SportsGolfIcon from '@mui/icons-material/SportsGolf';
 import { getCurrentSeason } from '@draco/shared-api-client';
+import { AccountSettingKey } from '@draco/shared-schemas';
 import AccountPageHeader from '../../../../components/AccountPageHeader';
 import { AdminCategoryCard, AdminHubSearch } from '../../../../components/admin';
 import { useRole } from '../../../../context/RoleContext';
+import { useAccountSettings } from '../../../../hooks/useAccountSettings';
 import { useApiClient } from '../../../../hooks/useApiClient';
 import { getGolfAdminItems } from '../../../../lib/admin-hub-registry';
 import { unwrapApiResult } from '../../../../utils/apiResult';
@@ -35,6 +37,13 @@ const GolfAdminHubPage: React.FC = () => {
   const isGlobalAdmin = hasRole('Administrator');
   const [searchTerm, setSearchTerm] = useState('');
   const [currentSeasonId, setCurrentSeasonId] = useState<string | undefined>(undefined);
+  const { settings: accountSettings } = useAccountSettings(accountId);
+
+  const enabledSettings = new Set<AccountSettingKey>(
+    (accountSettings ?? [])
+      .filter((setting) => Boolean(setting.effectiveValue ?? setting.value))
+      .map((setting) => setting.definition.key),
+  );
 
   useEffect(() => {
     if (!accountId) return;
@@ -117,6 +126,7 @@ const GolfAdminHubPage: React.FC = () => {
           isGlobalAdmin={isGlobalAdmin}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
+          enabledSettings={enabledSettings}
         />
 
         {!isSearching && (

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/GolfAdminHubPage.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import { Box, CircularProgress, Container, Divider, Typography } from '@mui/material';
+import { Alert, Box, CircularProgress, Container, Divider, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
@@ -37,7 +37,11 @@ const GolfAdminHubPage: React.FC = () => {
   const isGlobalAdmin = hasRole('Administrator');
   const [searchTerm, setSearchTerm] = useState('');
   const [currentSeasonId, setCurrentSeasonId] = useState<string | undefined>(undefined);
-  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
+  const {
+    settings: accountSettings,
+    loading: settingsLoading,
+    error: settingsError,
+  } = useAccountSettings(accountId);
 
   const enabledSettings = new Set<AccountSettingKey>(
     (accountSettings ?? [])
@@ -120,11 +124,16 @@ const GolfAdminHubPage: React.FC = () => {
       </AccountPageHeader>
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
+        {settingsError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Unable to load account settings: {settingsError}
+          </Alert>
+        )}
         {settingsLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
-        ) : (
+        ) : settingsError ? null : (
           <AdminHubSearch
             items={golfItems}
             accountId={accountId}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
@@ -36,7 +36,11 @@ const BaseballSeasonAdminPage: React.FC = () => {
   const accountId = Array.isArray(accountIdParam) ? accountIdParam[0] : accountIdParam;
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
-  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
+  const {
+    settings: accountSettings,
+    loading: settingsLoading,
+    error: settingsError,
+  } = useAccountSettings(accountId);
 
   const getSettingValue = (key: AccountSettingKey): boolean => {
     const state = accountSettings?.find((setting) => setting.definition.key === key);
@@ -128,6 +132,12 @@ const BaseballSeasonAdminPage: React.FC = () => {
         {error && (
           <Alert severity="warning" sx={{ mb: 3 }}>
             Unable to load summary data. You can still navigate to admin sections.
+          </Alert>
+        )}
+
+        {settingsError && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            Unable to load account settings: {settingsError}. Settings-gated tiles may be hidden.
           </Alert>
         )}
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
@@ -10,6 +10,7 @@ import SportsBaseballIcon from '@mui/icons-material/SportsBaseball';
 import FitnessCenterIcon from '@mui/icons-material/FitnessCenter';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import { AccountSettingKey } from '@draco/shared-schemas';
 import AccountPageHeader from '../../../../../components/AccountPageHeader';
 import {
   AdminBreadcrumbs,
@@ -17,6 +18,7 @@ import {
   type AdminSubItemMetric,
 } from '../../../../../components/admin';
 import { useAdminDashboardSummary } from '../../../../../hooks/useAdminDashboardSummary';
+import { useAccountSettings } from '../../../../../hooks/useAccountSettings';
 
 interface SubItemConfig {
   title: string;
@@ -34,6 +36,13 @@ const BaseballSeasonAdminPage: React.FC = () => {
   const accountId = Array.isArray(accountIdParam) ? accountIdParam[0] : accountIdParam;
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
+  const { settings: accountSettings } = useAccountSettings(accountId);
+
+  const getSettingValue = (key: AccountSettingKey): boolean => {
+    const state = accountSettings?.find((setting) => setting.definition.key === key);
+    return Boolean(state?.effectiveValue ?? state?.value);
+  };
+  const trackWaiverEnabled = getSettingValue('TrackWaiver');
 
   if (!accountId) {
     return null;
@@ -79,13 +88,17 @@ const BaseballSeasonAdminPage: React.FC = () => {
       getMetrics: (data) =>
         data ? [{ value: data.season.upcomingWorkouts, label: 'upcoming' }] : [],
     },
-    {
-      title: 'Player Waivers',
-      description: 'Track submitted player waivers across teams in the current season.',
-      icon: <AssignmentTurnedInIcon />,
-      href: `/account/${accountId}/waivers`,
-      getMetrics: () => [],
-    },
+    ...(trackWaiverEnabled
+      ? [
+          {
+            title: 'Player Waivers',
+            description: 'Track submitted player waivers across teams in the current season.',
+            icon: <AssignmentTurnedInIcon />,
+            href: `/account/${accountId}/waivers`,
+            getMetrics: () => [],
+          } satisfies SubItemConfig,
+        ]
+      : []),
   ];
 
   return (

--- a/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/admin/season/BaseballSeasonAdminPage.tsx
@@ -36,7 +36,7 @@ const BaseballSeasonAdminPage: React.FC = () => {
   const accountId = Array.isArray(accountIdParam) ? accountIdParam[0] : accountIdParam;
 
   const { summary, loading, error } = useAdminDashboardSummary(accountId || '');
-  const { settings: accountSettings } = useAccountSettings(accountId);
+  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
 
   const getSettingValue = (key: AccountSettingKey): boolean => {
     const state = accountSettings?.find((setting) => setting.definition.key === key);
@@ -119,7 +119,7 @@ const BaseballSeasonAdminPage: React.FC = () => {
       <Container maxWidth="lg" sx={{ py: 4 }}>
         <AdminBreadcrumbs accountId={accountId} currentPage="Season" />
 
-        {loading && (
+        {(loading || settingsLoading) && (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
@@ -131,19 +131,21 @@ const BaseballSeasonAdminPage: React.FC = () => {
           </Alert>
         )}
 
-        <Grid container spacing={3}>
-          {subItems.map((item) => (
-            <Grid key={item.title} size={{ xs: 12, sm: 6, md: 6 }}>
-              <AdminSubItemCard
-                title={item.title}
-                description={item.description}
-                icon={item.icon}
-                href={item.href}
-                metrics={item.getMetrics(summary)}
-              />
-            </Grid>
-          ))}
-        </Grid>
+        {!settingsLoading && (
+          <Grid container spacing={3}>
+            {subItems.map((item) => (
+              <Grid key={item.title} size={{ xs: 12, sm: 6, md: 6 }}>
+                <AdminSubItemCard
+                  title={item.title}
+                  description={item.description}
+                  icon={item.icon}
+                  href={item.href}
+                  metrics={item.getMetrics(summary)}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        )}
       </Container>
     </main>
   );

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -136,17 +136,45 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     };
   }, [accountId, currentSeasonId, selectedTeamSeasonId, apiClient]);
 
+  const setDriversLicense = (rosterMemberId: string, value: boolean) =>
+    setMembers((prev) =>
+      prev.map((m) =>
+        m.rosterMember.id === rosterMemberId
+          ? {
+              ...m,
+              rosterMember: {
+                ...m.rosterMember,
+                player: { ...m.rosterMember.player, submittedDriversLicense: value },
+              },
+            }
+          : m,
+      ),
+    );
+
+  const setWaiver = (rosterMemberId: string, teamSeasonId: string, value: boolean) =>
+    setMembers((prev) =>
+      prev.map((m) =>
+        m.rosterMember.id === rosterMemberId
+          ? {
+              ...m,
+              rosterMember: { ...m.rosterMember, submittedWaiver: value },
+              seasonTeams: m.seasonTeams.map((team) =>
+                team.teamSeasonId === teamSeasonId ? { ...team, submittedWaiver: value } : team,
+              ),
+            }
+          : m,
+      ),
+    );
+
   const handleToggleDriversLicense = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
     const rosterMemberId = member.rosterMember.id;
-    const nextValue = !member.rosterMember.player.submittedDriversLicense;
+    const previousValue = Boolean(member.rosterMember.player.submittedDriversLicense);
+    const nextValue = !previousValue;
 
-    setUpdatingDriversLicenseIds((prev) => {
-      const next = new Set(prev);
-      next.add(rosterMemberId);
-      return next;
-    });
+    setDriversLicense(rosterMemberId, nextValue);
     setUpdateError(null);
+    setUpdatingDriversLicenseIds((prev) => new Set(prev).add(rosterMemberId));
 
     try {
       const result = await updateRosterMember({
@@ -160,23 +188,9 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
         body: { player: { submittedDriversLicense: nextValue } },
         throwOnError: false,
       });
-
-      const updated = unwrapApiResult(result, 'Failed to update submitted drivers license status');
-
-      setMembers((prev) =>
-        prev.map((m) => {
-          if (m.rosterMember.id !== rosterMemberId) return m;
-          return {
-            ...m,
-            rosterMember: {
-              ...m.rosterMember,
-              ...updated,
-              player: { ...m.rosterMember.player, ...updated.player },
-            },
-          };
-        }),
-      );
+      unwrapApiResult(result, 'Failed to update submitted drivers license status');
     } catch (err: unknown) {
+      setDriversLicense(rosterMemberId, previousValue);
       setUpdateError(
         err instanceof Error ? err.message : 'Failed to update submitted drivers license status',
       );
@@ -192,14 +206,12 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
   const handleToggleWaiver = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
     const rosterMemberId = member.rosterMember.id;
-    const nextValue = !member.rosterMember.submittedWaiver;
+    const previousValue = Boolean(member.rosterMember.submittedWaiver);
+    const nextValue = !previousValue;
 
-    setUpdatingWaiverIds((prev) => {
-      const next = new Set(prev);
-      next.add(rosterMemberId);
-      return next;
-    });
+    setWaiver(rosterMemberId, selectedTeamSeasonId, nextValue);
     setUpdateError(null);
+    setUpdatingWaiverIds((prev) => new Set(prev).add(rosterMemberId));
 
     try {
       const result = await updateRosterMember({
@@ -213,26 +225,9 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
         body: { submittedWaiver: nextValue },
         throwOnError: false,
       });
-
-      const updated = unwrapApiResult(result, 'Failed to update waiver status');
-
-      setMembers((prev) =>
-        prev.map((m) => {
-          if (m.rosterMember.id !== rosterMemberId) return m;
-          const newWaiver = updated.submittedWaiver ?? nextValue;
-          const updatedSeasonTeams = m.seasonTeams.map((team) =>
-            team.teamSeasonId === selectedTeamSeasonId
-              ? { ...team, submittedWaiver: newWaiver }
-              : team,
-          );
-          return {
-            ...m,
-            rosterMember: { ...m.rosterMember, ...updated },
-            seasonTeams: updatedSeasonTeams,
-          };
-        }),
-      );
+      unwrapApiResult(result, 'Failed to update waiver status');
     } catch (err: unknown) {
+      setWaiver(rosterMemberId, selectedTeamSeasonId, previousValue);
       setUpdateError(err instanceof Error ? err.message : 'Failed to update waiver status');
     } finally {
       setUpdatingWaiverIds((prev) => {

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -41,7 +41,11 @@ type WaiverMember = TeamRosterWaiverSummaries['members'][number];
 
 export default function WaiversClient({ accountId }: WaiversClientProps) {
   const apiClient = useApiClient();
-  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
+  const {
+    settings: accountSettings,
+    loading: settingsLoading,
+    error: settingsError,
+  } = useAccountSettings(accountId);
   const trackWaiverSetting = accountSettings?.find(
     (setting) => setting.definition.key === 'TrackWaiver',
   );
@@ -273,6 +277,8 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
             <CircularProgress />
           </Box>
+        ) : settingsError ? (
+          <Alert severity="error">Unable to load account settings: {settingsError}</Alert>
         ) : !trackWaiverEnabled ? (
           <Alert severity="info">
             Player waiver tracking is currently disabled for this account.

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -121,6 +121,59 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     };
   }, [accountId, currentSeasonId, selectedTeamSeasonId, apiClient]);
 
+  const handleToggleDriversLicense = async (member: WaiverMember) => {
+    if (!currentSeasonId || !selectedTeamSeasonId) return;
+    const rosterMemberId = member.rosterMember.id;
+    const nextValue = !member.rosterMember.player.submittedDriversLicense;
+
+    setUpdatingMemberIds((prev) => {
+      const next = new Set(prev);
+      next.add(rosterMemberId);
+      return next;
+    });
+    setUpdateError(null);
+
+    try {
+      const result = await updateRosterMember({
+        client: apiClient,
+        path: {
+          accountId,
+          seasonId: currentSeasonId,
+          teamSeasonId: selectedTeamSeasonId,
+          rosterMemberId,
+        },
+        body: { player: { submittedDriversLicense: nextValue } },
+        throwOnError: false,
+      });
+
+      const updated = unwrapApiResult(result, 'Failed to update submitted drivers license status');
+
+      setMembers((prev) =>
+        prev.map((m) => {
+          if (m.rosterMember.id !== rosterMemberId) return m;
+          return {
+            ...m,
+            rosterMember: {
+              ...m.rosterMember,
+              ...updated,
+              player: { ...m.rosterMember.player, ...updated.player },
+            },
+          };
+        }),
+      );
+    } catch (err: unknown) {
+      setUpdateError(
+        err instanceof Error ? err.message : 'Failed to update submitted drivers license status',
+      );
+    } finally {
+      setUpdatingMemberIds((prev) => {
+        const next = new Set(prev);
+        next.delete(rosterMemberId);
+        return next;
+      });
+    }
+  };
+
   const handleToggleWaiver = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
     const rosterMemberId = member.rosterMember.id;
@@ -308,7 +361,12 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                       <TableHead>
                         <TableRow>
                           <TableCell>Player</TableCell>
-                          <TableCell sx={{ width: 200 }}>Waiver for This Team</TableCell>
+                          <TableCell align="center" sx={{ width: 220 }}>
+                            Submitted Drivers License
+                          </TableCell>
+                          <TableCell align="center" sx={{ width: 200 }}>
+                            Waiver for This Team
+                          </TableCell>
                           <TableCell>All Teams Waiver Submitted</TableCell>
                         </TableRow>
                       </TableHead>
@@ -326,8 +384,32 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                           return (
                             <TableRow key={rosterMemberId} hover>
                               <TableCell>{fullName}</TableCell>
-                              <TableCell>
-                                <Stack direction="row" spacing={1} alignItems="center">
+                              <TableCell align="center">
+                                <Stack
+                                  direction="row"
+                                  spacing={1}
+                                  alignItems="center"
+                                  justifyContent="center"
+                                >
+                                  <Switch
+                                    checked={Boolean(
+                                      member.rosterMember.player.submittedDriversLicense,
+                                    )}
+                                    onChange={() => handleToggleDriversLicense(member)}
+                                    disabled={isUpdating}
+                                    inputProps={{
+                                      'aria-label': `Toggle submitted drivers license for ${fullName}`,
+                                    }}
+                                  />
+                                </Stack>
+                              </TableCell>
+                              <TableCell align="center">
+                                <Stack
+                                  direction="row"
+                                  spacing={1}
+                                  alignItems="center"
+                                  justifyContent="center"
+                                >
                                   <Switch
                                     checked={Boolean(member.rosterMember.submittedWaiver)}
                                     onChange={() => handleToggleWaiver(member)}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -27,6 +27,7 @@ import {
   type TeamRosterWaiverSummaries,
 } from '@draco/shared-api-client';
 import AccountPageHeader from '../../../../components/AccountPageHeader';
+import { useAccountSettings } from '../../../../hooks/useAccountSettings';
 import { useApiClient } from '../../../../hooks/useApiClient';
 import { useCurrentSeason } from '../../../../hooks/useCurrentSeason';
 import { unwrapApiResult } from '../../../../utils/apiResult';
@@ -40,6 +41,13 @@ type WaiverMember = TeamRosterWaiverSummaries['members'][number];
 
 export default function WaiversClient({ accountId }: WaiversClientProps) {
   const apiClient = useApiClient();
+  const { settings: accountSettings, loading: settingsLoading } = useAccountSettings(accountId);
+  const trackWaiverSetting = accountSettings?.find(
+    (setting) => setting.definition.key === 'TrackWaiver',
+  );
+  const trackWaiverEnabled = Boolean(
+    trackWaiverSetting?.effectiveValue ?? trackWaiverSetting?.value,
+  );
   const {
     currentSeasonId,
     currentSeasonName,
@@ -66,7 +74,10 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
   const [members, setMembers] = useState<WaiverMember[]>([]);
   const [rosterLoading, setRosterLoading] = useState(false);
   const [rosterError, setRosterError] = useState<string | null>(null);
-  const [updatingMemberIds, setUpdatingMemberIds] = useState<Set<string>>(() => new Set());
+  const [updatingDriversLicenseIds, setUpdatingDriversLicenseIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [updatingWaiverIds, setUpdatingWaiverIds] = useState<Set<string>>(() => new Set());
   const [updateError, setUpdateError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -126,7 +137,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     const rosterMemberId = member.rosterMember.id;
     const nextValue = !member.rosterMember.player.submittedDriversLicense;
 
-    setUpdatingMemberIds((prev) => {
+    setUpdatingDriversLicenseIds((prev) => {
       const next = new Set(prev);
       next.add(rosterMemberId);
       return next;
@@ -166,7 +177,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
         err instanceof Error ? err.message : 'Failed to update submitted drivers license status',
       );
     } finally {
-      setUpdatingMemberIds((prev) => {
+      setUpdatingDriversLicenseIds((prev) => {
         const next = new Set(prev);
         next.delete(rosterMemberId);
         return next;
@@ -179,7 +190,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     const rosterMemberId = member.rosterMember.id;
     const nextValue = !member.rosterMember.submittedWaiver;
 
-    setUpdatingMemberIds((prev) => {
+    setUpdatingWaiverIds((prev) => {
       const next = new Set(prev);
       next.add(rosterMemberId);
       return next;
@@ -220,7 +231,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     } catch (err: unknown) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to update waiver status');
     } finally {
-      setUpdatingMemberIds((prev) => {
+      setUpdatingWaiverIds((prev) => {
         const next = new Set(prev);
         next.delete(rosterMemberId);
         return next;
@@ -258,206 +269,221 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
       </AccountPageHeader>
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
-        {seasonError && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {seasonError}
-          </Alert>
-        )}
-        {leaguesError && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {leaguesError}
-          </Alert>
-        )}
-        {updateError && (
-          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setUpdateError(null)}>
-            {updateError}
-          </Alert>
-        )}
-
-        {seasonLoading && !currentSeasonId ? (
+        {settingsLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
             <CircularProgress />
           </Box>
-        ) : !currentSeasonId ? (
-          <Alert severity="info">There is no current season configured for this account.</Alert>
+        ) : !trackWaiverEnabled ? (
+          <Alert severity="info">
+            Player waiver tracking is currently disabled for this account.
+          </Alert>
         ) : (
-          <Stack spacing={3}>
-            <Stack
-              direction={{ xs: 'column', sm: 'row' }}
-              spacing={2}
-              alignItems="center"
-              justifyContent="center"
-            >
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Typography component="label" htmlFor="waivers-league-select">
-                  League:
-                </Typography>
-                <FormControl size="small" sx={{ minWidth: 220 }} disabled={leaguesLoading}>
-                  <Select
-                    id="waivers-league-select"
-                    value={selectedLeagueSeasonId}
-                    onChange={(e) => setSelectedLeagueSeasonId(e.target.value)}
-                    displayEmpty
-                    inputProps={{ 'aria-label': 'League' }}
-                  >
-                    <MenuItem value="">
-                      <em>Select a league</em>
-                    </MenuItem>
-                    {leagues.map((league) => (
-                      <MenuItem key={league.leagueSeasonId} value={league.leagueSeasonId}>
-                        {league.leagueName}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Stack>
-
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Typography component="label" htmlFor="waivers-team-select">
-                  Team:
-                </Typography>
-                <FormControl
-                  size="small"
-                  sx={{ minWidth: 220 }}
-                  disabled={!selectedLeagueSeasonId || leaguesLoading}
-                >
-                  <Select
-                    id="waivers-team-select"
-                    value={selectedTeamSeasonId}
-                    onChange={(e) => setSelectedTeamSeasonId(e.target.value)}
-                    displayEmpty
-                    inputProps={{ 'aria-label': 'Team' }}
-                  >
-                    <MenuItem value="">
-                      <em>Select a team</em>
-                    </MenuItem>
-                    {teamsForSelectedLeague.map((team) => (
-                      <MenuItem key={team.teamSeasonId} value={team.teamSeasonId}>
-                        {team.teamName}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Stack>
-            </Stack>
-
-            {selectedTeamSeasonId && (
-              <Paper variant="outlined">
-                {rosterLoading ? (
-                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-                    <CircularProgress />
-                  </Box>
-                ) : rosterError ? (
-                  <Box sx={{ p: 3 }}>
-                    <Alert severity="error">{rosterError}</Alert>
-                  </Box>
-                ) : sortedMembers.length === 0 ? (
-                  <Box sx={{ p: 3 }}>
-                    <Typography color="text.secondary">No players on this team.</Typography>
-                  </Box>
-                ) : (
-                  <TableContainer>
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Player</TableCell>
-                          <TableCell align="center" sx={{ width: 220 }}>
-                            Submitted Drivers License
-                          </TableCell>
-                          <TableCell align="center" sx={{ width: 200 }}>
-                            Waiver for This Team
-                          </TableCell>
-                          <TableCell>All Teams Waiver Submitted</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {sortedMembers.map((member) => {
-                          const rosterMemberId = member.rosterMember.id;
-                          const contact = member.rosterMember.player.contact;
-                          const fullName =
-                            `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() ||
-                            'Unknown';
-                          const teamsWithWaiver = member.seasonTeams.filter(
-                            (team) => team.submittedWaiver,
-                          );
-                          const isUpdating = updatingMemberIds.has(rosterMemberId);
-                          return (
-                            <TableRow key={rosterMemberId} hover>
-                              <TableCell>{fullName}</TableCell>
-                              <TableCell align="center">
-                                <Stack
-                                  direction="row"
-                                  spacing={1}
-                                  alignItems="center"
-                                  justifyContent="center"
-                                >
-                                  <Switch
-                                    checked={Boolean(
-                                      member.rosterMember.player.submittedDriversLicense,
-                                    )}
-                                    onChange={() => handleToggleDriversLicense(member)}
-                                    disabled={isUpdating}
-                                    inputProps={{
-                                      'aria-label': `Toggle submitted drivers license for ${fullName}`,
-                                    }}
-                                  />
-                                </Stack>
-                              </TableCell>
-                              <TableCell align="center">
-                                <Stack
-                                  direction="row"
-                                  spacing={1}
-                                  alignItems="center"
-                                  justifyContent="center"
-                                >
-                                  <Switch
-                                    checked={Boolean(member.rosterMember.submittedWaiver)}
-                                    onChange={() => handleToggleWaiver(member)}
-                                    disabled={isUpdating}
-                                    inputProps={{
-                                      'aria-label': `Toggle waiver for ${fullName}`,
-                                    }}
-                                  />
-                                  {isUpdating && <CircularProgress size={16} />}
-                                </Stack>
-                              </TableCell>
-                              <TableCell>
-                                {teamsWithWaiver.length === 0 ? (
-                                  <Typography variant="body2" color="text.secondary">
-                                    —
-                                  </Typography>
-                                ) : (
-                                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                                    {teamsWithWaiver.map((team) => (
-                                      <Chip
-                                        key={team.teamSeasonId}
-                                        size="small"
-                                        color={
-                                          team.teamSeasonId === selectedTeamSeasonId
-                                            ? 'primary'
-                                            : 'default'
-                                        }
-                                        variant={
-                                          team.teamSeasonId === selectedTeamSeasonId
-                                            ? 'filled'
-                                            : 'outlined'
-                                        }
-                                        label={`${team.leagueName} / ${team.teamName}`}
-                                      />
-                                    ))}
-                                  </Stack>
-                                )}
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                )}
-              </Paper>
+          <>
+            {seasonError && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {seasonError}
+              </Alert>
             )}
-          </Stack>
+            {leaguesError && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {leaguesError}
+              </Alert>
+            )}
+            {updateError && (
+              <Alert severity="error" sx={{ mb: 2 }} onClose={() => setUpdateError(null)}>
+                {updateError}
+              </Alert>
+            )}
+
+            {seasonLoading && !currentSeasonId ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                <CircularProgress />
+              </Box>
+            ) : !currentSeasonId ? (
+              <Alert severity="info">There is no current season configured for this account.</Alert>
+            ) : (
+              <Stack spacing={3}>
+                <Stack
+                  direction={{ xs: 'column', sm: 'row' }}
+                  spacing={2}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography component="label" htmlFor="waivers-league-select">
+                      League:
+                    </Typography>
+                    <FormControl size="small" sx={{ minWidth: 220 }} disabled={leaguesLoading}>
+                      <Select
+                        id="waivers-league-select"
+                        value={selectedLeagueSeasonId}
+                        onChange={(e) => setSelectedLeagueSeasonId(e.target.value)}
+                        displayEmpty
+                        inputProps={{ 'aria-label': 'League' }}
+                      >
+                        <MenuItem value="">
+                          <em>Select a league</em>
+                        </MenuItem>
+                        {leagues.map((league) => (
+                          <MenuItem key={league.leagueSeasonId} value={league.leagueSeasonId}>
+                            {league.leagueName}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Stack>
+
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography component="label" htmlFor="waivers-team-select">
+                      Team:
+                    </Typography>
+                    <FormControl
+                      size="small"
+                      sx={{ minWidth: 220 }}
+                      disabled={!selectedLeagueSeasonId || leaguesLoading}
+                    >
+                      <Select
+                        id="waivers-team-select"
+                        value={selectedTeamSeasonId}
+                        onChange={(e) => setSelectedTeamSeasonId(e.target.value)}
+                        displayEmpty
+                        inputProps={{ 'aria-label': 'Team' }}
+                      >
+                        <MenuItem value="">
+                          <em>Select a team</em>
+                        </MenuItem>
+                        {teamsForSelectedLeague.map((team) => (
+                          <MenuItem key={team.teamSeasonId} value={team.teamSeasonId}>
+                            {team.teamName}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Stack>
+                </Stack>
+
+                {selectedTeamSeasonId && (
+                  <Paper variant="outlined">
+                    {rosterLoading ? (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                        <CircularProgress />
+                      </Box>
+                    ) : rosterError ? (
+                      <Box sx={{ p: 3 }}>
+                        <Alert severity="error">{rosterError}</Alert>
+                      </Box>
+                    ) : sortedMembers.length === 0 ? (
+                      <Box sx={{ p: 3 }}>
+                        <Typography color="text.secondary">No players on this team.</Typography>
+                      </Box>
+                    ) : (
+                      <TableContainer>
+                        <Table>
+                          <TableHead>
+                            <TableRow>
+                              <TableCell>Player</TableCell>
+                              <TableCell align="center" sx={{ width: 220 }}>
+                                Submitted Drivers License
+                              </TableCell>
+                              <TableCell align="center" sx={{ width: 200 }}>
+                                Waiver for This Team
+                              </TableCell>
+                              <TableCell>All Teams Waiver Submitted</TableCell>
+                            </TableRow>
+                          </TableHead>
+                          <TableBody>
+                            {sortedMembers.map((member) => {
+                              const rosterMemberId = member.rosterMember.id;
+                              const contact = member.rosterMember.player.contact;
+                              const fullName =
+                                `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() ||
+                                'Unknown';
+                              const teamsWithWaiver = member.seasonTeams.filter(
+                                (team) => team.submittedWaiver,
+                              );
+                              const isUpdatingDriversLicense =
+                                updatingDriversLicenseIds.has(rosterMemberId);
+                              const isUpdatingWaiver = updatingWaiverIds.has(rosterMemberId);
+                              return (
+                                <TableRow key={rosterMemberId} hover>
+                                  <TableCell>{fullName}</TableCell>
+                                  <TableCell align="center">
+                                    <Stack
+                                      direction="row"
+                                      spacing={1}
+                                      alignItems="center"
+                                      justifyContent="center"
+                                    >
+                                      <Switch
+                                        checked={Boolean(
+                                          member.rosterMember.player.submittedDriversLicense,
+                                        )}
+                                        onChange={() => handleToggleDriversLicense(member)}
+                                        disabled={isUpdatingDriversLicense}
+                                        inputProps={{
+                                          'aria-label': `Toggle submitted drivers license for ${fullName}`,
+                                        }}
+                                      />
+                                      {isUpdatingDriversLicense && <CircularProgress size={16} />}
+                                    </Stack>
+                                  </TableCell>
+                                  <TableCell align="center">
+                                    <Stack
+                                      direction="row"
+                                      spacing={1}
+                                      alignItems="center"
+                                      justifyContent="center"
+                                    >
+                                      <Switch
+                                        checked={Boolean(member.rosterMember.submittedWaiver)}
+                                        onChange={() => handleToggleWaiver(member)}
+                                        disabled={isUpdatingWaiver}
+                                        inputProps={{
+                                          'aria-label': `Toggle waiver for ${fullName}`,
+                                        }}
+                                      />
+                                      {isUpdatingWaiver && <CircularProgress size={16} />}
+                                    </Stack>
+                                  </TableCell>
+                                  <TableCell>
+                                    {teamsWithWaiver.length === 0 ? (
+                                      <Typography variant="body2" color="text.secondary">
+                                        —
+                                      </Typography>
+                                    ) : (
+                                      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                                        {teamsWithWaiver.map((team) => (
+                                          <Chip
+                                            key={team.teamSeasonId}
+                                            size="small"
+                                            color={
+                                              team.teamSeasonId === selectedTeamSeasonId
+                                                ? 'primary'
+                                                : 'default'
+                                            }
+                                            variant={
+                                              team.teamSeasonId === selectedTeamSeasonId
+                                                ? 'filled'
+                                                : 'outlined'
+                                            }
+                                            label={`${team.leagueName} / ${team.teamName}`}
+                                          />
+                                        ))}
+                                      </Stack>
+                                    )}
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
+                      </TableContainer>
+                    )}
+                  </Paper>
+                )}
+              </Stack>
+            )}
+          </>
         )}
       </Container>
     </main>

--- a/draco-nodejs/frontend-next/components/admin/AdminHubSearch.tsx
+++ b/draco-nodejs/frontend-next/components/admin/AdminHubSearch.tsx
@@ -23,7 +23,7 @@ interface AdminHubSearchProps {
   isGlobalAdmin: boolean;
   searchTerm: string;
   onSearchChange: (value: string) => void;
-  enabledSettings?: ReadonlySet<AccountSettingKey>;
+  enabledSettings: ReadonlySet<AccountSettingKey>;
 }
 
 const AdminHubSearch: React.FC<AdminHubSearchProps> = ({

--- a/draco-nodejs/frontend-next/components/admin/AdminHubSearch.tsx
+++ b/draco-nodejs/frontend-next/components/admin/AdminHubSearch.tsx
@@ -13,6 +13,7 @@ import {
 import Grid from '@mui/material/Grid';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
+import { AccountSettingKey } from '@draco/shared-schemas';
 import { AdminSubItemCard } from './index';
 import { type AdminSearchItem, searchAdminItems } from '../../lib/admin-hub-registry';
 
@@ -22,6 +23,7 @@ interface AdminHubSearchProps {
   isGlobalAdmin: boolean;
   searchTerm: string;
   onSearchChange: (value: string) => void;
+  enabledSettings?: ReadonlySet<AccountSettingKey>;
 }
 
 const AdminHubSearch: React.FC<AdminHubSearchProps> = ({
@@ -30,10 +32,11 @@ const AdminHubSearch: React.FC<AdminHubSearchProps> = ({
   isGlobalAdmin,
   searchTerm,
   onSearchChange,
+  enabledSettings,
 }) => {
   const theme = useTheme();
 
-  const results = searchAdminItems(items, searchTerm, isGlobalAdmin);
+  const results = searchAdminItems(items, searchTerm, isGlobalAdmin, enabledSettings);
   const isSearching = searchTerm.trim().length > 0;
 
   return (

--- a/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
+++ b/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
@@ -322,11 +322,11 @@ export function searchAdminItems(
   items: AdminSearchItem[],
   query: string,
   isGlobalAdmin: boolean,
-  enabledSettings?: ReadonlySet<AccountSettingKey>,
+  enabledSettings: ReadonlySet<AccountSettingKey>,
 ): AdminSearchItem[] {
   const roleFiltered = isGlobalAdmin ? items : items.filter((item) => !item.globalAdminOnly);
   const settingFiltered = roleFiltered.filter(
-    (item) => !item.requiresSetting || (enabledSettings?.has(item.requiresSetting) ?? false),
+    (item) => !item.requiresSetting || enabledSettings.has(item.requiresSetting),
   );
 
   if (!query.trim()) {

--- a/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
+++ b/draco-nodejs/frontend-next/lib/admin-hub-registry.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AccountSettingKey } from '@draco/shared-schemas';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ShareIcon from '@mui/icons-material/Share';
@@ -34,6 +35,7 @@ export interface AdminSearchItem {
   category: string;
   keywords: string[];
   globalAdminOnly?: boolean;
+  requiresSetting?: AccountSettingKey;
 }
 
 const baseAccountItems: AdminSearchItem[] = [
@@ -176,6 +178,7 @@ export function getBaseballAdminItems(): AdminSearchItem[] {
       getHref: (accountId) => `/account/${accountId}/waivers`,
       category: 'Season',
       keywords: ['waivers', 'waiver', 'player', 'roster', 'signed', 'consent'],
+      requiresSetting: 'TrackWaiver',
     },
     {
       id: 'announcements',
@@ -319,8 +322,12 @@ export function searchAdminItems(
   items: AdminSearchItem[],
   query: string,
   isGlobalAdmin: boolean,
+  enabledSettings?: ReadonlySet<AccountSettingKey>,
 ): AdminSearchItem[] {
-  const filtered = isGlobalAdmin ? items : items.filter((item) => !item.globalAdminOnly);
+  const roleFiltered = isGlobalAdmin ? items : items.filter((item) => !item.globalAdminOnly);
+  const settingFiltered = roleFiltered.filter(
+    (item) => !item.requiresSetting || (enabledSettings?.has(item.requiresSetting) ?? false),
+  );
 
   if (!query.trim()) {
     return [];
@@ -328,7 +335,7 @@ export function searchAdminItems(
 
   const lowerQuery = query.toLowerCase().trim();
 
-  return filtered.filter(
+  return settingFiltered.filter(
     (item) =>
       item.title.toLowerCase().includes(lowerQuery) ||
       item.description.toLowerCase().includes(lowerQuery) ||


### PR DESCRIPTION
Use account settings to conditionally show waiver-related admin items and UI. Integrates useAccountSettings and AccountSettingKey into admin pages to build a set of enabled settings and to gate the Player Waivers subitem (TrackWaiver). Update admin-hub-registry and AdminHubSearch to support an optional requiresSetting key and to filter search results by enabled settings. Add submitted drivers license column, toggle switch, and update handler to WaiversClient (with API update flow and local state update). Misc: import AccountSettingKey where needed and adjust searchAdminItems signature to accept enabled settings.