### PR TITLE
Add timezone-aware date ranges and leader transforms

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -13146,7 +13146,7 @@
           },
           "minAB": {
             "type": "string",
-            "default": 10
+            "default": 0
           },
           "sortField": {
             "type": "string",
@@ -13192,7 +13192,7 @@
           },
           "minIP": {
             "type": "string",
-            "default": 1
+            "default": 0
           },
           "sortField": {
             "type": "string",
@@ -74121,7 +74121,7 @@
           {
             "schema": {
               "type": "string",
-              "default": 10
+              "default": 0
             },
             "required": false,
             "name": "minAB",
@@ -74277,7 +74277,7 @@
           {
             "schema": {
               "type": "string",
-              "default": 1
+              "default": 0
             },
             "required": false,
             "name": "minIP",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -9814,7 +9814,7 @@ components:
           default: 50
         minAB:
           type: string
-          default: 10
+          default: 0
         sortField:
           type: string
           default: avg
@@ -9847,7 +9847,7 @@ components:
           default: 50
         minIP:
           type: string
-          default: 1
+          default: 0
         sortField:
           type: string
           default: era
@@ -49911,7 +49911,7 @@ paths:
           in: query
         - schema:
             type: string
-            default: 10
+            default: 0
           required: false
           name: minAB
           in: query
@@ -50013,7 +50013,7 @@ paths:
           in: query
         - schema:
             type: string
-            default: 1
+            default: 0
           required: false
           name: minIP
           in: query

--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -834,7 +834,7 @@ const BaseballAccountHome: React.FC = () => {
             )}
 
             {showInformationWidget && accountIdStr ? (
-              <Box sx={{ order: { xs: 6 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 7 }, minWidth: 0 }}>
                 <InformationWidget
                   accountId={accountIdStr}
                   showAccountMessages
@@ -845,7 +845,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {isAccountMember ? (
-              <Box sx={{ order: { xs: 7 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 8 }, minWidth: 0 }}>
                 <SpecialAnnouncementsWidget
                   accountId={accountIdStr}
                   teamIds={userTeamIds}
@@ -856,7 +856,7 @@ const BaseballAccountHome: React.FC = () => {
               </Box>
             ) : null}
 
-            <Box sx={{ order: { xs: 8 }, minWidth: 0 }}>
+            <Box sx={{ order: { xs: 9 }, minWidth: 0 }}>
               <PhotoGallerySection
                 title="Photo Gallery"
                 description={`Relive the highlights from ${accountDisplayName}.`}
@@ -876,7 +876,7 @@ const BaseballAccountHome: React.FC = () => {
             </Box>
 
             {showSubmissionPanel ? (
-              <Box sx={{ order: { xs: 9 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 10 }, minWidth: 0 }}>
                 <AccountOptional
                   accountId={accountIdStr}
                   componentId="account.home.photoUploadWidget"
@@ -899,7 +899,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {shouldShowPendingPanel ? (
-              <Box sx={{ order: { xs: 10 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 11 }, minWidth: 0 }}>
                 <PendingPhotoSubmissionsPanel
                   containerSx={{ p: 3, mb: 2 }}
                   contextLabel={accountDisplayName}
@@ -919,11 +919,11 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {shouldShowJoinLeagueNearSponsors ? (
-              <Box sx={{ order: { xs: 11 }, minWidth: 0 }}>{joinLeagueDashboard}</Box>
+              <Box sx={{ order: { xs: 12 }, minWidth: 0 }}>{joinLeagueDashboard}</Box>
             ) : null}
 
             {shouldShowAccountSponsors ? (
-              <Box sx={{ order: { xs: 12 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 13 }, minWidth: 0 }}>
                 <SponsorCard
                   sponsors={accountSponsors}
                   title="Account Sponsors"
@@ -933,7 +933,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {user ? (
-              <Box sx={{ order: { xs: 13 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 14 }, minWidth: 0 }}>
                 <OrganizationsWidget
                   title="Your Other Organizations"
                   showSearch={false}
@@ -966,13 +966,13 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {hasAccountContact ? (
-              <Box sx={{ order: { xs: 5 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 6 }, minWidth: 0 }}>
                 <AccountPollsCard accountId={accountIdStr} isAuthorizedForAccount />
               </Box>
             ) : null}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 2 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 2 }, minWidth: 0, '&:empty': { display: 'none' } }}>
                 <TodayScoreboard
                   accountId={accountIdStr}
                   layout="vertical"
@@ -987,13 +987,13 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 3 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 3 }, minWidth: 0, '&:empty': { display: 'none' } }}>
                 <GameRecapsWidget accountId={accountIdStr} seasonId={currentSeason.id} />
               </Box>
             ) : null}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 4 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 4 }, minWidth: 0, '&:empty': { display: 'none' } }}>
                 <YesterdayScoreboard
                   accountId={accountIdStr}
                   layout="vertical"
@@ -1003,7 +1003,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {leaderLeagues.length > 0 && accountIdStr ? (
-              <Box sx={{ order: { xs: 14 }, minWidth: 0 }}>
+              <Box sx={{ order: { xs: 5 }, minWidth: 0 }}>
                 <LeadersWidget
                   accountId={accountIdStr}
                   seasonId={currentSeasonId}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
@@ -139,6 +139,7 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
     accountType,
     filterType,
     filterDate,
+    timeZone,
     onError: setError,
     mode: 'manage',
   });

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -100,6 +100,7 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
     accountType,
     filterType,
     filterDate,
+    timeZone,
     onError: setError,
   });
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -148,6 +148,7 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     accountType,
     filterType,
     filterDate,
+    timeZone,
     onError: setError,
   });
 

--- a/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
+++ b/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
@@ -178,7 +178,7 @@ describe('CourseDetailView', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
       });
-    });
+    }, 15000);
 
     it('does not call onSave when there are no changes', () => {
       const onSave = vi.fn().mockResolvedValue(undefined);

--- a/draco-nodejs/frontend-next/components/schedule/hooks/scheduleDateHelpers.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/scheduleDateHelpers.ts
@@ -77,16 +77,32 @@ export const computeDateRange = (
   let start: Date;
   let end: Date;
 
+  const localStartOfDay = (): Date => {
+    const value = new Date(filterDate);
+    value.setHours(0, 0, 0, 0);
+    return value;
+  };
+  const localEndOfDay = (): Date => {
+    const value = new Date(filterDate);
+    value.setHours(23, 59, 59, 999);
+    return value;
+  };
+
   switch (filterType) {
     case 'day':
       if (timeZone) {
         start = startOfDayInTimezone(filterDate, timeZone);
         end = endOfDayInTimezone(filterDate, timeZone);
+        // startOfDayInTimezone/endOfDayInTimezone yield Invalid Date for an
+        // unsupported IANA timeZone; fall back to local day bounds so a bad
+        // account timezone can't propagate NaN dates into the range logic.
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+          start = localStartOfDay();
+          end = localEndOfDay();
+        }
       } else {
-        start = new Date(filterDate);
-        start.setHours(0, 0, 0, 0);
-        end = new Date(filterDate);
-        end.setHours(23, 59, 59, 999);
+        start = localStartOfDay();
+        end = localEndOfDay();
       }
       break;
     case 'week':

--- a/draco-nodejs/frontend-next/components/schedule/hooks/scheduleDateHelpers.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/scheduleDateHelpers.ts
@@ -9,6 +9,7 @@ import {
   startOfYear,
 } from 'date-fns';
 import { Game, FilterType } from '@/types/schedule';
+import { endOfDayInTimezone, startOfDayInTimezone } from '../../../utils/dateUtils';
 
 export const sortGamesAscending = (a: Game, b: Game): number => {
   const diff = new Date(a.gameDate).getTime() - new Date(b.gameDate).getTime();
@@ -71,16 +72,22 @@ export const collectGamesForRange = (
 export const computeDateRange = (
   filterType: FilterType,
   filterDate: Date,
+  timeZone?: string,
 ): { startDate: Date; endDate: Date } => {
   let start: Date;
   let end: Date;
 
   switch (filterType) {
     case 'day':
-      start = new Date(filterDate);
-      start.setHours(0, 0, 0, 0);
-      end = new Date(filterDate);
-      end.setHours(23, 59, 59, 999);
+      if (timeZone) {
+        start = startOfDayInTimezone(filterDate, timeZone);
+        end = endOfDayInTimezone(filterDate, timeZone);
+      } else {
+        start = new Date(filterDate);
+        start.setHours(0, 0, 0, 0);
+        end = new Date(filterDate);
+        end.setHours(23, 59, 59, 999);
+      }
       break;
     case 'week':
       start = startOfWeek(filterDate);

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useScheduleData.ts
@@ -29,6 +29,7 @@ interface UseScheduleDataProps {
   accountType?: string;
   filterType: FilterType;
   filterDate: Date;
+  timeZone?: string;
   onError?: (message: string) => void;
   mode?: ScheduleAccessMode;
 }
@@ -101,6 +102,7 @@ export const useScheduleData = ({
   accountType,
   filterType,
   filterDate,
+  timeZone,
   onError,
   mode = 'public',
 }: UseScheduleDataProps): UseScheduleDataReturn => {
@@ -131,7 +133,7 @@ export const useScheduleData = ({
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
-  const { startDate, endDate } = computeDateRange(filterType, filterDate);
+  const { startDate, endDate } = computeDateRange(filterType, filterDate, timeZone);
 
   useEffect(() => {
     gamesCacheRef.current.clear();
@@ -443,7 +445,11 @@ export const useScheduleData = ({
     }
 
     const controller = new AbortController();
-    const { startDate: rangeStart, endDate: rangeEnd } = computeDateRange(filterType, filterDate);
+    const { startDate: rangeStart, endDate: rangeEnd } = computeDateRange(
+      filterType,
+      filterDate,
+      timeZone,
+    );
 
     const runLoadGamesData = async () => {
       try {
@@ -521,7 +527,7 @@ export const useScheduleData = ({
     return () => {
       controller.abort();
     };
-  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate, mode]);
+  }, [authLoading, accountId, apiClient, adapter, filterType, filterDate, timeZone, mode]);
 
   const filteredGames = games;
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useTeamScheduleData.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useTeamScheduleData.ts
@@ -26,6 +26,7 @@ interface UseTeamScheduleDataProps {
   accountType?: string;
   filterType: FilterType;
   filterDate?: Date;
+  timeZone?: string;
   onError?: (message: string) => void;
 }
 
@@ -55,6 +56,7 @@ export const useTeamScheduleData = ({
   accountType,
   filterType,
   filterDate,
+  timeZone,
   onError,
 }: UseTeamScheduleDataProps): UseTeamScheduleDataReturn => {
   const { loading: authLoading } = useAuth();
@@ -80,7 +82,7 @@ export const useTeamScheduleData = ({
   const [latestGameDate, setLatestGameDate] = useState<Date | null>(null);
 
   const referenceDate = filterDate ?? new Date();
-  const { startDate, endDate } = computeDateRange(filterType, referenceDate);
+  const { startDate, endDate } = computeDateRange(filterType, referenceDate, timeZone);
 
   useEffect(() => {
     gamesCacheRef.current.clear();
@@ -200,7 +202,11 @@ export const useTeamScheduleData = ({
 
     const controller = new AbortController();
     const requestCache = gamesRequestCacheRef.current;
-    const { startDate: rangeStart, endDate: rangeEnd } = computeDateRange(filterType, filterDate);
+    const { startDate: rangeStart, endDate: rangeEnd } = computeDateRange(
+      filterType,
+      filterDate,
+      timeZone,
+    );
 
     const runLoadGamesData = async () => {
       try {
@@ -281,6 +287,7 @@ export const useTeamScheduleData = ({
     adapter,
     filterType,
     filterDate,
+    timeZone,
     supportsTeamSchedule,
   ]);
 

--- a/draco-nodejs/frontend-next/components/statistics/LeaderCategoryPanel.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/LeaderCategoryPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from './StatisticsTable';
 import LeaderCard from './LeaderCard';
 import TeamBadges from './TeamBadges';
+import { getLeaderForCard, processLeadersForTable } from './leaderTransforms';
 import type { LeaderCategoryType, LeaderRowType } from '@draco/shared-schemas';
 
 type LeaderRow = LeaderRowType;
@@ -27,53 +28,6 @@ const formatters: Record<string, (value: unknown) => string> = {
 
 const getFormatter = (format: string) => {
   return formatters[format] ?? ((value: unknown) => String(value ?? '0'));
-};
-
-const getLeaderForCard = (leaders: LeaderRow[]): LeaderRow | null => {
-  const firstPlaceEntries = leaders.filter((row) => row.rank === 1 && !row.isTie);
-
-  if (firstPlaceEntries.length === 1) {
-    return firstPlaceEntries[0];
-  }
-
-  if (firstPlaceEntries.length > 1) {
-    return {
-      playerId: 'tie-entry',
-      playerName: `${firstPlaceEntries.length} tied`,
-      teams: [],
-      teamName: '',
-      statValue: firstPlaceEntries[0].statValue,
-      category: firstPlaceEntries[0].category,
-      rank: 1,
-      isTie: true,
-      tieCount: firstPlaceEntries.length,
-    };
-  }
-
-  return null;
-};
-
-const processLeadersForTable = (
-  leaders: LeaderRow[],
-  leaderCard: LeaderRow | null,
-): LeaderRow[] => {
-  const processed = leaders.map((leader) => {
-    if (leader.isTie) {
-      return {
-        ...leader,
-        playerName: `${leader.tieCount} tied`,
-        teamName: '',
-        teams: [],
-      };
-    }
-    return leader;
-  });
-
-  if (leaderCard && !leaderCard.isTie) {
-    return processed.filter((leader) => leader.rank !== 1 || leader.isTie);
-  }
-
-  return processed;
 };
 
 const createLeaderColumns = (

--- a/draco-nodejs/frontend-next/components/statistics/LeadersWidget.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/LeadersWidget.tsx
@@ -144,6 +144,56 @@ const resolveCategoryForType = (
   return categories[0]?.key ?? null;
 };
 
+const tupleKey = (selection: WidgetSelection): string =>
+  `${selection.leagueId}::${selection.statType}::${selection.categoryKey}`;
+
+const shuffle = <T,>(items: T[]): T[] => {
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+};
+
+const enumerateCategoriesForLeague = (
+  leagueId: string,
+  battingCategories: LeaderCategoryType[],
+  pitchingCategories: LeaderCategoryType[],
+): WidgetSelection[] => {
+  const out: WidgetSelection[] = [];
+  for (const category of battingCategories) {
+    out.push({ leagueId, statType: 'batting', categoryKey: category.key });
+  }
+  for (const category of pitchingCategories) {
+    out.push({ leagueId, statType: 'pitching', categoryKey: category.key });
+  }
+  return out;
+};
+
+const buildFallbackOrder = (
+  initial: WidgetSelection,
+  leagues: LeagueOption[],
+  battingCategories: LeaderCategoryType[],
+  pitchingCategories: LeaderCategoryType[],
+): WidgetSelection[] => {
+  const initialKey = tupleKey(initial);
+  const sameLeagueRest = shuffle(
+    enumerateCategoriesForLeague(initial.leagueId, battingCategories, pitchingCategories).filter(
+      (tuple) => tupleKey(tuple) !== initialKey,
+    ),
+  );
+  const otherLeagues = shuffle(leagues.filter((league) => league.id !== initial.leagueId));
+  const otherTuples: WidgetSelection[] = [];
+  for (const league of otherLeagues) {
+    const tuples = shuffle(
+      enumerateCategoriesForLeague(league.id, battingCategories, pitchingCategories),
+    );
+    otherTuples.push(...tuples);
+  }
+  return [initial, ...sameLeagueRest, ...otherTuples];
+};
+
 const buildStatTypeTabSx = (muiTheme: Theme) => ({
   minWidth: 120,
   borderRadius: 2,
@@ -219,6 +269,8 @@ export default function LeadersWidget(props: LeadersWidgetProps) {
   const leagueTabsRef = useRef<HTMLDivElement | null>(null);
   const statTabsRef = useRef<HTMLDivElement | null>(null);
   const categoryTabsRef = useRef<HTMLDivElement | null>(null);
+  const triedSelectionsRef = useRef<Set<string>>(new Set());
+  const fallbackOrderRef = useRef<WidgetSelection[] | null>(null);
 
   const {
     battingCategories,
@@ -229,6 +281,25 @@ export default function LeadersWidget(props: LeadersWidgetProps) {
   const isTeamDataFetchable = !isTeamVariant || Boolean(teamIdFilter);
 
   const initialSelectionQueuedRef = useRef(false);
+
+  const resolvedLeagueIdsKey = resolvedLeagues.map((league) => league.id).join(',');
+  const battingCategoryKeysKey = battingCategories.map((category) => category.key).join(',');
+  const pitchingCategoryKeysKey = pitchingCategories.map((category) => category.key).join(',');
+
+  useEffect(() => {
+    triedSelectionsRef.current = new Set();
+    fallbackOrderRef.current = null;
+    initialSelectionQueuedRef.current = false;
+    setHasAnyLeaders(null);
+    setModel(null);
+    setPendingSelection(null);
+  }, [
+    accountId,
+    seasonIdProp,
+    resolvedLeagueIdsKey,
+    battingCategoryKeysKey,
+    pitchingCategoryKeysKey,
+  ]);
 
   useEffect(() => {
     if (initialSelectionQueuedRef.current || model || pendingSelection || !isTeamDataFetchable) {
@@ -302,40 +373,74 @@ export default function LeadersWidget(props: LeadersWidgetProps) {
 
     const controller = new AbortController();
     setLeadersErrorMessage(null);
-    const selection = pendingSelection;
+
+    const isInitialLoad = hasAnyLeaders === null;
+    const allowFallback = isInitialLoad && !isTeamVariant;
+
+    if (allowFallback && !fallbackOrderRef.current) {
+      fallbackOrderRef.current = buildFallbackOrder(
+        pendingSelection,
+        leaguesProp ?? [],
+        battingCategories,
+        pitchingCategories,
+      );
+    }
 
     const run = async () => {
+      let currentAttempt: WidgetSelection | null = pendingSelection;
+
       try {
-        const leaders = await fetchStatisticalLeaders(
-          accountId,
-          selection.leagueId,
-          selection.categoryKey,
-          {
-            divisionId: divisionId ?? undefined,
-            teamId: isTeamVariant ? (teamIdFilter ?? undefined) : undefined,
-            isHistorical,
-            includeAllGameTypes: undefined,
-            limit: leaderLimit,
-          },
-          { client: apiClient, signal: controller.signal },
-        );
+        while (currentAttempt) {
+          const attempt = currentAttempt;
+          const leaders = await fetchStatisticalLeaders(
+            accountId,
+            attempt.leagueId,
+            attempt.categoryKey,
+            {
+              divisionId: divisionId ?? undefined,
+              teamId: isTeamVariant ? (teamIdFilter ?? undefined) : undefined,
+              isHistorical,
+              includeAllGameTypes: undefined,
+              limit: leaderLimit,
+            },
+            { client: apiClient, signal: controller.signal },
+          );
 
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        setModel({ selection, leaders });
-        setCategoryPreferences((previous) => ({
-          ...previous,
-          [selection.statType]: selection.categoryKey,
-        }));
-        if (leaders.length > 0) {
-          if (!hasAnyLeaders) {
-            setHasAnyLeaders(true);
+          if (controller.signal.aborted) {
+            return;
           }
-        } else if (hasAnyLeaders === null) {
-          setHasAnyLeaders(false);
+
+          if (leaders.length > 0) {
+            setModel({ selection: attempt, leaders });
+            setCategoryPreferences((previous) => ({
+              ...previous,
+              [attempt.statType]: attempt.categoryKey,
+            }));
+            if (!hasAnyLeaders) {
+              setHasAnyLeaders(true);
+            }
+            return;
+          }
+
+          if (!allowFallback) {
+            setModel({ selection: attempt, leaders });
+            setCategoryPreferences((previous) => ({
+              ...previous,
+              [attempt.statType]: attempt.categoryKey,
+            }));
+            if (hasAnyLeaders === null) {
+              setHasAnyLeaders(false);
+            }
+            return;
+          }
+
+          triedSelectionsRef.current.add(tupleKey(attempt));
+          const order = fallbackOrderRef.current ?? [];
+          currentAttempt =
+            order.find((tuple) => !triedSelectionsRef.current.has(tupleKey(tuple))) ?? null;
         }
+
+        setHasAnyLeaders(false);
       } catch (err) {
         if (controller.signal.aborted) {
           return;
@@ -358,12 +463,15 @@ export default function LeadersWidget(props: LeadersWidgetProps) {
   }, [
     accountId,
     apiClient,
+    battingCategories,
     divisionId,
     hasAnyLeaders,
     isHistorical,
     isTeamVariant,
     leaderLimit,
+    leaguesProp,
     pendingSelection,
+    pitchingCategories,
     teamIdFilter,
   ]);
 

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/leaderTransforms.test.ts
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/leaderTransforms.test.ts
@@ -44,7 +44,7 @@ describe('getLeaderForCard', () => {
     ];
     const card = getLeaderForCard(leaders);
     expect(card).toEqual({
-      playerId: 'tie-entry',
+      playerId: '0',
       playerName: '3 tied',
       teams: [],
       teamName: '',

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/leaderTransforms.test.ts
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/leaderTransforms.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import type { LeaderRowType } from '@draco/shared-schemas';
+import { getLeaderForCard, processLeadersForTable } from '../leaderTransforms';
+
+const makePlayerRow = (overrides: Partial<LeaderRowType> = {}): LeaderRowType => ({
+  playerId: '1',
+  playerName: 'Test Player',
+  teams: ['Test Team'],
+  teamName: 'Test Team',
+  statValue: 1.0,
+  category: 'avg',
+  rank: 1,
+  ...overrides,
+});
+
+const makeTieIndicator = (overrides: Partial<LeaderRowType> = {}): LeaderRowType => ({
+  playerId: '0',
+  playerName: '',
+  teamName: '',
+  statValue: 1.0,
+  category: 'avg',
+  rank: 1,
+  isTie: true,
+  tieCount: 8,
+  ...overrides,
+});
+
+describe('getLeaderForCard', () => {
+  it('returns null when no rank-1 entries exist', () => {
+    expect(getLeaderForCard([])).toBeNull();
+    expect(getLeaderForCard([makePlayerRow({ rank: 2 })])).toBeNull();
+  });
+
+  it('returns the single rank-1 player when only one leader exists', () => {
+    const leader = makePlayerRow({ playerName: 'Solo Leader' });
+    expect(getLeaderForCard([leader])).toEqual(leader);
+  });
+
+  it('synthesizes a tie card when multiple individual players share rank 1', () => {
+    const leaders = [
+      makePlayerRow({ playerId: '1', playerName: 'P1', statValue: 3, category: 'rbi' }),
+      makePlayerRow({ playerId: '2', playerName: 'P2', statValue: 3, category: 'rbi' }),
+      makePlayerRow({ playerId: '3', playerName: 'P3', statValue: 3, category: 'rbi' }),
+    ];
+    const card = getLeaderForCard(leaders);
+    expect(card).toEqual({
+      playerId: 'tie-entry',
+      playerName: '3 tied',
+      teams: [],
+      teamName: '',
+      statValue: 3,
+      category: 'rbi',
+      rank: 1,
+      isTie: true,
+      tieCount: 3,
+    });
+  });
+
+  it('promotes a backend-supplied rank-1 isTie indicator to the leader card', () => {
+    const indicator = makeTieIndicator({ tieCount: 8, statValue: 1.0, category: 'avg' });
+    expect(getLeaderForCard([indicator])).toEqual(indicator);
+  });
+
+  it('promotes a 50-way tie indicator to the leader card', () => {
+    const indicator = makeTieIndicator({ tieCount: 50, statValue: 0, category: 'hr' });
+    const card = getLeaderForCard([indicator]);
+    expect(card?.isTie).toBe(true);
+    expect(card?.tieCount).toBe(50);
+    expect(card?.statValue).toBe(0);
+  });
+});
+
+describe('processLeadersForTable', () => {
+  it('returns leaders unchanged when no leader card is set', () => {
+    const leaders = [makePlayerRow({ rank: 2 })];
+    expect(processLeadersForTable(leaders, null)).toEqual(leaders);
+  });
+
+  it('removes the rank-1 player row when a single-player card is shown', () => {
+    const leaders = [
+      makePlayerRow({ playerId: '1', rank: 1 }),
+      makePlayerRow({ playerId: '2', rank: 2 }),
+    ];
+    const card = leaders[0];
+    const result = processLeadersForTable(leaders, card);
+    expect(result).toHaveLength(1);
+    expect(result[0].playerId).toBe('2');
+  });
+
+  it('keeps individual rank-1 rows when the tie card is synthesized from real players', () => {
+    const leaders = [
+      makePlayerRow({ playerId: '1', rank: 1, statValue: 3, category: 'rbi' }),
+      makePlayerRow({ playerId: '2', rank: 1, statValue: 3, category: 'rbi' }),
+      makePlayerRow({ playerId: '3', rank: 1, statValue: 3, category: 'rbi' }),
+      { ...makeTieIndicator({ rank: 4, tieCount: 4, statValue: 2, category: 'rbi' }) },
+    ];
+    const card = getLeaderForCard(leaders);
+    const result = processLeadersForTable(leaders, card);
+    expect(result.map((row) => row.playerId)).toEqual(['1', '2', '3', '0']);
+    expect(result[3].playerName).toBe('4 tied');
+  });
+
+  it('hides the rank-1 tie indicator row from the table when promoted to the card', () => {
+    const indicator = makeTieIndicator({ tieCount: 8 });
+    const leaders = [indicator];
+    const card = getLeaderForCard(leaders);
+    const result = processLeadersForTable(leaders, card);
+    expect(result).toEqual([]);
+  });
+
+  it('reformats lower-ranked isTie rows with a "N tied" label', () => {
+    const leaders = [
+      makePlayerRow({ playerId: '1', rank: 1 }),
+      makeTieIndicator({ rank: 3, tieCount: 4, statValue: 2 }),
+    ];
+    const result = processLeadersForTable(leaders, leaders[0]);
+    expect(result).toHaveLength(1);
+    expect(result[0].playerName).toBe('4 tied');
+  });
+});

--- a/draco-nodejs/frontend-next/components/statistics/leaderTransforms.ts
+++ b/draco-nodejs/frontend-next/components/statistics/leaderTransforms.ts
@@ -1,0 +1,57 @@
+import type { LeaderRowType } from '@draco/shared-schemas';
+
+export const getLeaderForCard = (leaders: LeaderRowType[]): LeaderRowType | null => {
+  const firstPlaceEntries = leaders.filter((row) => row.rank === 1 && !row.isTie);
+
+  if (firstPlaceEntries.length === 1) {
+    return firstPlaceEntries[0];
+  }
+
+  if (firstPlaceEntries.length > 1) {
+    return {
+      playerId: 'tie-entry',
+      playerName: `${firstPlaceEntries.length} tied`,
+      teams: [],
+      teamName: '',
+      statValue: firstPlaceEntries[0].statValue,
+      category: firstPlaceEntries[0].category,
+      rank: 1,
+      isTie: true,
+      tieCount: firstPlaceEntries.length,
+    };
+  }
+
+  const tieIndicator = leaders.find((row) => row.rank === 1 && row.isTie);
+  if (tieIndicator) {
+    return tieIndicator;
+  }
+
+  return null;
+};
+
+export const processLeadersForTable = (
+  leaders: LeaderRowType[],
+  leaderCard: LeaderRowType | null,
+): LeaderRowType[] => {
+  const processed = leaders.map((leader) => {
+    if (leader.isTie) {
+      return {
+        ...leader,
+        playerName: `${leader.tieCount} tied`,
+        teamName: '',
+        teams: [],
+      };
+    }
+    return leader;
+  });
+
+  if (!leaderCard) {
+    return processed;
+  }
+
+  if (leaderCard.isTie) {
+    return processed.filter((leader) => !(leader.rank === 1 && leader.isTie));
+  }
+
+  return processed.filter((leader) => leader.rank !== 1 || leader.isTie);
+};

--- a/draco-nodejs/frontend-next/components/statistics/leaderTransforms.ts
+++ b/draco-nodejs/frontend-next/components/statistics/leaderTransforms.ts
@@ -9,7 +9,7 @@ export const getLeaderForCard = (leaders: LeaderRowType[]): LeaderRowType | null
 
   if (firstPlaceEntries.length > 1) {
     return {
-      playerId: 'tie-entry',
+      playerId: '0',
       playerName: `${firstPlaceEntries.length} tied`,
       teams: [],
       teamName: '',

--- a/draco-nodejs/frontend-next/utils/dateUtils.ts
+++ b/draco-nodejs/frontend-next/utils/dateUtils.ts
@@ -35,23 +35,28 @@ const getDateTimePartsInTimezone = (
     return null;
   }
 
-  const formatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  });
+  let parts: Record<string, string>;
+  try {
+    const formatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
 
-  const parts = formatter.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
-    if (part.type !== 'literal') {
-      acc[part.type] = part.value;
-    }
-    return acc;
-  }, {});
+    parts = formatter.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+      if (part.type !== 'literal') {
+        acc[part.type] = part.value;
+      }
+      return acc;
+    }, {});
+  } catch {
+    return null;
+  }
 
   const requiredParts = ['year', 'month', 'day', 'hour', 'minute', 'second'] as const;
   const hasAllParts = requiredParts.every((part) => parts[part] !== undefined);

--- a/draco-nodejs/frontend-next/utils/dateUtils.ts
+++ b/draco-nodejs/frontend-next/utils/dateUtils.ts
@@ -334,6 +334,41 @@ export function isSameDayInTimezone(
   return partsA.year === partsB.year && partsA.month === partsB.month && partsA.day === partsB.day;
 }
 
+export function startOfDayInTimezone(date: Date, timeZone: string): Date {
+  if (Number.isNaN(date.getTime())) {
+    return new Date(NaN);
+  }
+  return convertZonedPartsToUTCDate(
+    {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      hour: 0,
+      minute: 0,
+      second: 0,
+    },
+    timeZone,
+  );
+}
+
+export function endOfDayInTimezone(date: Date, timeZone: string): Date {
+  if (Number.isNaN(date.getTime())) {
+    return new Date(NaN);
+  }
+  const lastSecond = convertZonedPartsToUTCDate(
+    {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      hour: 23,
+      minute: 59,
+      second: 59,
+    },
+    timeZone,
+  );
+  return new Date(lastSecond.getTime() + 999);
+}
+
 /**
  * Checks if a date value is valid
  * @param dateValue - Date value to validate

--- a/draco-nodejs/frontend-next/utils/dateUtils.ts
+++ b/draco-nodejs/frontend-next/utils/dateUtils.ts
@@ -338,11 +338,15 @@ export function startOfDayInTimezone(date: Date, timeZone: string): Date {
   if (Number.isNaN(date.getTime())) {
     return new Date(NaN);
   }
+  const zonedParts = getDateTimePartsInTimezone(date, timeZone);
+  if (!zonedParts) {
+    return new Date(NaN);
+  }
   return convertZonedPartsToUTCDate(
     {
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
+      year: zonedParts.year,
+      month: zonedParts.month,
+      day: zonedParts.day,
       hour: 0,
       minute: 0,
       second: 0,
@@ -355,11 +359,15 @@ export function endOfDayInTimezone(date: Date, timeZone: string): Date {
   if (Number.isNaN(date.getTime())) {
     return new Date(NaN);
   }
+  const zonedParts = getDateTimePartsInTimezone(date, timeZone);
+  if (!zonedParts) {
+    return new Date(NaN);
+  }
   const lastSecond = convertZonedPartsToUTCDate(
     {
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
+      year: zonedParts.year,
+      month: zonedParts.month,
+      day: zonedParts.day,
       hour: 23,
       minute: 59,
       second: 59,

--- a/draco-nodejs/shared/shared-schemas/statistics.ts
+++ b/draco-nodejs/shared/shared-schemas/statistics.ts
@@ -149,7 +149,7 @@ export const BattingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
   minAB: z
     .string()
     .transform((val) => parseInt(val))
-    .default(10),
+    .default(0),
   sortField: z.string().default('avg'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
 });
@@ -160,7 +160,7 @@ export const PitchingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
   minIP: z
     .string()
     .transform((val) => parseInt(val))
-    .default(1),
+    .default(0),
   sortField: z.string().default('era'),
   sortOrder: z.enum(['asc', 'desc']).default('asc'),
 });


### PR DESCRIPTION
Make schedule date range calculations timezone-aware by adding startOfDayInTimezone/endOfDayInTimezone helpers and threading an optional timeZone through Schedule components and hooks (useScheduleData, useTeamScheduleData, computeDateRange). Update effect dependencies to include timeZone. Change statistics defaults for minAB/minIP from 10/1 to 0 in shared schemas and OpenAPI (JSON/YAML). Extract leader card/table logic into components/statistics/leaderTransforms.ts with unit tests and refactor LeaderCategoryPanel to use the new helpers.

## Shared-schemas modification (maintainer-approved)

This PR edits `draco-nodejs/shared/shared-schemas/statistics.ts` to relax the `minAB`/`minIP` defaults from `10`/`1` to `0`, so leader views display all players by default. This is an intentional maintainer-approved change. `pnpm sync:api` was run; the regenerated OpenAPI JSON/YAML are included in the same commit.