### PR TITLE
Add waiver CSV export endpoints & support

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -48247,6 +48247,200 @@
         }
       }
     },
+    "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/export": {
+      "get": {
+        "description": "Export team waiver roster to CSV file (only players with submitted waiver and email)",
+        "summary": "Export team waivers",
+        "operationId": "exportTeamWaivers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Exports"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/export": {
+      "get": {
+        "description": "Export league waiver roster to CSV file (only players with submitted waiver and email, ordered by team)",
+        "summary": "Export league waivers",
+        "operationId": "exportLeagueWaivers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Exports"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "leagueSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export": {
       "get": {
         "description": "Export team roster to CSV file",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -34320,11 +34320,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalServerError"
-  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export:
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/export:
     get:
-      description: Export team roster to CSV file
-      summary: Export team roster
-      operationId: exportTeamRoster
+      description: Export team waiver roster to CSV file (only players with submitted
+        waiver and email)
+      summary: Export team waivers
+      operationId: exportTeamWaivers
       security:
         - bearerAuth: []
       tags:
@@ -34358,6 +34359,101 @@ paths:
               schema:
                 type: string
                 format: binary
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/export:
+    get:
+      description: Export league waiver roster to CSV file (only players with
+        submitted waiver and email, ordered by team)
+      summary: Export league waivers
+      operationId: exportLeagueWaivers
+      security:
+        - bearerAuth: []
+      tags:
+        - Exports
+      parameters:
+        - *a14
+        - *a15
+        - name: leagueSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: CSV file export
+          content:
+            text/csv: *a16
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export:
+    get:
+      description: Export team roster to CSV file
+      summary: Export team roster
+      operationId: exportTeamRoster
+      security:
+        - bearerAuth: []
+      tags:
+        - Exports
+      parameters:
+        - *a14
+        - *a15
+        - name: teamSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: CSV file export
+          content:
+            text/csv: *a16
         "401":
           description: Authentication required
           content:

--- a/draco-nodejs/backend/src/openapi/paths/exports/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/exports/index.ts
@@ -52,6 +52,48 @@ export const registerExportsEndpoints = ({ registry, schemaRefs }: RegisterConte
 
   registry.registerPath({
     method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/export',
+    description:
+      'Export team waiver roster to CSV file (only players with submitted waiver and email)',
+    summary: 'Export team waivers',
+    operationId: 'exportTeamWaivers',
+    security: [{ bearerAuth: [] }],
+    tags: ['Exports'],
+    parameters: [
+      ...pathParams,
+      {
+        name: 'teamSeasonId',
+        in: 'path' as const,
+        required: true,
+        schema: { type: 'string' as const, format: 'number' },
+      },
+    ],
+    responses: csvResponse,
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/export',
+    description:
+      'Export league waiver roster to CSV file (only players with submitted waiver and email, ordered by team)',
+    summary: 'Export league waivers',
+    operationId: 'exportLeagueWaivers',
+    security: [{ bearerAuth: [] }],
+    tags: ['Exports'],
+    parameters: [
+      ...pathParams,
+      {
+        name: 'leagueSeasonId',
+        in: 'path' as const,
+        required: true,
+        schema: { type: 'string' as const, format: 'number' },
+      },
+    ],
+    responses: csvResponse,
+  });
+
+  registry.registerPath({
+    method: 'get',
     path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export',
     description: 'Export team roster to CSV file',
     summary: 'Export team roster',

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaManagerRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaManagerRepository.ts
@@ -8,6 +8,7 @@ import {
   dbSeasonManagerWithRelations,
   dbTeamManagerWithContact,
 } from '../types/dbTypes.js';
+import { NotFoundError } from '../../utils/customErrors.js';
 
 export class PrismaManagerRepository implements IManagerRepository {
   constructor(private readonly prisma: PrismaClient) {}
@@ -193,21 +194,49 @@ export class PrismaManagerRepository implements IManagerRepository {
     },
   } as const;
 
-  async findLeagueManagersForExport(leagueSeasonId: bigint): Promise<dbManagerExportData[]> {
-    return this.prisma.teamseasonmanager.findMany({
+  async findLeagueManagersForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; managers: dbManagerExportData[] }> {
+    const leagueSeason = await this.prisma.leagueseason.findFirst({
+      where: {
+        id: leagueSeasonId,
+        seasonid: seasonId,
+        league: { accountid: accountId },
+      },
+      select: { league: { select: { name: true } } },
+    });
+
+    if (!leagueSeason) {
+      throw new NotFoundError('League season not found');
+    }
+
+    const managers = await this.prisma.teamseasonmanager.findMany({
       where: {
         teamsseason: { leagueseasonid: leagueSeasonId },
       },
       select: this.managerExportSelect,
       orderBy: [{ contacts: { lastname: 'asc' } }, { contacts: { firstname: 'asc' } }],
     });
+
+    return { leagueName: leagueSeason.league.name, managers };
   }
 
   async findSeasonManagersForExport(
-    seasonId: bigint,
     accountId: bigint,
-  ): Promise<dbManagerExportData[]> {
-    return this.prisma.teamseasonmanager.findMany({
+    seasonId: bigint,
+  ): Promise<{ seasonName: string; managers: dbManagerExportData[] }> {
+    const season = await this.prisma.season.findFirst({
+      where: { id: seasonId, accountid: accountId },
+      select: { name: true },
+    });
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const managers = await this.prisma.teamseasonmanager.findMany({
       where: {
         teamsseason: {
           leagueseason: {
@@ -219,5 +248,7 @@ export class PrismaManagerRepository implements IManagerRepository {
       select: this.managerExportSelect,
       orderBy: [{ contacts: { lastname: 'asc' } }, { contacts: { firstname: 'asc' } }],
     });
+
+    return { seasonName: season.name, managers };
   }
 }

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
@@ -237,35 +237,41 @@ export class PrismaRosterRepository implements IRosterRepository {
     }));
   }
 
-  private readonly exportSelect = {
-    playerid: true,
-    roster: {
-      select: {
-        contacts: {
-          select: {
-            firstname: true,
-            lastname: true,
-            middlename: true,
-            email: true,
-            streetaddress: true,
-            city: true,
-            state: true,
-            zip: true,
+  private buildExportSelect(seasonId: bigint) {
+    return {
+      playerid: true,
+      roster: {
+        select: {
+          contacts: {
+            select: {
+              firstname: true,
+              lastname: true,
+              middlename: true,
+              email: true,
+              streetaddress: true,
+              city: true,
+              state: true,
+              zip: true,
+            },
           },
-        },
-        rosterseason: {
-          select: {
-            inactive: true,
-            submittedwaiver: true,
-            teamsseason: {
-              select: {
-                name: true,
-                leagueseason: {
-                  select: {
-                    seasonid: true,
-                    league: {
-                      select: {
-                        name: true,
+          rosterseason: {
+            where: {
+              inactive: false,
+              teamsseason: { leagueseason: { seasonid: seasonId } },
+            },
+            select: {
+              inactive: true,
+              submittedwaiver: true,
+              teamsseason: {
+                select: {
+                  name: true,
+                  leagueseason: {
+                    select: {
+                      seasonid: true,
+                      league: {
+                        select: {
+                          name: true,
+                        },
                       },
                     },
                   },
@@ -275,8 +281,8 @@ export class PrismaRosterRepository implements IRosterRepository {
           },
         },
       },
-    },
-  } as const;
+    } as const;
+  }
 
   async findRosterMembersForExport(
     teamSeasonId: bigint,
@@ -299,7 +305,7 @@ export class PrismaRosterRepository implements IRosterRepository {
         teamseasonid: teamSeasonId,
         inactive: false,
       },
-      select: this.exportSelect,
+      select: this.buildExportSelect(seasonId),
       orderBy: [
         { roster: { contacts: { lastname: 'asc' } } },
         { roster: { contacts: { firstname: 'asc' } } },
@@ -332,7 +338,7 @@ export class PrismaRosterRepository implements IRosterRepository {
         },
         inactive: false,
       },
-      select: this.exportSelect,
+      select: this.buildExportSelect(seasonId),
       orderBy: [
         { roster: { contacts: { lastname: 'asc' } } },
         { roster: { contacts: { firstname: 'asc' } } },
@@ -366,7 +372,7 @@ export class PrismaRosterRepository implements IRosterRepository {
         },
         inactive: false,
       },
-      select: this.exportSelect,
+      select: this.buildExportSelect(seasonId),
       orderBy: [
         { roster: { contacts: { lastname: 'asc' } } },
         { roster: { contacts: { firstname: 'asc' } } },

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
@@ -239,7 +239,6 @@ export class PrismaRosterRepository implements IRosterRepository {
 
   private readonly exportSelect = {
     playerid: true,
-    submittedwaiver: true,
     roster: {
       select: {
         contacts: {
@@ -257,6 +256,7 @@ export class PrismaRosterRepository implements IRosterRepository {
         rosterseason: {
           select: {
             inactive: true,
+            submittedwaiver: true,
             teamsseason: {
               select: {
                 name: true,
@@ -308,22 +308,24 @@ export class PrismaRosterRepository implements IRosterRepository {
   }
 
   async findLeagueRosterForExport(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-  ): Promise<dbRosterExportData[]> {
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbRosterExportData[] }> {
     const leagueSeason = await this.prisma.leagueseason.findFirst({
       where: {
         id: leagueSeasonId,
         seasonid: seasonId,
+        league: { accountid: accountId },
       },
-      select: { id: true },
+      select: { league: { select: { name: true } } },
     });
 
     if (!leagueSeason) {
-      throw new NotFoundError('League season not found or does not belong to the specified season');
+      throw new NotFoundError('League season not found');
     }
 
-    return this.prisma.rosterseason.findMany({
+    const members = await this.prisma.rosterseason.findMany({
       where: {
         teamsseason: {
           leagueseasonid: leagueSeasonId,
@@ -337,13 +339,24 @@ export class PrismaRosterRepository implements IRosterRepository {
       ],
       distinct: ['playerid'],
     });
+
+    return { leagueName: leagueSeason.league.name, members };
   }
 
   async findSeasonRosterForExport(
-    seasonId: bigint,
     accountId: bigint,
-  ): Promise<dbRosterExportData[]> {
-    return this.prisma.rosterseason.findMany({
+    seasonId: bigint,
+  ): Promise<{ seasonName: string; members: dbRosterExportData[] }> {
+    const season = await this.prisma.season.findFirst({
+      where: { id: seasonId, accountid: accountId },
+      select: { name: true },
+    });
+
+    if (!season) {
+      throw new NotFoundError('Season not found');
+    }
+
+    const members = await this.prisma.rosterseason.findMany({
       where: {
         teamsseason: {
           leagueseason: {
@@ -360,6 +373,8 @@ export class PrismaRosterRepository implements IRosterRepository {
       ],
       distinct: ['playerid'],
     });
+
+    return { seasonName: season.name, members };
   }
 
   private readonly waiverExportSelect = {
@@ -388,22 +403,26 @@ export class PrismaRosterRepository implements IRosterRepository {
   } as const;
 
   async findTeamWaiverRosterForExport(
-    teamSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-  ): Promise<dbWaiverExportData[]> {
+    teamSeasonId: bigint,
+  ): Promise<{ teamName: string; members: dbWaiverExportData[] }> {
     const teamSeason = await this.prisma.teamsseason.findFirst({
       where: {
         id: teamSeasonId,
-        leagueseason: { seasonid: seasonId },
+        leagueseason: {
+          seasonid: seasonId,
+          league: { accountid: accountId },
+        },
       },
-      select: { id: true },
+      select: { name: true },
     });
 
     if (!teamSeason) {
-      throw new NotFoundError('Team season not found or does not belong to the specified season');
+      throw new NotFoundError('Team season not found');
     }
 
-    return this.prisma.rosterseason.findMany({
+    const members = await this.prisma.rosterseason.findMany({
       where: {
         teamseasonid: teamSeasonId,
         inactive: false,
@@ -420,25 +439,29 @@ export class PrismaRosterRepository implements IRosterRepository {
         { roster: { contacts: { firstname: 'asc' } } },
       ],
     });
+
+    return { teamName: teamSeason.name, members };
   }
 
   async findLeagueWaiverRosterForExport(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-  ): Promise<dbWaiverExportData[]> {
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbWaiverExportData[] }> {
     const leagueSeason = await this.prisma.leagueseason.findFirst({
       where: {
         id: leagueSeasonId,
         seasonid: seasonId,
+        league: { accountid: accountId },
       },
-      select: { id: true },
+      select: { league: { select: { name: true } } },
     });
 
     if (!leagueSeason) {
-      throw new NotFoundError('League season not found or does not belong to the specified season');
+      throw new NotFoundError('League season not found');
     }
 
-    return this.prisma.rosterseason.findMany({
+    const members = await this.prisma.rosterseason.findMany({
       where: {
         teamsseason: { leagueseasonid: leagueSeasonId },
         inactive: false,
@@ -456,5 +479,7 @@ export class PrismaRosterRepository implements IRosterRepository {
         { roster: { contacts: { firstname: 'asc' } } },
       ],
     });
+
+    return { leagueName: leagueSeason.league.name, members };
   }
 }

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
@@ -6,6 +6,7 @@ import {
   dbRosterPlayer,
   dbRosterSeason,
   dbRosterSeasonContactReference,
+  dbWaiverExportData,
 } from '../types/dbTypes.js';
 import { NotFoundError } from '../../utils/customErrors.js';
 
@@ -238,6 +239,7 @@ export class PrismaRosterRepository implements IRosterRepository {
 
   private readonly exportSelect = {
     playerid: true,
+    submittedwaiver: true,
     roster: {
       select: {
         contacts: {
@@ -252,10 +254,24 @@ export class PrismaRosterRepository implements IRosterRepository {
             zip: true,
           },
         },
-        playerseasonaffiliationdues: {
+        rosterseason: {
           select: {
-            affiliationduespaid: true,
-            seasonid: true,
+            inactive: true,
+            teamsseason: {
+              select: {
+                name: true,
+                leagueseason: {
+                  select: {
+                    seasonid: true,
+                    league: {
+                      select: {
+                        name: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
           },
         },
       },
@@ -343,6 +359,102 @@ export class PrismaRosterRepository implements IRosterRepository {
         { roster: { contacts: { firstname: 'asc' } } },
       ],
       distinct: ['playerid'],
+    });
+  }
+
+  private readonly waiverExportSelect = {
+    submittedwaiver: true,
+    teamsseason: {
+      select: {
+        name: true,
+      },
+    },
+    roster: {
+      select: {
+        contacts: {
+          select: {
+            firstname: true,
+            lastname: true,
+            middlename: true,
+            email: true,
+            streetaddress: true,
+            city: true,
+            state: true,
+            zip: true,
+          },
+        },
+      },
+    },
+  } as const;
+
+  async findTeamWaiverRosterForExport(
+    teamSeasonId: bigint,
+    seasonId: bigint,
+  ): Promise<dbWaiverExportData[]> {
+    const teamSeason = await this.prisma.teamsseason.findFirst({
+      where: {
+        id: teamSeasonId,
+        leagueseason: { seasonid: seasonId },
+      },
+      select: { id: true },
+    });
+
+    if (!teamSeason) {
+      throw new NotFoundError('Team season not found or does not belong to the specified season');
+    }
+
+    return this.prisma.rosterseason.findMany({
+      where: {
+        teamseasonid: teamSeasonId,
+        inactive: false,
+        submittedwaiver: true,
+        roster: {
+          contacts: {
+            email: { not: null },
+          },
+        },
+      },
+      select: this.waiverExportSelect,
+      orderBy: [
+        { roster: { contacts: { lastname: 'asc' } } },
+        { roster: { contacts: { firstname: 'asc' } } },
+      ],
+    });
+  }
+
+  async findLeagueWaiverRosterForExport(
+    leagueSeasonId: bigint,
+    seasonId: bigint,
+  ): Promise<dbWaiverExportData[]> {
+    const leagueSeason = await this.prisma.leagueseason.findFirst({
+      where: {
+        id: leagueSeasonId,
+        seasonid: seasonId,
+      },
+      select: { id: true },
+    });
+
+    if (!leagueSeason) {
+      throw new NotFoundError('League season not found or does not belong to the specified season');
+    }
+
+    return this.prisma.rosterseason.findMany({
+      where: {
+        teamsseason: { leagueseasonid: leagueSeasonId },
+        inactive: false,
+        submittedwaiver: true,
+        roster: {
+          contacts: {
+            email: { not: null },
+          },
+        },
+      },
+      select: this.waiverExportSelect,
+      orderBy: [
+        { teamsseason: { name: 'asc' } },
+        { roster: { contacts: { lastname: 'asc' } } },
+        { roster: { contacts: { firstname: 'asc' } } },
+      ],
     });
   }
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/IManagerRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IManagerRepository.ts
@@ -22,6 +22,13 @@ export interface IManagerRepository extends IBaseRepository<teamseasonmanager> {
   findManagersForTeams(teamSeasonIds: bigint[]): Promise<dbTeamManagerWithContact[]>;
   createTeamManager(teamSeasonId: bigint, contactId: bigint): Promise<dbTeamManagerWithContact>;
   findTeamManager(teamSeasonId: bigint, contactId: bigint): Promise<teamseasonmanager | null>;
-  findLeagueManagersForExport(leagueSeasonId: bigint): Promise<dbManagerExportData[]>;
-  findSeasonManagersForExport(seasonId: bigint, accountId: bigint): Promise<dbManagerExportData[]>;
+  findLeagueManagersForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; managers: dbManagerExportData[] }>;
+  findSeasonManagersForExport(
+    accountId: bigint,
+    seasonId: bigint,
+  ): Promise<{ seasonName: string; managers: dbManagerExportData[] }>;
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
@@ -4,6 +4,7 @@ import {
   dbRosterPlayer,
   dbRosterSeason,
   dbRosterSeasonContactReference,
+  dbWaiverExportData,
 } from '../types/dbTypes.js';
 
 export interface IRosterRepository {
@@ -63,4 +64,12 @@ export interface IRosterRepository {
     seasonId: bigint,
   ): Promise<dbRosterExportData[]>;
   findSeasonRosterForExport(seasonId: bigint, accountId: bigint): Promise<dbRosterExportData[]>;
+  findTeamWaiverRosterForExport(
+    teamSeasonId: bigint,
+    seasonId: bigint,
+  ): Promise<dbWaiverExportData[]>;
+  findLeagueWaiverRosterForExport(
+    leagueSeasonId: bigint,
+    seasonId: bigint,
+  ): Promise<dbWaiverExportData[]>;
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
@@ -60,16 +60,22 @@ export interface IRosterRepository {
   hasGameStats(rosterMemberId: bigint): Promise<boolean>;
   findRosterMembersForExport(teamSeasonId: bigint, seasonId: bigint): Promise<dbRosterExportData[]>;
   findLeagueRosterForExport(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-  ): Promise<dbRosterExportData[]>;
-  findSeasonRosterForExport(seasonId: bigint, accountId: bigint): Promise<dbRosterExportData[]>;
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbRosterExportData[] }>;
+  findSeasonRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
+  ): Promise<{ seasonName: string; members: dbRosterExportData[] }>;
   findTeamWaiverRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
     teamSeasonId: bigint,
-    seasonId: bigint,
-  ): Promise<dbWaiverExportData[]>;
+  ): Promise<{ teamName: string; members: dbWaiverExportData[] }>;
   findLeagueWaiverRosterForExport(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-  ): Promise<dbWaiverExportData[]>;
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbWaiverExportData[] }>;
 }

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -2405,7 +2405,6 @@ export type dbHofClassSummary = {
 export type dbRosterExportData = Prisma.rosterseasonGetPayload<{
   select: {
     playerid: true;
-    submittedwaiver: true;
     roster: {
       select: {
         contacts: {
@@ -2423,6 +2422,7 @@ export type dbRosterExportData = Prisma.rosterseasonGetPayload<{
         rosterseason: {
           select: {
             inactive: true;
+            submittedwaiver: true;
             teamsseason: {
               select: {
                 name: true;

--- a/draco-nodejs/backend/src/repositories/types/dbTypes.ts
+++ b/draco-nodejs/backend/src/repositories/types/dbTypes.ts
@@ -2405,6 +2405,7 @@ export type dbHofClassSummary = {
 export type dbRosterExportData = Prisma.rosterseasonGetPayload<{
   select: {
     playerid: true;
+    submittedwaiver: true;
     roster: {
       select: {
         contacts: {
@@ -2419,10 +2420,51 @@ export type dbRosterExportData = Prisma.rosterseasonGetPayload<{
             zip: true;
           };
         };
-        playerseasonaffiliationdues: {
+        rosterseason: {
           select: {
-            affiliationduespaid: true;
-            seasonid: true;
+            inactive: true;
+            teamsseason: {
+              select: {
+                name: true;
+                leagueseason: {
+                  select: {
+                    seasonid: true;
+                    league: {
+                      select: {
+                        name: true;
+                      };
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}>;
+
+export type dbWaiverExportData = Prisma.rosterseasonGetPayload<{
+  select: {
+    submittedwaiver: true;
+    teamsseason: {
+      select: {
+        name: true;
+      };
+    };
+    roster: {
+      select: {
+        contacts: {
+          select: {
+            firstname: true;
+            lastname: true;
+            middlename: true;
+            email: true;
+            streetaddress: true;
+            city: true;
+            state: true;
+            zip: true;
           };
         };
       };

--- a/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
@@ -80,6 +80,8 @@ const csvExportServiceMock = {
   exportSeasonRoster: vi.fn(),
   exportLeagueManagers: vi.fn(),
   exportSeasonManagers: vi.fn(),
+  exportTeamWaivers: vi.fn(),
+  exportLeagueWaivers: vi.fn(),
 };
 
 let app: Express;
@@ -257,6 +259,50 @@ describe('Exports routes', () => {
     });
   });
 
+  describe('GET /teams/:teamSeasonId/roster/waivers/export', () => {
+    it('exports team waivers as CSV', async () => {
+      const csvBuffer = Buffer.from('Full Name,Email,Team\nJohn Doe,john@example.com,Tigers');
+      csvExportServiceMock.exportTeamWaivers.mockResolvedValue({
+        buffer: csvBuffer,
+        fileName: 'tigers-waivers.csv',
+      });
+
+      const { res } = await runRoute('get', '/teams/:teamSeasonId/roster/waivers/export', {
+        params: { accountId: '1', seasonId: '1', teamSeasonId: '75' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toBe('text/csv');
+      expect(res.headers['Content-Disposition']).toContain('tigers-waivers.csv');
+      expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportTeamWaivers).toHaveBeenCalledWith(1n, 1n, 75n);
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+  });
+
+  describe('GET /leagues/:leagueSeasonId/roster/waivers/export', () => {
+    it('exports league waivers as CSV', async () => {
+      const csvBuffer = Buffer.from('Full Name,Email,Team\nJane Smith,jane@example.com,Panthers');
+      csvExportServiceMock.exportLeagueWaivers.mockResolvedValue({
+        buffer: csvBuffer,
+        fileName: 'spring-league-waivers.csv',
+      });
+
+      const { res } = await runRoute('get', '/leagues/:leagueSeasonId/roster/waivers/export', {
+        params: { accountId: '1', seasonId: '1', leagueSeasonId: '50' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toBe('text/csv');
+      expect(res.headers['Content-Disposition']).toContain('spring-league-waivers.csv');
+      expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportLeagueWaivers).toHaveBeenCalledWith(1n, 1n, 50n);
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+  });
+
   describe('GET /leagues/:leagueSeasonId/managers/export', () => {
     it('exports league managers as CSV', async () => {
       const csvBuffer = Buffer.from('Full Name,Email\nJane Smith,jane@example.com');
@@ -324,6 +370,34 @@ describe('Exports routes', () => {
   });
 
   describe('authorization', () => {
+    it('requires manage-users permission for team waivers export', async () => {
+      csvExportServiceMock.exportTeamWaivers.mockResolvedValue({
+        buffer: Buffer.from(''),
+        fileName: 'test.csv',
+      });
+
+      await runRoute('get', '/teams/:teamSeasonId/roster/waivers/export', {
+        params: { accountId: '1', seasonId: '1', teamSeasonId: '75' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+
+    it('requires manage-users permission for league waivers export', async () => {
+      csvExportServiceMock.exportLeagueWaivers.mockResolvedValue({
+        buffer: Buffer.from(''),
+        fileName: 'test.csv',
+      });
+
+      await runRoute('get', '/leagues/:leagueSeasonId/roster/waivers/export', {
+        params: { accountId: '1', seasonId: '1', leagueSeasonId: '50' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+
     it('requires manage-users permission for league roster export', async () => {
       csvExportServiceMock.exportLeagueRoster.mockResolvedValue({
         buffer: Buffer.from(''),

--- a/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
@@ -17,17 +17,6 @@ vi.mock('../../middleware/authMiddleware.js', () => ({
   },
 }));
 
-vi.mock('../../lib/prisma.js', () => ({
-  default: {
-    leagueseason: {
-      findFirst: vi.fn(),
-    },
-    season: {
-      findFirst: vi.fn(),
-    },
-  },
-}));
-
 const createRouteProtectionMock = () => {
   const passThrough = () => (_req: Request, _res: Response, next: NextFunction) => next();
 
@@ -96,8 +85,6 @@ const csvExportServiceMock = {
 let app: Express;
 let router: Router;
 
-let prismaMock: any;
-
 describe('Exports routes', () => {
   beforeAll(async () => {
     process.env.JWT_SECRET = 'test-secret'; // pragma: allowlist secret
@@ -108,9 +95,6 @@ describe('Exports routes', () => {
       createRouteProtectionMock() as never,
     );
     vi.spyOn(ServiceFactory, 'getCsvExportService').mockReturnValue(csvExportServiceMock as never);
-
-    const prismaModule = await import('../../lib/prisma.js');
-    prismaMock = prismaModule.default;
 
     const routerModule = await import('../exports.js');
     router = routerModule.default;
@@ -128,8 +112,6 @@ describe('Exports routes', () => {
         (fn as ReturnType<typeof vi.fn>).mockReset();
       }
     });
-    prismaMock.leagueseason.findFirst.mockReset();
-    prismaMock.season.findFirst.mockReset();
   });
 
   afterAll(() => {
@@ -256,10 +238,6 @@ describe('Exports routes', () => {
   describe('GET /leagues/:leagueSeasonId/roster/export', () => {
     it('exports league roster as CSV', async () => {
       const csvBuffer = Buffer.from('Full Name,Email\nJohn Doe,john@example.com');
-      prismaMock.leagueseason.findFirst.mockResolvedValue({
-        id: 50n,
-        league: { name: 'Spring League' },
-      });
       csvExportServiceMock.exportLeagueRoster.mockResolvedValue({
         buffer: csvBuffer,
         fileName: 'spring-league-roster.csv',
@@ -274,6 +252,7 @@ describe('Exports routes', () => {
       expect(res.headers['Content-Type']).toBe('text/csv');
       expect(res.headers['Content-Disposition']).toContain('spring-league-roster.csv');
       expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportLeagueRoster).toHaveBeenCalledWith(1n, 1n, 50n);
       expect(lastPermissionRequested).toBe('manage-users');
     });
   });
@@ -281,10 +260,6 @@ describe('Exports routes', () => {
   describe('GET /leagues/:leagueSeasonId/managers/export', () => {
     it('exports league managers as CSV', async () => {
       const csvBuffer = Buffer.from('Full Name,Email\nJane Smith,jane@example.com');
-      prismaMock.leagueseason.findFirst.mockResolvedValue({
-        id: 50n,
-        league: { name: 'Spring League' },
-      });
       csvExportServiceMock.exportLeagueManagers.mockResolvedValue({
         buffer: csvBuffer,
         fileName: 'spring-league-managers.csv',
@@ -299,6 +274,7 @@ describe('Exports routes', () => {
       expect(res.headers['Content-Type']).toBe('text/csv');
       expect(res.headers['Content-Disposition']).toContain('spring-league-managers.csv');
       expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportLeagueManagers).toHaveBeenCalledWith(1n, 1n, 50n);
       expect(lastPermissionRequested).toBe('manage-users');
     });
   });
@@ -306,10 +282,6 @@ describe('Exports routes', () => {
   describe('GET /roster/export', () => {
     it('exports season roster as CSV', async () => {
       const csvBuffer = Buffer.from('Full Name,Email\nJohn Doe,john@example.com');
-      prismaMock.season.findFirst.mockResolvedValue({
-        id: 1n,
-        name: 'Spring 2024',
-      });
       csvExportServiceMock.exportSeasonRoster.mockResolvedValue({
         buffer: csvBuffer,
         fileName: 'spring-2024-roster.csv',
@@ -324,6 +296,7 @@ describe('Exports routes', () => {
       expect(res.headers['Content-Type']).toBe('text/csv');
       expect(res.headers['Content-Disposition']).toContain('spring-2024-roster.csv');
       expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportSeasonRoster).toHaveBeenCalledWith(1n, 1n);
       expect(lastPermissionRequested).toBe('manage-users');
     });
   });
@@ -331,10 +304,6 @@ describe('Exports routes', () => {
   describe('GET /managers/export', () => {
     it('exports season managers as CSV', async () => {
       const csvBuffer = Buffer.from('Full Name,Email\nJane Smith,jane@example.com');
-      prismaMock.season.findFirst.mockResolvedValue({
-        id: 1n,
-        name: 'Spring 2024',
-      });
       csvExportServiceMock.exportSeasonManagers.mockResolvedValue({
         buffer: csvBuffer,
         fileName: 'spring-2024-managers.csv',
@@ -349,16 +318,13 @@ describe('Exports routes', () => {
       expect(res.headers['Content-Type']).toBe('text/csv');
       expect(res.headers['Content-Disposition']).toContain('spring-2024-managers.csv');
       expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportSeasonManagers).toHaveBeenCalledWith(1n, 1n);
       expect(lastPermissionRequested).toBe('manage-users');
     });
   });
 
   describe('authorization', () => {
     it('requires manage-users permission for league roster export', async () => {
-      prismaMock.leagueseason.findFirst.mockResolvedValue({
-        id: 50n,
-        league: { name: 'Spring League' },
-      });
       csvExportServiceMock.exportLeagueRoster.mockResolvedValue({
         buffer: Buffer.from(''),
         fileName: 'test.csv',
@@ -373,10 +339,6 @@ describe('Exports routes', () => {
     });
 
     it('requires manage-users permission for league managers export', async () => {
-      prismaMock.leagueseason.findFirst.mockResolvedValue({
-        id: 50n,
-        league: { name: 'Spring League' },
-      });
       csvExportServiceMock.exportLeagueManagers.mockResolvedValue({
         buffer: Buffer.from(''),
         fileName: 'test.csv',
@@ -391,10 +353,6 @@ describe('Exports routes', () => {
     });
 
     it('requires manage-users permission for season roster export', async () => {
-      prismaMock.season.findFirst.mockResolvedValue({
-        id: 1n,
-        name: 'Spring 2024',
-      });
       csvExportServiceMock.exportSeasonRoster.mockResolvedValue({
         buffer: Buffer.from(''),
         fileName: 'test.csv',
@@ -409,10 +367,6 @@ describe('Exports routes', () => {
     });
 
     it('requires manage-users permission for season managers export', async () => {
-      prismaMock.season.findFirst.mockResolvedValue({
-        id: 1n,
-        name: 'Spring 2024',
-      });
       csvExportServiceMock.exportSeasonManagers.mockResolvedValue({
         buffer: Buffer.from(''),
         fileName: 'test.csv',

--- a/draco-nodejs/backend/src/routes/exports.ts
+++ b/draco-nodejs/backend/src/routes/exports.ts
@@ -12,6 +12,90 @@ const routeProtection = ServiceFactory.getRouteProtection();
 const csvExportService = ServiceFactory.getCsvExportService();
 
 router.get(
+  '/teams/:teamSeasonId/roster/waivers/export',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('manage-users'),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'teamSeasonId',
+    );
+
+    const teamSeason = await prisma.teamsseason.findFirst({
+      where: {
+        id: teamSeasonId,
+        leagueseason: {
+          seasonid: seasonId,
+          league: { accountid: accountId },
+        },
+      },
+      select: { name: true },
+    });
+
+    if (!teamSeason) {
+      throw new NotFoundError('Team season not found');
+    }
+
+    const result = await csvExportService.exportTeamWaivers(
+      teamSeasonId,
+      seasonId,
+      teamSeason.name,
+    );
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      contentDisposition(result.fileName, { type: 'attachment' }),
+    );
+    res.send(result.buffer);
+  }),
+);
+
+router.get(
+  '/leagues/:leagueSeasonId/roster/waivers/export',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('manage-users'),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, leagueSeasonId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'leagueSeasonId',
+    );
+
+    const leagueSeason = await prisma.leagueseason.findFirst({
+      where: {
+        id: leagueSeasonId,
+        seasonid: seasonId,
+        league: { accountid: accountId },
+      },
+      include: { league: true },
+    });
+
+    if (!leagueSeason) {
+      throw new NotFoundError('League season not found');
+    }
+
+    const result = await csvExportService.exportLeagueWaivers(
+      leagueSeasonId,
+      seasonId,
+      leagueSeason.league.name,
+    );
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      contentDisposition(result.fileName, { type: 'attachment' }),
+    );
+    res.send(result.buffer);
+  }),
+);
+
+router.get(
   '/leagues/:leagueSeasonId/roster/export',
   authenticateToken,
   routeProtection.enforceAccountBoundary(),

--- a/draco-nodejs/backend/src/routes/exports.ts
+++ b/draco-nodejs/backend/src/routes/exports.ts
@@ -4,8 +4,6 @@ import { authenticateToken } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { extractBigIntParams } from '../utils/paramExtraction.js';
-import prisma from '../lib/prisma.js';
-import { NotFoundError } from '../utils/customErrors.js';
 
 const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
@@ -24,26 +22,7 @@ router.get(
       'teamSeasonId',
     );
 
-    const teamSeason = await prisma.teamsseason.findFirst({
-      where: {
-        id: teamSeasonId,
-        leagueseason: {
-          seasonid: seasonId,
-          league: { accountid: accountId },
-        },
-      },
-      select: { name: true },
-    });
-
-    if (!teamSeason) {
-      throw new NotFoundError('Team season not found');
-    }
-
-    const result = await csvExportService.exportTeamWaivers(
-      teamSeasonId,
-      seasonId,
-      teamSeason.name,
-    );
+    const result = await csvExportService.exportTeamWaivers(accountId, seasonId, teamSeasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
@@ -67,24 +46,7 @@ router.get(
       'leagueSeasonId',
     );
 
-    const leagueSeason = await prisma.leagueseason.findFirst({
-      where: {
-        id: leagueSeasonId,
-        seasonid: seasonId,
-        league: { accountid: accountId },
-      },
-      include: { league: true },
-    });
-
-    if (!leagueSeason) {
-      throw new NotFoundError('League season not found');
-    }
-
-    const result = await csvExportService.exportLeagueWaivers(
-      leagueSeasonId,
-      seasonId,
-      leagueSeason.league.name,
-    );
+    const result = await csvExportService.exportLeagueWaivers(accountId, seasonId, leagueSeasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
@@ -108,24 +70,7 @@ router.get(
       'leagueSeasonId',
     );
 
-    const leagueSeason = await prisma.leagueseason.findFirst({
-      where: {
-        id: leagueSeasonId,
-        seasonid: seasonId,
-        league: { accountid: accountId },
-      },
-      include: { league: true },
-    });
-
-    if (!leagueSeason) {
-      throw new NotFoundError('League season not found');
-    }
-
-    const result = await csvExportService.exportLeagueRoster(
-      leagueSeasonId,
-      seasonId,
-      leagueSeason.league.name,
-    );
+    const result = await csvExportService.exportLeagueRoster(accountId, seasonId, leagueSeasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
@@ -149,23 +94,7 @@ router.get(
       'leagueSeasonId',
     );
 
-    const leagueSeason = await prisma.leagueseason.findFirst({
-      where: {
-        id: leagueSeasonId,
-        seasonid: seasonId,
-        league: { accountid: accountId },
-      },
-      include: { league: true },
-    });
-
-    if (!leagueSeason) {
-      throw new NotFoundError('League season not found');
-    }
-
-    const result = await csvExportService.exportLeagueManagers(
-      leagueSeasonId,
-      leagueSeason.league.name,
-    );
+    const result = await csvExportService.exportLeagueManagers(accountId, seasonId, leagueSeasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
@@ -184,18 +113,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const { accountId, seasonId } = extractBigIntParams(req.params, 'accountId', 'seasonId');
 
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
-
-    if (!season) {
-      throw new NotFoundError('Season not found');
-    }
-
-    const result = await csvExportService.exportSeasonRoster(seasonId, accountId, season.name);
+    const result = await csvExportService.exportSeasonRoster(accountId, seasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
@@ -214,18 +132,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const { accountId, seasonId } = extractBigIntParams(req.params, 'accountId', 'seasonId');
 
-    const season = await prisma.season.findFirst({
-      where: {
-        id: seasonId,
-        accountid: accountId,
-      },
-    });
-
-    if (!season) {
-      throw new NotFoundError('Season not found');
-    }
-
-    const result = await csvExportService.exportSeasonManagers(seasonId, accountId, season.name);
+    const result = await csvExportService.exportSeasonManagers(accountId, seasonId);
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -131,6 +131,7 @@ const createMockRosterExportData = (
   const seasonId = overrides.seasonid ?? 1n;
   const rosterseasonEntry = {
     inactive: false,
+    submittedwaiver: overrides.submittedwaiver ?? true,
     teamsseason: {
       name: overrides.teamName ?? 'Panthers',
       leagueseason: {
@@ -144,7 +145,6 @@ const createMockRosterExportData = (
 
   return {
     playerid: overrides.playerid ?? mockPlayerIdCounter++,
-    submittedwaiver: overrides.submittedwaiver ?? true,
     roster: {
       contacts: contacts as dbRosterExportData['roster']['contacts'],
       rosterseason: [rosterseasonEntry] as dbRosterExportData['roster']['rosterseason'],
@@ -404,67 +404,123 @@ describe('CsvExportService', () => {
 
   describe('exportLeagueRoster', () => {
     it('should export league roster with correct filename', async () => {
-      rosterRepository.findLeagueRosterForExport.mockResolvedValue([
-        createMockRosterExportData({ seasonid: 1n, submittedwaiver: true }),
-      ]);
+      rosterRepository.findLeagueRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [createMockRosterExportData({ seasonid: 1n, submittedwaiver: true })],
+      });
 
-      const result = await service.exportLeagueRoster(50n, 1n, 'Spring League');
+      const result = await service.exportLeagueRoster(1n, 1n, 50n);
 
       expect(result.fileName).toBe('spring-league-roster.csv');
-      expect(rosterRepository.findLeagueRosterForExport).toHaveBeenCalledWith(50n, 1n);
+      expect(rosterRepository.findLeagueRosterForExport).toHaveBeenCalledWith(1n, 1n, 50n);
     });
 
     it('should handle empty roster', async () => {
-      rosterRepository.findLeagueRosterForExport.mockResolvedValue([]);
+      rosterRepository.findLeagueRosterForExport.mockResolvedValue({
+        leagueName: 'Empty League',
+        members: [],
+      });
 
-      const result = await service.exportLeagueRoster(50n, 1n, 'Empty League');
+      const result = await service.exportLeagueRoster(1n, 1n, 50n);
 
       expect(result.fileName).toBe('empty-league-roster.csv');
       expect(result.buffer.toString()).toBe('');
+    });
+
+    it('should report Yes when a deduplicated player has a waiver on any season team', async () => {
+      const multiTeamPlayer: dbRosterExportData = {
+        playerid: 999n,
+        roster: {
+          contacts: {
+            firstname: 'Multi',
+            lastname: 'Team',
+            middlename: '',
+            email: 'multi@example.com',
+            streetaddress: '1 Main St',
+            city: 'Town',
+            state: 'IL',
+            zip: '00000',
+          } as dbRosterExportData['roster']['contacts'],
+          rosterseason: [
+            {
+              inactive: false,
+              submittedwaiver: false,
+              teamsseason: {
+                name: 'Team A',
+                leagueseason: { seasonid: 1n, league: { name: 'League A' } },
+              },
+            },
+            {
+              inactive: false,
+              submittedwaiver: true,
+              teamsseason: {
+                name: 'Team B',
+                leagueseason: { seasonid: 1n, league: { name: 'League B' } },
+              },
+            },
+          ] as dbRosterExportData['roster']['rosterseason'],
+        },
+      };
+      rosterRepository.findLeagueRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [multiTeamPlayer],
+      });
+
+      const result = await service.exportLeagueRoster(1n, 1n, 50n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Yes');
+      expect(csvContent).toContain('League A / Team A');
+      expect(csvContent).toContain('League B / Team B');
     });
   });
 
   describe('exportSeasonRoster', () => {
     it('should export season roster with correct filename', async () => {
-      rosterRepository.findSeasonRosterForExport.mockResolvedValue([
-        createMockRosterExportData({ seasonid: 1n, submittedwaiver: true }),
-      ]);
+      rosterRepository.findSeasonRosterForExport.mockResolvedValue({
+        seasonName: 'Spring 2024',
+        members: [createMockRosterExportData({ seasonid: 1n, submittedwaiver: true })],
+      });
 
-      const result = await service.exportSeasonRoster(1n, 10n, 'Spring 2024');
+      const result = await service.exportSeasonRoster(10n, 1n);
 
       expect(result.fileName).toBe('spring-2024-roster.csv');
-      expect(rosterRepository.findSeasonRosterForExport).toHaveBeenCalledWith(1n, 10n);
+      expect(rosterRepository.findSeasonRosterForExport).toHaveBeenCalledWith(10n, 1n);
     });
   });
 
   describe('exportTeamWaivers', () => {
     it('should export team waivers with correct filename', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData(),
-      ]);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [createMockWaiverExportData()],
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
 
       expect(result.fileName).toBe('panthers-waivers.csv');
       expect(Buffer.isBuffer(result.buffer)).toBe(true);
-      expect(rosterRepository.findTeamWaiverRosterForExport).toHaveBeenCalledWith(100n, 1n);
+      expect(rosterRepository.findTeamWaiverRosterForExport).toHaveBeenCalledWith(1n, 1n, 100n);
     });
 
     it('should include waiver data in CSV', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData({
-          firstname: 'John',
-          lastname: 'Doe',
-          email: 'john@example.com',
-          streetaddress: '123 Main St',
-          city: 'Springfield',
-          state: 'IL',
-          zip: '62701',
-          teamName: 'Panthers',
-        }),
-      ]);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [
+          createMockWaiverExportData({
+            firstname: 'John',
+            lastname: 'Doe',
+            email: 'john@example.com',
+            streetaddress: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            teamName: 'Panthers',
+          }),
+        ],
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).toContain('John Doe');
@@ -477,27 +533,31 @@ describe('CsvExportService', () => {
     });
 
     it('should include Team column header', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData(),
-      ]);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [createMockWaiverExportData()],
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).toContain('Team');
     });
 
     it('should filter out records with null email', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData({ email: null }),
-        createMockWaiverExportData({
-          firstname: 'Jane',
-          lastname: 'Smith',
-          email: 'jane@example.com',
-        }),
-      ]);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [
+          createMockWaiverExportData({ email: null }),
+          createMockWaiverExportData({
+            firstname: 'Jane',
+            lastname: 'Smith',
+            email: 'jane@example.com',
+          }),
+        ],
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).not.toContain('John Doe');
@@ -505,26 +565,50 @@ describe('CsvExportService', () => {
     });
 
     it('should filter out records with empty email', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData({ email: '' }),
-        createMockWaiverExportData({
-          firstname: 'Jane',
-          lastname: 'Smith',
-          email: 'jane@example.com',
-        }),
-      ]);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [
+          createMockWaiverExportData({ email: '' }),
+          createMockWaiverExportData({
+            firstname: 'Jane',
+            lastname: 'Smith',
+            email: 'jane@example.com',
+          }),
+        ],
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).not.toContain('John Doe');
       expect(csvContent).toContain('Jane Smith');
     });
 
-    it('should handle empty waiver list', async () => {
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([]);
+    it('should apply the export limit after filtering out records without email', async () => {
+      const members = [
+        ...Array.from({ length: 10000 }, (_, i) =>
+          createMockWaiverExportData({ firstname: `User${i}`, email: `user${i}@example.com` }),
+        ),
+        ...Array.from({ length: 5 }, () => createMockWaiverExportData({ email: null })),
+      ];
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Edge Team',
+        members,
+      });
 
-      const result = await service.exportTeamWaivers(100n, 1n, 'Empty Team');
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
+
+      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(result.fileName).toBe('edge-team-waivers.csv');
+    });
+
+    it('should handle empty waiver list', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Empty Team',
+        members: [],
+      });
+
+      const result = await service.exportTeamWaivers(1n, 1n, 100n);
 
       expect(result.fileName).toBe('empty-team-waivers.csv');
       expect(result.buffer.toString()).toBe('');
@@ -534,43 +618,48 @@ describe('CsvExportService', () => {
       const largeDataset = Array.from({ length: 10001 }, (_, i) =>
         createMockWaiverExportData({ firstname: `User${i}`, email: `user${i}@example.com` }),
       );
-      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue(largeDataset);
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Large Team',
+        members: largeDataset,
+      });
 
-      await expect(service.exportTeamWaivers(100n, 1n, 'Large Team')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportTeamWaivers(1n, 1n, 100n)).rejects.toThrow(PayloadTooLargeError);
     });
   });
 
   describe('exportLeagueWaivers', () => {
     it('should export league waivers with correct filename', async () => {
-      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData(),
-      ]);
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [createMockWaiverExportData()],
+      });
 
-      const result = await service.exportLeagueWaivers(50n, 1n, 'Spring League');
+      const result = await service.exportLeagueWaivers(1n, 1n, 50n);
 
       expect(result.fileName).toBe('spring-league-waivers.csv');
-      expect(rosterRepository.findLeagueWaiverRosterForExport).toHaveBeenCalledWith(50n, 1n);
+      expect(rosterRepository.findLeagueWaiverRosterForExport).toHaveBeenCalledWith(1n, 1n, 50n);
     });
 
     it('should include team name in exported data', async () => {
-      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([
-        createMockWaiverExportData({
-          teamName: 'Tigers',
-          firstname: 'Alice',
-          lastname: 'Jones',
-          email: 'alice@example.com',
-        }),
-        createMockWaiverExportData({
-          teamName: 'Panthers',
-          firstname: 'Bob',
-          lastname: 'Smith',
-          email: 'bob@example.com',
-        }),
-      ]);
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [
+          createMockWaiverExportData({
+            teamName: 'Tigers',
+            firstname: 'Alice',
+            lastname: 'Jones',
+            email: 'alice@example.com',
+          }),
+          createMockWaiverExportData({
+            teamName: 'Panthers',
+            firstname: 'Bob',
+            lastname: 'Smith',
+            email: 'bob@example.com',
+          }),
+        ],
+      });
 
-      const result = await service.exportLeagueWaivers(50n, 1n, 'Spring League');
+      const result = await service.exportLeagueWaivers(1n, 1n, 50n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).toContain('Tigers');
@@ -578,9 +667,12 @@ describe('CsvExportService', () => {
     });
 
     it('should handle empty league waiver list', async () => {
-      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([]);
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Empty League',
+        members: [],
+      });
 
-      const result = await service.exportLeagueWaivers(50n, 1n, 'Empty League');
+      const result = await service.exportLeagueWaivers(1n, 1n, 50n);
 
       expect(result.fileName).toBe('empty-league-waivers.csv');
       expect(result.buffer.toString()).toBe('');
@@ -590,45 +682,50 @@ describe('CsvExportService', () => {
       const largeDataset = Array.from({ length: 10001 }, (_, i) =>
         createMockWaiverExportData({ firstname: `User${i}`, email: `user${i}@example.com` }),
       );
-      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue(largeDataset);
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Large League',
+        members: largeDataset,
+      });
 
-      await expect(service.exportLeagueWaivers(50n, 1n, 'Large League')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportLeagueWaivers(1n, 1n, 50n)).rejects.toThrow(PayloadTooLargeError);
     });
   });
 
   describe('exportLeagueManagers', () => {
     it('should export league managers with correct filename', async () => {
-      managerRepository.findLeagueManagersForExport.mockResolvedValue([
-        createMockManagerExportData(),
-      ]);
+      managerRepository.findLeagueManagersForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        managers: [createMockManagerExportData()],
+      });
 
-      const result = await service.exportLeagueManagers(50n, 'Spring League');
+      const result = await service.exportLeagueManagers(1n, 1n, 50n);
 
       expect(result.fileName).toBe('spring-league-managers.csv');
-      expect(managerRepository.findLeagueManagersForExport).toHaveBeenCalledWith(50n);
+      expect(managerRepository.findLeagueManagersForExport).toHaveBeenCalledWith(1n, 1n, 50n);
     });
 
     it('should include manager data in CSV', async () => {
-      managerRepository.findLeagueManagersForExport.mockResolvedValue([
-        createMockManagerExportData({
-          firstname: 'Jane',
-          lastname: 'Smith',
-          email: 'jane@example.com',
-          phone1: '555-0101',
-          phone2: '555-0102',
-          phone3: '555-0103',
-          streetaddress: '456 Oak Ave',
-          city: 'Chicago',
-          state: 'IL',
-          zip: '60601',
-          leagueName: 'Spring League',
-          teamName: 'Tigers',
-        }),
-      ]);
+      managerRepository.findLeagueManagersForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        managers: [
+          createMockManagerExportData({
+            firstname: 'Jane',
+            lastname: 'Smith',
+            email: 'jane@example.com',
+            phone1: '555-0101',
+            phone2: '555-0102',
+            phone3: '555-0103',
+            streetaddress: '456 Oak Ave',
+            city: 'Chicago',
+            state: 'IL',
+            zip: '60601',
+            leagueName: 'Spring League',
+            teamName: 'Tigers',
+          }),
+        ],
+      });
 
-      const result = await service.exportLeagueManagers(50n, 'Spring League');
+      const result = await service.exportLeagueManagers(1n, 1n, 50n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).toContain('Jane Smith');
@@ -644,29 +741,35 @@ describe('CsvExportService', () => {
     });
 
     it('should format league/team name correctly', async () => {
-      managerRepository.findLeagueManagersForExport.mockResolvedValue([
-        createMockManagerExportData({
-          leagueName: 'Major Division',
-          teamName: 'Panthers',
-        }),
-      ]);
+      managerRepository.findLeagueManagersForExport.mockResolvedValue({
+        leagueName: 'Major Division',
+        managers: [
+          createMockManagerExportData({
+            leagueName: 'Major Division',
+            teamName: 'Panthers',
+          }),
+        ],
+      });
 
-      const result = await service.exportLeagueManagers(50n, 'Major Division');
+      const result = await service.exportLeagueManagers(1n, 1n, 50n);
       const csvContent = result.buffer.toString();
 
       expect(csvContent).toContain('Major Division - Panthers');
     });
 
     it('should handle null phone numbers', async () => {
-      managerRepository.findLeagueManagersForExport.mockResolvedValue([
-        createMockManagerExportData({
-          phone1: null,
-          phone2: null,
-          phone3: null,
-        }),
-      ]);
+      managerRepository.findLeagueManagersForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        managers: [
+          createMockManagerExportData({
+            phone1: null,
+            phone2: null,
+            phone3: null,
+          }),
+        ],
+      });
 
-      const result = await service.exportLeagueManagers(50n, 'Spring League');
+      const result = await service.exportLeagueManagers(1n, 1n, 50n);
 
       expect(Buffer.isBuffer(result.buffer)).toBe(true);
     });
@@ -674,20 +777,24 @@ describe('CsvExportService', () => {
 
   describe('exportSeasonManagers', () => {
     it('should export season managers with correct filename', async () => {
-      managerRepository.findSeasonManagersForExport.mockResolvedValue([
-        createMockManagerExportData(),
-      ]);
+      managerRepository.findSeasonManagersForExport.mockResolvedValue({
+        seasonName: 'Spring 2024',
+        managers: [createMockManagerExportData()],
+      });
 
-      const result = await service.exportSeasonManagers(1n, 10n, 'Spring 2024');
+      const result = await service.exportSeasonManagers(10n, 1n);
 
       expect(result.fileName).toBe('spring-2024-managers.csv');
-      expect(managerRepository.findSeasonManagersForExport).toHaveBeenCalledWith(1n, 10n);
+      expect(managerRepository.findSeasonManagersForExport).toHaveBeenCalledWith(10n, 1n);
     });
 
     it('should handle empty manager list', async () => {
-      managerRepository.findSeasonManagersForExport.mockResolvedValue([]);
+      managerRepository.findSeasonManagersForExport.mockResolvedValue({
+        seasonName: 'Empty Season',
+        managers: [],
+      });
 
-      const result = await service.exportSeasonManagers(1n, 10n, 'Empty Season');
+      const result = await service.exportSeasonManagers(10n, 1n);
 
       expect(result.fileName).toBe('empty-season-managers.csv');
       expect(result.buffer.toString()).toBe('');
@@ -823,39 +930,39 @@ describe('CsvExportService', () => {
     });
 
     it('should throw PayloadTooLargeError when league roster exceeds 10,000 rows', async () => {
-      rosterRepository.findLeagueRosterForExport.mockResolvedValue(createLargeDataset(10001));
+      rosterRepository.findLeagueRosterForExport.mockResolvedValue({
+        leagueName: 'Large League',
+        members: createLargeDataset(10001),
+      });
 
-      await expect(service.exportLeagueRoster(50n, 1n, 'Large League')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportLeagueRoster(1n, 1n, 50n)).rejects.toThrow(PayloadTooLargeError);
     });
 
     it('should throw PayloadTooLargeError when season roster exceeds 10,000 rows', async () => {
-      rosterRepository.findSeasonRosterForExport.mockResolvedValue(createLargeDataset(10001));
+      rosterRepository.findSeasonRosterForExport.mockResolvedValue({
+        seasonName: 'Large Season',
+        members: createLargeDataset(10001),
+      });
 
-      await expect(service.exportSeasonRoster(1n, 10n, 'Large Season')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportSeasonRoster(10n, 1n)).rejects.toThrow(PayloadTooLargeError);
     });
 
     it('should throw PayloadTooLargeError when league managers exceeds 10,000 rows', async () => {
-      managerRepository.findLeagueManagersForExport.mockResolvedValue(
-        createLargeManagerDataset(10001),
-      );
+      managerRepository.findLeagueManagersForExport.mockResolvedValue({
+        leagueName: 'Large League',
+        managers: createLargeManagerDataset(10001),
+      });
 
-      await expect(service.exportLeagueManagers(50n, 'Large League')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportLeagueManagers(1n, 1n, 50n)).rejects.toThrow(PayloadTooLargeError);
     });
 
     it('should throw PayloadTooLargeError when season managers exceeds 10,000 rows', async () => {
-      managerRepository.findSeasonManagersForExport.mockResolvedValue(
-        createLargeManagerDataset(10001),
-      );
+      managerRepository.findSeasonManagersForExport.mockResolvedValue({
+        seasonName: 'Large Season',
+        managers: createLargeManagerDataset(10001),
+      });
 
-      await expect(service.exportSeasonManagers(1n, 10n, 'Large Season')).rejects.toThrow(
-        PayloadTooLargeError,
-      );
+      await expect(service.exportSeasonManagers(10n, 1n)).rejects.toThrow(PayloadTooLargeError);
     });
 
     it('should allow export at exactly 10,000 rows', async () => {

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -11,6 +11,7 @@ import {
   dbRosterExportData,
   dbManagerExportData,
   dbContactExportData,
+  dbWaiverExportData,
   dbAspnetRole,
 } from '../../repositories/types/dbTypes.js';
 import { PayloadTooLargeError } from '../../utils/customErrors.js';
@@ -33,6 +34,8 @@ class RosterRepositoryStub implements IRosterRepository {
   findRosterMembersForExport = vi.fn<IRosterRepository['findRosterMembersForExport']>();
   findLeagueRosterForExport = vi.fn<IRosterRepository['findLeagueRosterForExport']>();
   findSeasonRosterForExport = vi.fn<IRosterRepository['findSeasonRosterForExport']>();
+  findTeamWaiverRosterForExport = vi.fn<IRosterRepository['findTeamWaiverRosterForExport']>();
+  findLeagueWaiverRosterForExport = vi.fn<IRosterRepository['findLeagueWaiverRosterForExport']>();
 }
 
 class ManagerRepositoryStub implements IManagerRepository {
@@ -108,8 +111,10 @@ const createMockRosterExportData = (
     city: string | null;
     state: string | null;
     zip: string | null;
-    affiliationduespaid: string;
+    submittedwaiver: boolean;
     seasonid: bigint;
+    leagueName: string;
+    teamName: string;
   }> = {},
 ): dbRosterExportData => {
   const contacts = {
@@ -123,19 +128,59 @@ const createMockRosterExportData = (
     zip: overrides.zip ?? '62701',
   };
 
+  const seasonId = overrides.seasonid ?? 1n;
+  const rosterseasonEntry = {
+    inactive: false,
+    teamsseason: {
+      name: overrides.teamName ?? 'Panthers',
+      leagueseason: {
+        seasonid: seasonId,
+        league: {
+          name: overrides.leagueName ?? 'Spring League',
+        },
+      },
+    },
+  };
+
   return {
     playerid: overrides.playerid ?? mockPlayerIdCounter++,
+    submittedwaiver: overrides.submittedwaiver ?? true,
     roster: {
       contacts: contacts as dbRosterExportData['roster']['contacts'],
-      playerseasonaffiliationdues:
-        overrides.affiliationduespaid !== undefined
-          ? [
-              {
-                affiliationduespaid: overrides.affiliationduespaid,
-                seasonid: overrides.seasonid ?? 1n,
-              },
-            ]
-          : [],
+      rosterseason: [rosterseasonEntry] as dbRosterExportData['roster']['rosterseason'],
+    },
+  };
+};
+
+const createMockWaiverExportData = (
+  overrides: Partial<{
+    firstname: string | null;
+    lastname: string | null;
+    middlename: string | null;
+    email: string | null;
+    streetaddress: string | null;
+    city: string | null;
+    state: string | null;
+    zip: string | null;
+    teamName: string;
+  }> = {},
+): dbWaiverExportData => {
+  return {
+    submittedwaiver: true,
+    teamsseason: {
+      name: overrides.teamName ?? 'Panthers',
+    },
+    roster: {
+      contacts: {
+        firstname: 'firstname' in overrides ? overrides.firstname : 'John',
+        lastname: 'lastname' in overrides ? overrides.lastname : 'Doe',
+        middlename: 'middlename' in overrides ? overrides.middlename : null,
+        email: 'email' in overrides ? overrides.email : 'john@example.com',
+        streetaddress: 'streetaddress' in overrides ? overrides.streetaddress : '123 Main St',
+        city: 'city' in overrides ? overrides.city : 'Springfield',
+        state: 'state' in overrides ? overrides.state : 'IL',
+        zip: 'zip' in overrides ? overrides.zip : '62701',
+      } as dbWaiverExportData['roster']['contacts'],
     },
   };
 };
@@ -238,7 +283,7 @@ describe('CsvExportService', () => {
   describe('exportTeamRoster', () => {
     it('should export team roster with correct filename', async () => {
       rosterRepository.findRosterMembersForExport.mockResolvedValue([
-        createMockRosterExportData({ seasonid: 1n, affiliationduespaid: 'Yes' }),
+        createMockRosterExportData({ seasonid: 1n, submittedwaiver: true }),
       ]);
 
       const result = await service.exportTeamRoster(100n, 1n, 'Panthers');
@@ -266,7 +311,7 @@ describe('CsvExportService', () => {
           city: 'Springfield',
           state: 'IL',
           zip: '62701',
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
           seasonid: 1n,
         }),
       ]);
@@ -309,7 +354,7 @@ describe('CsvExportService', () => {
           middlename: 'Michael',
           lastname: 'Doe',
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       ]);
 
@@ -319,32 +364,48 @@ describe('CsvExportService', () => {
       expect(csvContent).toContain('John Michael Doe');
     });
 
-    it('should include affiliation dues status when present', async () => {
+    it('should show Yes for submitted waiver', async () => {
       rosterRepository.findRosterMembersForExport.mockResolvedValue([
-        createMockRosterExportData({ affiliationduespaid: 'Paid', seasonid: 1n }),
+        createMockRosterExportData({ submittedwaiver: true, seasonid: 1n }),
       ]);
 
       const result = await service.exportTeamRoster(100n, 1n, 'Panthers');
       const csvContent = result.buffer.toString();
 
-      expect(csvContent).toContain('Paid');
+      expect(csvContent).toContain('Yes');
     });
 
-    it('should handle missing dues information', async () => {
+    it('should show No for unsubmitted waiver', async () => {
       rosterRepository.findRosterMembersForExport.mockResolvedValue([
-        createMockRosterExportData(), // No dues info
+        createMockRosterExportData({ submittedwaiver: false, seasonid: 1n }),
       ]);
 
       const result = await service.exportTeamRoster(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
 
-      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(csvContent).toContain('No');
+    });
+
+    it('should include registered teams in CSV', async () => {
+      rosterRepository.findRosterMembersForExport.mockResolvedValue([
+        createMockRosterExportData({
+          seasonid: 1n,
+          leagueName: 'Spring League',
+          teamName: 'Panthers',
+        }),
+      ]);
+
+      const result = await service.exportTeamRoster(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Spring League / Panthers');
     });
   });
 
   describe('exportLeagueRoster', () => {
     it('should export league roster with correct filename', async () => {
       rosterRepository.findLeagueRosterForExport.mockResolvedValue([
-        createMockRosterExportData({ seasonid: 1n, affiliationduespaid: 'Yes' }),
+        createMockRosterExportData({ seasonid: 1n, submittedwaiver: true }),
       ]);
 
       const result = await service.exportLeagueRoster(50n, 1n, 'Spring League');
@@ -366,13 +427,174 @@ describe('CsvExportService', () => {
   describe('exportSeasonRoster', () => {
     it('should export season roster with correct filename', async () => {
       rosterRepository.findSeasonRosterForExport.mockResolvedValue([
-        createMockRosterExportData({ seasonid: 1n, affiliationduespaid: 'Yes' }),
+        createMockRosterExportData({ seasonid: 1n, submittedwaiver: true }),
       ]);
 
       const result = await service.exportSeasonRoster(1n, 10n, 'Spring 2024');
 
       expect(result.fileName).toBe('spring-2024-roster.csv');
       expect(rosterRepository.findSeasonRosterForExport).toHaveBeenCalledWith(1n, 10n);
+    });
+  });
+
+  describe('exportTeamWaivers', () => {
+    it('should export team waivers with correct filename', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData(),
+      ]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+
+      expect(result.fileName).toBe('panthers-waivers.csv');
+      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(rosterRepository.findTeamWaiverRosterForExport).toHaveBeenCalledWith(100n, 1n);
+    });
+
+    it('should include waiver data in CSV', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData({
+          firstname: 'John',
+          lastname: 'Doe',
+          email: 'john@example.com',
+          streetaddress: '123 Main St',
+          city: 'Springfield',
+          state: 'IL',
+          zip: '62701',
+          teamName: 'Panthers',
+        }),
+      ]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('John Doe');
+      expect(csvContent).toContain('john@example.com');
+      expect(csvContent).toContain('123 Main St');
+      expect(csvContent).toContain('Springfield');
+      expect(csvContent).toContain('IL');
+      expect(csvContent).toContain('62701');
+      expect(csvContent).toContain('Panthers');
+    });
+
+    it('should include Team column header', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData(),
+      ]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Team');
+    });
+
+    it('should filter out records with null email', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData({ email: null }),
+        createMockWaiverExportData({
+          firstname: 'Jane',
+          lastname: 'Smith',
+          email: 'jane@example.com',
+        }),
+      ]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).not.toContain('John Doe');
+      expect(csvContent).toContain('Jane Smith');
+    });
+
+    it('should filter out records with empty email', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData({ email: '' }),
+        createMockWaiverExportData({
+          firstname: 'Jane',
+          lastname: 'Smith',
+          email: 'jane@example.com',
+        }),
+      ]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Panthers');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).not.toContain('John Doe');
+      expect(csvContent).toContain('Jane Smith');
+    });
+
+    it('should handle empty waiver list', async () => {
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue([]);
+
+      const result = await service.exportTeamWaivers(100n, 1n, 'Empty Team');
+
+      expect(result.fileName).toBe('empty-team-waivers.csv');
+      expect(result.buffer.toString()).toBe('');
+    });
+
+    it('should throw PayloadTooLargeError when waivers exceed 10,000 rows', async () => {
+      const largeDataset = Array.from({ length: 10001 }, (_, i) =>
+        createMockWaiverExportData({ firstname: `User${i}`, email: `user${i}@example.com` }),
+      );
+      rosterRepository.findTeamWaiverRosterForExport.mockResolvedValue(largeDataset);
+
+      await expect(service.exportTeamWaivers(100n, 1n, 'Large Team')).rejects.toThrow(
+        PayloadTooLargeError,
+      );
+    });
+  });
+
+  describe('exportLeagueWaivers', () => {
+    it('should export league waivers with correct filename', async () => {
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData(),
+      ]);
+
+      const result = await service.exportLeagueWaivers(50n, 1n, 'Spring League');
+
+      expect(result.fileName).toBe('spring-league-waivers.csv');
+      expect(rosterRepository.findLeagueWaiverRosterForExport).toHaveBeenCalledWith(50n, 1n);
+    });
+
+    it('should include team name in exported data', async () => {
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([
+        createMockWaiverExportData({
+          teamName: 'Tigers',
+          firstname: 'Alice',
+          lastname: 'Jones',
+          email: 'alice@example.com',
+        }),
+        createMockWaiverExportData({
+          teamName: 'Panthers',
+          firstname: 'Bob',
+          lastname: 'Smith',
+          email: 'bob@example.com',
+        }),
+      ]);
+
+      const result = await service.exportLeagueWaivers(50n, 1n, 'Spring League');
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Tigers');
+      expect(csvContent).toContain('Panthers');
+    });
+
+    it('should handle empty league waiver list', async () => {
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue([]);
+
+      const result = await service.exportLeagueWaivers(50n, 1n, 'Empty League');
+
+      expect(result.fileName).toBe('empty-league-waivers.csv');
+      expect(result.buffer.toString()).toBe('');
+    });
+
+    it('should throw PayloadTooLargeError when league waivers exceed 10,000 rows', async () => {
+      const largeDataset = Array.from({ length: 10001 }, (_, i) =>
+        createMockWaiverExportData({ firstname: `User${i}`, email: `user${i}@example.com` }),
+      );
+      rosterRepository.findLeagueWaiverRosterForExport.mockResolvedValue(largeDataset);
+
+      await expect(service.exportLeagueWaivers(50n, 1n, 'Large League')).rejects.toThrow(
+        PayloadTooLargeError,
+      );
     });
   });
 
@@ -506,7 +728,7 @@ describe('CsvExportService', () => {
           middlename: null,
           lastname: 'Doe',
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       ]);
 
@@ -523,7 +745,7 @@ describe('CsvExportService', () => {
           middlename: null,
           lastname: null,
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       ]);
 
@@ -540,7 +762,7 @@ describe('CsvExportService', () => {
           middlename: null,
           lastname: 'Doe',
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       ]);
 
@@ -557,7 +779,7 @@ describe('CsvExportService', () => {
           middlename: 'Michael',
           lastname: 'Doe',
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       ]);
 
@@ -575,7 +797,7 @@ describe('CsvExportService', () => {
           firstname: `User${i}`,
           lastname: 'Test',
           seasonid: 1n,
-          affiliationduespaid: 'Yes',
+          submittedwaiver: true,
         }),
       );
     };

--- a/draco-nodejs/backend/src/services/csvExportService.ts
+++ b/draco-nodejs/backend/src/services/csvExportService.ts
@@ -56,7 +56,7 @@ export class CsvExportService {
       seasonId,
     );
     this.checkExportLimit(rosterData.length, 'team roster', teamName);
-    const rows = this.mapRosterToExportRows(rosterData, seasonId);
+    const rows = this.mapRosterToExportRows(rosterData);
     const buffer = await generateCsv(rows, ROSTER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(teamName);
     this.logExportMetrics('team roster', teamName, rows.length, buffer.length, startTime);
@@ -78,7 +78,7 @@ export class CsvExportService {
       leagueSeasonId,
     );
     this.checkExportLimit(members.length, 'league roster', leagueName);
-    const rows = this.mapRosterToExportRows(members, seasonId);
+    const rows = this.mapRosterToExportRows(members);
     const buffer = await generateCsv(rows, ROSTER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(leagueName);
     this.logExportMetrics('league roster', leagueName, rows.length, buffer.length, startTime);
@@ -139,7 +139,7 @@ export class CsvExportService {
       seasonId,
     );
     this.checkExportLimit(members.length, 'season roster', seasonName);
-    const rows = this.mapRosterToExportRows(members, seasonId);
+    const rows = this.mapRosterToExportRows(members);
     const buffer = await generateCsv(rows, ROSTER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(seasonName);
     this.logExportMetrics('season roster', seasonName, rows.length, buffer.length, startTime);
@@ -270,16 +270,14 @@ export class CsvExportService {
     }));
   }
 
-  private mapRosterToExportRows(data: dbRosterExportData[], seasonId: bigint): RosterExportRow[] {
+  private mapRosterToExportRows(data: dbRosterExportData[]): RosterExportRow[] {
     return data.map((item) => {
       const contact = item.roster.contacts;
-      const seasonRosterSeasons = item.roster.rosterseason.filter(
-        (rs) => !rs.inactive && rs.teamsseason.leagueseason.seasonid === seasonId,
-      );
-      const submittedWaiver = seasonRosterSeasons.some((rs) => rs.submittedwaiver);
+      const rosterSeasons = item.roster.rosterseason;
+      const submittedWaiver = rosterSeasons.some((rs) => rs.submittedwaiver);
       const registeredTeams = [
         ...new Set(
-          seasonRosterSeasons
+          rosterSeasons
             .map((rs) => `${rs.teamsseason.leagueseason.league.name} / ${rs.teamsseason.name}`)
             .sort(),
         ),

--- a/draco-nodejs/backend/src/services/csvExportService.ts
+++ b/draco-nodejs/backend/src/services/csvExportService.ts
@@ -11,6 +11,7 @@ import {
   dbManagerExportData,
   dbContactExportData,
   dbWorkoutRegistration,
+  dbWaiverExportData,
 } from '../repositories/types/dbTypes.js';
 import { DateUtils } from '../utils/dateUtils.js';
 import {
@@ -19,10 +20,12 @@ import {
   ManagerExportRow,
   ContactExportRow,
   WorkoutRegistrationExportRow,
+  WaiverExportRow,
   ROSTER_EXPORT_HEADERS,
   MANAGER_EXPORT_HEADERS,
   CONTACT_EXPORT_HEADERS,
   WORKOUT_REGISTRATION_EXPORT_HEADERS,
+  WAIVER_EXPORT_HEADERS,
 } from '../utils/csvGenerator.js';
 import { PayloadTooLargeError } from '../utils/customErrors.js';
 
@@ -81,6 +84,48 @@ export class CsvExportService {
     return {
       buffer,
       fileName: `${sanitizedName}-roster.csv`,
+    };
+  }
+
+  async exportTeamWaivers(
+    teamSeasonId: bigint,
+    seasonId: bigint,
+    teamName: string,
+  ): Promise<CsvExportResult> {
+    const startTime = Date.now();
+    const waiverData = await this.rosterRepository.findTeamWaiverRosterForExport(
+      teamSeasonId,
+      seasonId,
+    );
+    this.checkExportLimit(waiverData.length, 'team waivers', teamName);
+    const rows = this.mapWaiversToExportRows(waiverData);
+    const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
+    const sanitizedName = this.sanitizeFileName(teamName);
+    this.logExportMetrics('team waivers', teamName, rows.length, buffer.length, startTime);
+    return {
+      buffer,
+      fileName: `${sanitizedName}-waivers.csv`,
+    };
+  }
+
+  async exportLeagueWaivers(
+    leagueSeasonId: bigint,
+    seasonId: bigint,
+    leagueName: string,
+  ): Promise<CsvExportResult> {
+    const startTime = Date.now();
+    const waiverData = await this.rosterRepository.findLeagueWaiverRosterForExport(
+      leagueSeasonId,
+      seasonId,
+    );
+    this.checkExportLimit(waiverData.length, 'league waivers', leagueName);
+    const rows = this.mapWaiversToExportRows(waiverData);
+    const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
+    const sanitizedName = this.sanitizeFileName(leagueName);
+    this.logExportMetrics('league waivers', leagueName, rows.length, buffer.length, startTime);
+    return {
+      buffer,
+      fileName: `${sanitizedName}-waivers.csv`,
     };
   }
 
@@ -222,7 +267,14 @@ export class CsvExportService {
   private mapRosterToExportRows(data: dbRosterExportData[], seasonId: bigint): RosterExportRow[] {
     return data.map((item) => {
       const contact = item.roster.contacts;
-      const dues = item.roster.playerseasonaffiliationdues.find((d) => d.seasonid === seasonId);
+      const registeredTeams = [
+        ...new Set(
+          item.roster.rosterseason
+            .filter((rs) => !rs.inactive && rs.teamsseason.leagueseason.seasonid === seasonId)
+            .map((rs) => `${rs.teamsseason.leagueseason.league.name} / ${rs.teamsseason.name}`)
+            .sort(),
+        ),
+      ].join('; ');
       return {
         fullName: this.formatFullName(contact.firstname, contact.middlename, contact.lastname),
         email: contact.email ?? '',
@@ -230,9 +282,30 @@ export class CsvExportService {
         city: contact.city ?? '',
         state: contact.state ?? '',
         zip: contact.zip ?? '',
-        affiliationDuesPaid: dues?.affiliationduespaid ?? '',
+        submittedWaiver: item.submittedwaiver ? 'Yes' : 'No',
+        registeredTeams,
       };
     });
+  }
+
+  private mapWaiversToExportRows(data: dbWaiverExportData[]): WaiverExportRow[] {
+    return data
+      .filter((item) => {
+        const email = item.roster.contacts.email;
+        return email !== null && email.trim() !== '';
+      })
+      .map((item) => {
+        const contact = item.roster.contacts;
+        return {
+          fullName: this.formatFullName(contact.firstname, contact.middlename, contact.lastname),
+          email: contact.email ?? '',
+          streetAddress: contact.streetaddress ?? '',
+          city: contact.city ?? '',
+          state: contact.state ?? '',
+          zip: contact.zip ?? '',
+          team: item.teamsseason.name,
+        };
+      });
   }
 
   private mapManagersToExportRows(data: dbManagerExportData[]): ManagerExportRow[] {

--- a/draco-nodejs/backend/src/services/csvExportService.ts
+++ b/draco-nodejs/backend/src/services/csvExportService.ts
@@ -67,17 +67,18 @@ export class CsvExportService {
   }
 
   async exportLeagueRoster(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-    leagueName: string,
+    leagueSeasonId: bigint,
   ): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const rosterData = await this.rosterRepository.findLeagueRosterForExport(
-      leagueSeasonId,
+    const { leagueName, members } = await this.rosterRepository.findLeagueRosterForExport(
+      accountId,
       seasonId,
+      leagueSeasonId,
     );
-    this.checkExportLimit(rosterData.length, 'league roster', leagueName);
-    const rows = this.mapRosterToExportRows(rosterData, seasonId);
+    this.checkExportLimit(members.length, 'league roster', leagueName);
+    const rows = this.mapRosterToExportRows(members, seasonId);
     const buffer = await generateCsv(rows, ROSTER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(leagueName);
     this.logExportMetrics('league roster', leagueName, rows.length, buffer.length, startTime);
@@ -88,17 +89,18 @@ export class CsvExportService {
   }
 
   async exportTeamWaivers(
-    teamSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-    teamName: string,
+    teamSeasonId: bigint,
   ): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const waiverData = await this.rosterRepository.findTeamWaiverRosterForExport(
-      teamSeasonId,
+    const { teamName, members } = await this.rosterRepository.findTeamWaiverRosterForExport(
+      accountId,
       seasonId,
+      teamSeasonId,
     );
-    this.checkExportLimit(waiverData.length, 'team waivers', teamName);
-    const rows = this.mapWaiversToExportRows(waiverData);
+    const rows = this.mapWaiversToExportRows(members);
+    this.checkExportLimit(rows.length, 'team waivers', teamName);
     const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(teamName);
     this.logExportMetrics('team waivers', teamName, rows.length, buffer.length, startTime);
@@ -109,17 +111,18 @@ export class CsvExportService {
   }
 
   async exportLeagueWaivers(
-    leagueSeasonId: bigint,
+    accountId: bigint,
     seasonId: bigint,
-    leagueName: string,
+    leagueSeasonId: bigint,
   ): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const waiverData = await this.rosterRepository.findLeagueWaiverRosterForExport(
-      leagueSeasonId,
+    const { leagueName, members } = await this.rosterRepository.findLeagueWaiverRosterForExport(
+      accountId,
       seasonId,
+      leagueSeasonId,
     );
-    this.checkExportLimit(waiverData.length, 'league waivers', leagueName);
-    const rows = this.mapWaiversToExportRows(waiverData);
+    const rows = this.mapWaiversToExportRows(members);
+    this.checkExportLimit(rows.length, 'league waivers', leagueName);
     const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(leagueName);
     this.logExportMetrics('league waivers', leagueName, rows.length, buffer.length, startTime);
@@ -129,15 +132,14 @@ export class CsvExportService {
     };
   }
 
-  async exportSeasonRoster(
-    seasonId: bigint,
-    accountId: bigint,
-    seasonName: string,
-  ): Promise<CsvExportResult> {
+  async exportSeasonRoster(accountId: bigint, seasonId: bigint): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const rosterData = await this.rosterRepository.findSeasonRosterForExport(seasonId, accountId);
-    this.checkExportLimit(rosterData.length, 'season roster', seasonName);
-    const rows = this.mapRosterToExportRows(rosterData, seasonId);
+    const { seasonName, members } = await this.rosterRepository.findSeasonRosterForExport(
+      accountId,
+      seasonId,
+    );
+    this.checkExportLimit(members.length, 'season roster', seasonName);
+    const rows = this.mapRosterToExportRows(members, seasonId);
     const buffer = await generateCsv(rows, ROSTER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(seasonName);
     this.logExportMetrics('season roster', seasonName, rows.length, buffer.length, startTime);
@@ -147,11 +149,19 @@ export class CsvExportService {
     };
   }
 
-  async exportLeagueManagers(leagueSeasonId: bigint, leagueName: string): Promise<CsvExportResult> {
+  async exportLeagueManagers(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const managerData = await this.managerRepository.findLeagueManagersForExport(leagueSeasonId);
-    this.checkExportLimit(managerData.length, 'league managers', leagueName);
-    const rows = this.mapManagersToExportRows(managerData);
+    const { leagueName, managers } = await this.managerRepository.findLeagueManagersForExport(
+      accountId,
+      seasonId,
+      leagueSeasonId,
+    );
+    this.checkExportLimit(managers.length, 'league managers', leagueName);
+    const rows = this.mapManagersToExportRows(managers);
     const buffer = await generateCsv(rows, MANAGER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(leagueName);
     this.logExportMetrics('league managers', leagueName, rows.length, buffer.length, startTime);
@@ -161,18 +171,14 @@ export class CsvExportService {
     };
   }
 
-  async exportSeasonManagers(
-    seasonId: bigint,
-    accountId: bigint,
-    seasonName: string,
-  ): Promise<CsvExportResult> {
+  async exportSeasonManagers(accountId: bigint, seasonId: bigint): Promise<CsvExportResult> {
     const startTime = Date.now();
-    const managerData = await this.managerRepository.findSeasonManagersForExport(
-      seasonId,
+    const { seasonName, managers } = await this.managerRepository.findSeasonManagersForExport(
       accountId,
+      seasonId,
     );
-    this.checkExportLimit(managerData.length, 'season managers', seasonName);
-    const rows = this.mapManagersToExportRows(managerData);
+    this.checkExportLimit(managers.length, 'season managers', seasonName);
+    const rows = this.mapManagersToExportRows(managers);
     const buffer = await generateCsv(rows, MANAGER_EXPORT_HEADERS);
     const sanitizedName = this.sanitizeFileName(seasonName);
     this.logExportMetrics('season managers', seasonName, rows.length, buffer.length, startTime);
@@ -267,10 +273,13 @@ export class CsvExportService {
   private mapRosterToExportRows(data: dbRosterExportData[], seasonId: bigint): RosterExportRow[] {
     return data.map((item) => {
       const contact = item.roster.contacts;
+      const seasonRosterSeasons = item.roster.rosterseason.filter(
+        (rs) => !rs.inactive && rs.teamsseason.leagueseason.seasonid === seasonId,
+      );
+      const submittedWaiver = seasonRosterSeasons.some((rs) => rs.submittedwaiver);
       const registeredTeams = [
         ...new Set(
-          item.roster.rosterseason
-            .filter((rs) => !rs.inactive && rs.teamsseason.leagueseason.seasonid === seasonId)
+          seasonRosterSeasons
             .map((rs) => `${rs.teamsseason.leagueseason.league.name} / ${rs.teamsseason.name}`)
             .sort(),
         ),
@@ -282,7 +291,7 @@ export class CsvExportService {
         city: contact.city ?? '',
         state: contact.state ?? '',
         zip: contact.zip ?? '',
-        submittedWaiver: item.submittedwaiver ? 'Yes' : 'No',
+        submittedWaiver: submittedWaiver ? 'Yes' : 'No',
         registeredTeams,
       };
     });

--- a/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
@@ -158,6 +158,43 @@ describe('csvGenerator', () => {
       expect(csvString).toContain('Jane,false');
     });
 
+    it('should neutralize CSV formula injection in cell values', async () => {
+      interface TestRow {
+        team: string;
+        name: string;
+      }
+      const headers: CsvHeader<TestRow>[] = [
+        { key: 'team', header: 'Team' },
+        { key: 'name', header: 'Name' },
+      ];
+      const data: TestRow[] = [
+        { team: '=HYPERLINK(1)', name: '+1-555-0100' },
+        { team: '-2+3', name: '@SUM(A1)' },
+      ];
+
+      const result = await generateCsv(data, headers);
+      const csvString = result.toString();
+      const lines = csvString.trim().split('\n');
+
+      // Leading =, +, -, @ are prefixed with a single quote so spreadsheets treat them as text
+      expect(lines[1]).toBe(`'=HYPERLINK(1),'+1-555-0100`);
+      expect(lines[2]).toBe(`'-2+3,'@SUM(A1)`);
+    });
+
+    it('should not modify values that do not start with a formula character', async () => {
+      interface TestRow {
+        name: string;
+      }
+      const headers: CsvHeader<TestRow>[] = [{ key: 'name', header: 'Name' }];
+      const data: TestRow[] = [{ name: 'John = Doe' }];
+
+      const result = await generateCsv(data, headers);
+      const csvString = result.toString();
+      const lines = csvString.trim().split('\n');
+
+      expect(lines[1]).toBe('John = Doe');
+    });
+
     it('should return a Buffer', async () => {
       interface TestRow {
         name: string;

--- a/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
@@ -176,7 +176,6 @@ describe('csvGenerator', () => {
       const csvString = result.toString();
       const lines = csvString.trim().split('\n');
 
-      // Leading =, +, -, @ are prefixed with a single quote so spreadsheets treat them as text
       expect(lines[1]).toBe(`'=HYPERLINK(1),'+1-555-0100`);
       expect(lines[2]).toBe(`'-2+3,'@SUM(A1)`);
     });

--- a/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
@@ -4,8 +4,10 @@ import {
   CsvHeader,
   ROSTER_EXPORT_HEADERS,
   MANAGER_EXPORT_HEADERS,
+  WAIVER_EXPORT_HEADERS,
   RosterExportRow,
   ManagerExportRow,
+  WaiverExportRow,
 } from '../csvGenerator.js';
 
 describe('csvGenerator', () => {
@@ -273,6 +275,62 @@ describe('csvGenerator', () => {
 
       expect(lines[1]).toBe(
         'John Doe,john@example.com,123 Main St,Springfield,IL,62701,Yes,Spring League / Panthers',
+      );
+    });
+  });
+
+  describe('WAIVER_EXPORT_HEADERS', () => {
+    it('should have correct header definitions', () => {
+      expect(WAIVER_EXPORT_HEADERS).toHaveLength(7);
+      expect(WAIVER_EXPORT_HEADERS.map((h) => h.header)).toEqual([
+        'Full Name',
+        'Email',
+        'Street Address',
+        'City',
+        'State',
+        'Zip',
+        'Team',
+      ]);
+    });
+
+    it('should include headers in output when there is data', async () => {
+      const data: WaiverExportRow[] = [
+        {
+          fullName: 'Test User',
+          email: 'test@example.com',
+          streetAddress: '123 Test St',
+          city: 'Test City',
+          state: 'TS',
+          zip: '12345',
+          team: 'Spring League / Tigers',
+        },
+      ];
+      const result = await generateCsv(data, WAIVER_EXPORT_HEADERS);
+      const csvString = result.toString();
+      const lines = csvString.trim().split('\n');
+
+      expect(lines[0]).toBe('Full Name,Email,Street Address,City,State,Zip,Team');
+    });
+
+    it('should generate correct waiver export row', async () => {
+      const data: WaiverExportRow[] = [
+        {
+          fullName: 'John Doe',
+          email: 'john@example.com',
+          streetAddress: '123 Main St',
+          city: 'Springfield',
+          state: 'IL',
+          zip: '62701',
+          team: 'Spring League / Panthers',
+        },
+      ];
+
+      const result = await generateCsv(data, WAIVER_EXPORT_HEADERS);
+      const csvString = result.toString();
+      const lines = csvString.trim().split('\n');
+
+      expect(lines[1]).toBe(
+        'John Doe,john@example.com,123 Main St,Springfield,IL,62701,Spring League / Panthers',
       );
     });
   });

--- a/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/csvGenerator.test.ts
@@ -218,7 +218,7 @@ describe('csvGenerator', () => {
 
   describe('ROSTER_EXPORT_HEADERS', () => {
     it('should have correct header definitions', () => {
-      expect(ROSTER_EXPORT_HEADERS).toHaveLength(7);
+      expect(ROSTER_EXPORT_HEADERS).toHaveLength(8);
       expect(ROSTER_EXPORT_HEADERS.map((h) => h.header)).toEqual([
         'Full Name',
         'Email',
@@ -226,7 +226,8 @@ describe('csvGenerator', () => {
         'City',
         'State',
         'Zip',
-        'Affiliation Dues Paid',
+        'Submitted Waiver',
+        'Registered Teams',
       ]);
     });
 
@@ -239,14 +240,17 @@ describe('csvGenerator', () => {
           city: 'Test City',
           state: 'TS',
           zip: '12345',
-          affiliationDuesPaid: 'Yes',
+          submittedWaiver: 'Yes',
+          registeredTeams: 'Spring League / Tigers',
         },
       ];
       const result = await generateCsv(data, ROSTER_EXPORT_HEADERS);
       const csvString = result.toString();
       const lines = csvString.trim().split('\n');
 
-      expect(lines[0]).toBe('Full Name,Email,Street Address,City,State,Zip,Affiliation Dues Paid');
+      expect(lines[0]).toBe(
+        'Full Name,Email,Street Address,City,State,Zip,Submitted Waiver,Registered Teams',
+      );
     });
 
     it('should generate correct roster export row', async () => {
@@ -258,7 +262,8 @@ describe('csvGenerator', () => {
           city: 'Springfield',
           state: 'IL',
           zip: '62701',
-          affiliationDuesPaid: 'Yes',
+          submittedWaiver: 'Yes',
+          registeredTeams: 'Spring League / Panthers',
         },
       ];
 
@@ -266,7 +271,9 @@ describe('csvGenerator', () => {
       const csvString = result.toString();
       const lines = csvString.trim().split('\n');
 
-      expect(lines[1]).toBe('John Doe,john@example.com,123 Main St,Springfield,IL,62701,Yes');
+      expect(lines[1]).toBe(
+        'John Doe,john@example.com,123 Main St,Springfield,IL,62701,Yes,Spring League / Panthers',
+      );
     });
   });
 

--- a/draco-nodejs/backend/src/utils/csvGenerator.ts
+++ b/draco-nodejs/backend/src/utils/csvGenerator.ts
@@ -53,7 +53,8 @@ export interface RosterExportRow {
   city: string;
   state: string;
   zip: string;
-  affiliationDuesPaid: string;
+  submittedWaiver: string;
+  registeredTeams: string;
 }
 
 export const ROSTER_EXPORT_HEADERS: CsvHeader<RosterExportRow>[] = [
@@ -63,7 +64,28 @@ export const ROSTER_EXPORT_HEADERS: CsvHeader<RosterExportRow>[] = [
   { key: 'city', header: 'City' },
   { key: 'state', header: 'State' },
   { key: 'zip', header: 'Zip' },
-  { key: 'affiliationDuesPaid', header: 'Affiliation Dues Paid' },
+  { key: 'submittedWaiver', header: 'Submitted Waiver' },
+  { key: 'registeredTeams', header: 'Registered Teams' },
+];
+
+export interface WaiverExportRow {
+  fullName: string;
+  email: string;
+  streetAddress: string;
+  city: string;
+  state: string;
+  zip: string;
+  team: string;
+}
+
+export const WAIVER_EXPORT_HEADERS: CsvHeader<WaiverExportRow>[] = [
+  { key: 'fullName', header: 'Full Name' },
+  { key: 'email', header: 'Email' },
+  { key: 'streetAddress', header: 'Street Address' },
+  { key: 'city', header: 'City' },
+  { key: 'state', header: 'State' },
+  { key: 'zip', header: 'Zip' },
+  { key: 'team', header: 'Team' },
 ];
 
 export interface ManagerExportRow {

--- a/draco-nodejs/backend/src/utils/csvGenerator.ts
+++ b/draco-nodejs/backend/src/utils/csvGenerator.ts
@@ -5,7 +5,7 @@ export interface CsvHeader<T> {
   header: string;
 }
 
-const CSV_INJECTION_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+const CSV_INJECTION_PREFIXES = ['=', '+', '-', '@', '\t', '\r', '\n'];
 
 function neutralizeCsvValue(value: string): string {
   if (value.length > 0 && CSV_INJECTION_PREFIXES.includes(value[0])) {

--- a/draco-nodejs/backend/src/utils/csvGenerator.ts
+++ b/draco-nodejs/backend/src/utils/csvGenerator.ts
@@ -5,6 +5,15 @@ export interface CsvHeader<T> {
   header: string;
 }
 
+const CSV_INJECTION_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+
+function neutralizeCsvValue(value: string): string {
+  if (value.length > 0 && CSV_INJECTION_PREFIXES.includes(value[0])) {
+    return `'${value}`;
+  }
+  return value;
+}
+
 export async function generateCsv<T extends object>(
   data: T[],
   headers: CsvHeader<T>[],
@@ -37,7 +46,7 @@ export async function generateCsv<T extends object>(
         if (value === null || value === undefined) {
           return '';
         }
-        return String(value);
+        return neutralizeCsvValue(String(value));
       });
       csvStream.write(rowData);
     }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -626,7 +626,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                     onClick={() => void handleCheckMultipleRegistrations()}
                     disabled={leaguesLoading || leagues.length === 0}
                   >
-                    Check for Multiple Registrations
+                    Check for Multiple Submitted Waivers
                   </Button>
 
                   <Button

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Box,
+  Button,
+  Card,
+  CardContent,
   Chip,
   CircularProgress,
   Container,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   FormControl,
+  IconButton,
   MenuItem,
   Paper,
   Select,
@@ -19,25 +26,158 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import {
+  exportLeagueWaivers,
+  exportTeamWaivers,
   getTeamRosterWaiverSummaries,
   updateRosterMember,
-  type TeamRosterWaiverSummaries,
 } from '@draco/shared-api-client';
 import AccountPageHeader from '../../../../components/AccountPageHeader';
 import { useAccountSettings } from '../../../../hooks/useAccountSettings';
 import { useApiClient } from '../../../../hooks/useApiClient';
 import { useCurrentSeason } from '../../../../hooks/useCurrentSeason';
 import { unwrapApiResult } from '../../../../utils/apiResult';
+import { downloadBlob } from '../../../../utils/downloadUtils';
+import { useLeagueWaiverData, type WaiverMember } from './useLeagueWaiverData';
 import { useSeasonLeaguesAndTeams } from './useSeasonLeaguesAndTeams';
 
 interface WaiversClientProps {
   accountId: string;
 }
 
-type WaiverMember = TeamRosterWaiverSummaries['members'][number];
+interface MultiRegPlayer {
+  contactId: string;
+  fullName: string;
+  waiverTeams: Array<{ leagueName: string; teamName: string }>;
+}
+
+type TeamWaiverDataItem = { teamSeasonId: string; members: WaiverMember[] };
+
+function computeLeagueSummary(data: TeamWaiverDataItem[], leagueSeasonId: string) {
+  const seenContactIds = new Set<string>();
+  let inLeague = 0;
+  let anotherLeague = 0;
+  let noWaiver = 0;
+
+  for (const team of data) {
+    for (const member of team.members) {
+      const contactId = member.rosterMember.player.contact.id;
+      if (seenContactIds.has(contactId)) continue;
+      seenContactIds.add(contactId);
+
+      const hasWaiverInLeague = member.seasonTeams.some(
+        (t) => t.leagueSeasonId === leagueSeasonId && t.submittedWaiver,
+      );
+      const hasWaiverAnywhere = member.seasonTeams.some((t) => t.submittedWaiver);
+
+      if (hasWaiverInLeague) {
+        inLeague++;
+      } else if (hasWaiverAnywhere) {
+        anotherLeague++;
+      } else {
+        noWaiver++;
+      }
+    }
+  }
+
+  return { inLeague, anotherLeague, noWaiver, total: seenContactIds.size };
+}
+
+function computeTeamSummary(members: WaiverMember[], leagueSeasonId: string) {
+  let inLeague = 0;
+  let anotherLeague = 0;
+  let noWaiver = 0;
+
+  for (const member of members) {
+    const hasWaiverInLeague = member.seasonTeams.some(
+      (t) => t.leagueSeasonId === leagueSeasonId && t.submittedWaiver,
+    );
+    const hasWaiverAnywhere = member.seasonTeams.some((t) => t.submittedWaiver);
+
+    if (hasWaiverInLeague) {
+      inLeague++;
+    } else if (hasWaiverAnywhere) {
+      anotherLeague++;
+    } else {
+      noWaiver++;
+    }
+  }
+
+  return { inLeague, anotherLeague, noWaiver, total: members.length };
+}
+
+interface SummaryCardsProps {
+  inLeague: number;
+  anotherLeague: number;
+  noWaiver: number;
+  total: number;
+  label: string;
+  firstStatLabel: string;
+}
+
+function SummaryCards({
+  inLeague,
+  anotherLeague,
+  noWaiver,
+  total,
+  label,
+  firstStatLabel,
+}: SummaryCardsProps) {
+  return (
+    <Box>
+      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+        {label}
+      </Typography>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="h5" color="success.main" align="center">
+              {inLeague}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" align="center" display="block">
+              {firstStatLabel}
+            </Typography>
+          </CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="h5" color="warning.main" align="center">
+              {anotherLeague}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" align="center" display="block">
+              Waiver for Another League
+            </Typography>
+          </CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="h5" color="error.main" align="center">
+              {noWaiver}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" align="center" display="block">
+              No Waiver
+            </Typography>
+          </CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="h5" color="text.primary" align="center">
+              {total}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" align="center" display="block">
+              Total Players
+            </Typography>
+          </CardContent>
+        </Card>
+      </Stack>
+    </Box>
+  );
+}
 
 export default function WaiversClient({ accountId }: WaiversClientProps) {
   const apiClient = useApiClient();
@@ -75,96 +215,63 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
 
   const [selectedLeagueSeasonId, setSelectedLeagueSeasonId] = useState<string>('');
   const [selectedTeamSeasonId, setSelectedTeamSeasonId] = useState<string>('');
-  const [members, setMembers] = useState<WaiverMember[]>([]);
-  const [rosterLoading, setRosterLoading] = useState(false);
-  const [rosterError, setRosterError] = useState<string | null>(null);
   const [updatingDriversLicenseIds, setUpdatingDriversLicenseIds] = useState<Set<string>>(
     () => new Set(),
   );
   const [updatingWaiverIds, setUpdatingWaiverIds] = useState<Set<string>>(() => new Set());
   const [updateError, setUpdateError] = useState<string | null>(null);
 
+  const [multiRegOpen, setMultiRegOpen] = useState(false);
+  const [multiRegLoading, setMultiRegLoading] = useState(false);
+  const [multiRegError, setMultiRegError] = useState<string | null>(null);
+  const [multiRegPlayers, setMultiRegPlayers] = useState<MultiRegPlayer[] | null>(null);
+  const multiRegControllerRef = useRef<AbortController | null>(null);
+
+  const [exportLoading, setExportLoading] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const teamsForSelectedLeague = selectedLeagueSeasonId
+    ? (teamsByLeague.get(selectedLeagueSeasonId) ?? [])
+    : [];
+
+  const {
+    teamWaiverData,
+    loading: rosterLoading,
+    error: rosterError,
+  } = useLeagueWaiverData(accountId, currentSeasonId, selectedLeagueSeasonId, teamsByLeague);
+
+  const [localTeamWaiverData, setLocalTeamWaiverData] = useState<TeamWaiverDataItem[]>([]);
+
+  useEffect(() => {
+    setLocalTeamWaiverData(teamWaiverData);
+  }, [teamWaiverData]);
+
   useEffect(() => {
     setSelectedTeamSeasonId('');
-    setMembers([]);
-    setRosterError(null);
+    setUpdateError(null);
   }, [selectedLeagueSeasonId, currentSeasonId]);
 
-  useEffect(() => {
-    if (!currentSeasonId || !selectedTeamSeasonId) {
-      setMembers([]);
-      setRosterError(null);
-      setRosterLoading(false);
-      return;
-    }
+  const displayTeamData = localTeamWaiverData.find((d) => d.teamSeasonId === selectedTeamSeasonId);
+  const displayMembers = displayTeamData?.members ?? [];
 
-    const controller = new AbortController();
+  const sortedMembers = [...displayMembers].sort((a, b) => {
+    const lastA = a.rosterMember.player.contact.lastName ?? '';
+    const lastB = b.rosterMember.player.contact.lastName ?? '';
+    const lastCompare = lastA.localeCompare(lastB);
+    if (lastCompare !== 0) return lastCompare;
+    const firstA = a.rosterMember.player.contact.firstName ?? '';
+    const firstB = b.rosterMember.player.contact.firstName ?? '';
+    return firstA.localeCompare(firstB);
+  });
 
-    const run = async () => {
-      setRosterLoading(true);
-      setRosterError(null);
-      try {
-        const result = await getTeamRosterWaiverSummaries({
-          client: apiClient,
-          path: {
-            accountId,
-            seasonId: currentSeasonId,
-            teamSeasonId: selectedTeamSeasonId,
-          },
-          signal: controller.signal,
-          throwOnError: false,
-        });
+  const leagueSummary = selectedLeagueSeasonId
+    ? computeLeagueSummary(localTeamWaiverData, selectedLeagueSeasonId)
+    : null;
 
-        if (controller.signal.aborted) return;
-        const data = unwrapApiResult(result, 'Failed to load roster');
-        setMembers(data.members);
-      } catch (err: unknown) {
-        if (controller.signal.aborted) return;
-        setRosterError(err instanceof Error ? err.message : 'Failed to load roster');
-        setMembers([]);
-      } finally {
-        if (!controller.signal.aborted) {
-          setRosterLoading(false);
-        }
-      }
-    };
-
-    void run();
-
-    return () => {
-      controller.abort();
-    };
-  }, [accountId, currentSeasonId, selectedTeamSeasonId, apiClient]);
-
-  const setDriversLicense = (rosterMemberId: string, value: boolean) =>
-    setMembers((prev) =>
-      prev.map((m) =>
-        m.rosterMember.id === rosterMemberId
-          ? {
-              ...m,
-              rosterMember: {
-                ...m.rosterMember,
-                player: { ...m.rosterMember.player, submittedDriversLicense: value },
-              },
-            }
-          : m,
-      ),
-    );
-
-  const setWaiver = (rosterMemberId: string, teamSeasonId: string, value: boolean) =>
-    setMembers((prev) =>
-      prev.map((m) =>
-        m.rosterMember.id === rosterMemberId
-          ? {
-              ...m,
-              rosterMember: { ...m.rosterMember, submittedWaiver: value },
-              seasonTeams: m.seasonTeams.map((team) =>
-                team.teamSeasonId === teamSeasonId ? { ...team, submittedWaiver: value } : team,
-              ),
-            }
-          : m,
-      ),
-    );
+  const teamSummary =
+    selectedTeamSeasonId && selectedLeagueSeasonId
+      ? computeTeamSummary(displayMembers, selectedLeagueSeasonId)
+      : null;
 
   const handleToggleDriversLicense = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
@@ -172,7 +279,22 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     const previousValue = Boolean(member.rosterMember.player.submittedDriversLicense);
     const nextValue = !previousValue;
 
-    setDriversLicense(rosterMemberId, nextValue);
+    setLocalTeamWaiverData((prev) =>
+      prev.map((teamData) => ({
+        ...teamData,
+        members: teamData.members.map((m) =>
+          m.rosterMember.id === rosterMemberId
+            ? {
+                ...m,
+                rosterMember: {
+                  ...m.rosterMember,
+                  player: { ...m.rosterMember.player, submittedDriversLicense: nextValue },
+                },
+              }
+            : m,
+        ),
+      })),
+    );
     setUpdateError(null);
     setUpdatingDriversLicenseIds((prev) => new Set(prev).add(rosterMemberId));
 
@@ -190,7 +312,25 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
       });
       unwrapApiResult(result, 'Failed to update submitted drivers license status');
     } catch (err: unknown) {
-      setDriversLicense(rosterMemberId, previousValue);
+      setLocalTeamWaiverData((prev) =>
+        prev.map((teamData) => ({
+          ...teamData,
+          members: teamData.members.map((m) =>
+            m.rosterMember.id === rosterMemberId
+              ? {
+                  ...m,
+                  rosterMember: {
+                    ...m.rosterMember,
+                    player: {
+                      ...m.rosterMember.player,
+                      submittedDriversLicense: previousValue,
+                    },
+                  },
+                }
+              : m,
+          ),
+        })),
+      );
       setUpdateError(
         err instanceof Error ? err.message : 'Failed to update submitted drivers license status',
       );
@@ -209,7 +349,24 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     const previousValue = Boolean(member.rosterMember.submittedWaiver);
     const nextValue = !previousValue;
 
-    setWaiver(rosterMemberId, selectedTeamSeasonId, nextValue);
+    setLocalTeamWaiverData((prev) =>
+      prev.map((teamData) => ({
+        ...teamData,
+        members: teamData.members.map((m) =>
+          m.rosterMember.id === rosterMemberId
+            ? {
+                ...m,
+                rosterMember: { ...m.rosterMember, submittedWaiver: nextValue },
+                seasonTeams: m.seasonTeams.map((team) =>
+                  team.teamSeasonId === selectedTeamSeasonId
+                    ? { ...team, submittedWaiver: nextValue }
+                    : team,
+                ),
+              }
+            : m,
+        ),
+      })),
+    );
     setUpdateError(null);
     setUpdatingWaiverIds((prev) => new Set(prev).add(rosterMemberId));
 
@@ -227,7 +384,24 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
       });
       unwrapApiResult(result, 'Failed to update waiver status');
     } catch (err: unknown) {
-      setWaiver(rosterMemberId, selectedTeamSeasonId, previousValue);
+      setLocalTeamWaiverData((prev) =>
+        prev.map((teamData) => ({
+          ...teamData,
+          members: teamData.members.map((m) =>
+            m.rosterMember.id === rosterMemberId
+              ? {
+                  ...m,
+                  rosterMember: { ...m.rosterMember, submittedWaiver: previousValue },
+                  seasonTeams: m.seasonTeams.map((team) =>
+                    team.teamSeasonId === selectedTeamSeasonId
+                      ? { ...team, submittedWaiver: previousValue }
+                      : team,
+                  ),
+                }
+              : m,
+          ),
+        })),
+      );
       setUpdateError(err instanceof Error ? err.message : 'Failed to update waiver status');
     } finally {
       setUpdatingWaiverIds((prev) => {
@@ -238,19 +412,131 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     }
   };
 
-  const teamsForSelectedLeague = selectedLeagueSeasonId
-    ? (teamsByLeague.get(selectedLeagueSeasonId) ?? [])
-    : [];
+  const handleCheckMultipleRegistrations = async () => {
+    if (!currentSeasonId) return;
 
-  const sortedMembers = [...members].sort((a, b) => {
-    const lastA = a.rosterMember.player.contact.lastName ?? '';
-    const lastB = b.rosterMember.player.contact.lastName ?? '';
-    const lastCompare = lastA.localeCompare(lastB);
-    if (lastCompare !== 0) return lastCompare;
-    const firstA = a.rosterMember.player.contact.firstName ?? '';
-    const firstB = b.rosterMember.player.contact.firstName ?? '';
-    return firstA.localeCompare(firstB);
-  });
+    multiRegControllerRef.current?.abort();
+    const controller = new AbortController();
+    multiRegControllerRef.current = controller;
+
+    setMultiRegOpen(true);
+    setMultiRegLoading(true);
+    setMultiRegError(null);
+    setMultiRegPlayers(null);
+
+    try {
+      const allTeams = Array.from(teamsByLeague.values()).flat();
+
+      const results = await Promise.all(
+        allTeams.map((team) =>
+          getTeamRosterWaiverSummaries({
+            client: apiClient,
+            path: {
+              accountId,
+              seasonId: currentSeasonId,
+              teamSeasonId: team.teamSeasonId,
+            },
+            signal: controller.signal,
+            throwOnError: false,
+          }),
+        ),
+      );
+
+      if (controller.signal.aborted) return;
+
+      const contactMap = new Map<
+        string,
+        { fullName: string; waiverTeams: Array<{ leagueName: string; teamName: string }> }
+      >();
+
+      for (const result of results) {
+        const teamData = unwrapApiResult(result, 'Failed to load roster');
+        for (const member of teamData.members) {
+          const contactId = member.rosterMember.player.contact.id;
+          const contact = member.rosterMember.player.contact;
+          const fullName =
+            `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() || 'Unknown';
+
+          const waiverTeams = member.seasonTeams
+            .filter((t) => t.submittedWaiver)
+            .map((t) => ({ leagueName: t.leagueName, teamName: t.teamName }));
+
+          if (waiverTeams.length >= 2 && !contactMap.has(contactId)) {
+            contactMap.set(contactId, { fullName, waiverTeams });
+          }
+        }
+      }
+
+      const flagged: MultiRegPlayer[] = Array.from(contactMap.entries())
+        .map(([contactId, data]) => ({
+          contactId,
+          fullName: data.fullName,
+          waiverTeams: data.waiverTeams,
+        }))
+        .sort((a, b) => a.fullName.localeCompare(b.fullName));
+
+      setMultiRegPlayers(flagged);
+    } catch (err: unknown) {
+      if (controller.signal.aborted) return;
+      setMultiRegError(err instanceof Error ? err.message : 'Failed to check registrations');
+    } finally {
+      if (!controller.signal.aborted) {
+        setMultiRegLoading(false);
+      }
+    }
+  };
+
+  const handleCloseMultiReg = () => {
+    multiRegControllerRef.current?.abort();
+    setMultiRegOpen(false);
+  };
+
+  const handleExportWaivers = async () => {
+    if (!currentSeasonId || !selectedLeagueSeasonId) return;
+    setExportLoading(true);
+    setExportError(null);
+    try {
+      if (selectedTeamSeasonId) {
+        const selectedTeam = teamsForSelectedLeague.find(
+          (t) => t.teamSeasonId === selectedTeamSeasonId,
+        );
+        const result = await exportTeamWaivers({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: currentSeasonId,
+            teamSeasonId: selectedTeamSeasonId,
+          },
+          throwOnError: false,
+          parseAs: 'blob',
+        });
+        const blob = unwrapApiResult(result, 'Failed to export waivers') as Blob;
+        const teamName = selectedTeam?.teamName ?? 'team';
+        const sanitizedName = teamName.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+        downloadBlob(blob, `${sanitizedName}-waivers.csv`);
+      } else {
+        const selectedLeague = leagues.find((l) => l.leagueSeasonId === selectedLeagueSeasonId);
+        const result = await exportLeagueWaivers({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: currentSeasonId,
+            leagueSeasonId: selectedLeagueSeasonId,
+          },
+          throwOnError: false,
+          parseAs: 'blob',
+        });
+        const blob = unwrapApiResult(result, 'Failed to export waivers') as Blob;
+        const leagueName = selectedLeague?.leagueName ?? 'league';
+        const sanitizedName = leagueName.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+        downloadBlob(blob, `${sanitizedName}-waivers.csv`);
+      }
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : 'Failed to export waivers');
+    } finally {
+      setExportLoading(false);
+    }
+  };
 
   return (
     <main className="min-h-screen bg-background">
@@ -295,6 +581,11 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                 {updateError}
               </Alert>
             )}
+            {exportError && (
+              <Alert severity="error" sx={{ mb: 2 }} onClose={() => setExportError(null)}>
+                {exportError}
+              </Alert>
+            )}
 
             {seasonLoading && !currentSeasonId ? (
               <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
@@ -309,6 +600,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                   spacing={2}
                   alignItems="center"
                   justifyContent="center"
+                  flexWrap="wrap"
                 >
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Typography component="label" htmlFor="waivers-league-select">
@@ -361,132 +653,250 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                       </Select>
                     </FormControl>
                   </Stack>
+
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => void handleCheckMultipleRegistrations()}
+                    disabled={leaguesLoading || leagues.length === 0}
+                  >
+                    Check for Multiple Registrations
+                  </Button>
+
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={
+                      exportLoading ? <CircularProgress size={16} /> : <FileDownloadIcon />
+                    }
+                    onClick={() => void handleExportWaivers()}
+                    disabled={!selectedLeagueSeasonId || exportLoading}
+                  >
+                    Export Waivers
+                  </Button>
                 </Stack>
 
-                {selectedTeamSeasonId && (
-                  <Paper variant="outlined">
-                    {rosterLoading ? (
-                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-                        <CircularProgress />
-                      </Box>
-                    ) : rosterError ? (
-                      <Box sx={{ p: 3 }}>
-                        <Alert severity="error">{rosterError}</Alert>
-                      </Box>
-                    ) : sortedMembers.length === 0 ? (
-                      <Box sx={{ p: 3 }}>
-                        <Typography color="text.secondary">No players on this team.</Typography>
-                      </Box>
-                    ) : (
-                      <TableContainer>
-                        <Table>
-                          <TableHead>
-                            <TableRow>
-                              <TableCell>Player</TableCell>
-                              <TableCell align="center" sx={{ width: 220 }}>
-                                Submitted Drivers License
-                              </TableCell>
-                              <TableCell align="center" sx={{ width: 200 }}>
-                                Waiver for This Team
-                              </TableCell>
-                              <TableCell>All Teams Waiver Submitted</TableCell>
-                            </TableRow>
-                          </TableHead>
-                          <TableBody>
-                            {sortedMembers.map((member) => {
-                              const rosterMemberId = member.rosterMember.id;
-                              const contact = member.rosterMember.player.contact;
-                              const fullName =
-                                `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() ||
-                                'Unknown';
-                              const teamsWithWaiver = member.seasonTeams.filter(
-                                (team) => team.submittedWaiver,
-                              );
-                              const isUpdatingDriversLicense =
-                                updatingDriversLicenseIds.has(rosterMemberId);
-                              const isUpdatingWaiver = updatingWaiverIds.has(rosterMemberId);
-                              return (
-                                <TableRow key={rosterMemberId} hover>
-                                  <TableCell>{fullName}</TableCell>
-                                  <TableCell align="center">
-                                    <Stack
-                                      direction="row"
-                                      spacing={1}
-                                      alignItems="center"
-                                      justifyContent="center"
-                                    >
-                                      <Switch
-                                        checked={Boolean(
-                                          member.rosterMember.player.submittedDriversLicense,
-                                        )}
-                                        onChange={() => handleToggleDriversLicense(member)}
-                                        disabled={isUpdatingDriversLicense}
-                                        inputProps={{
-                                          'aria-label': `Toggle submitted drivers license for ${fullName}`,
-                                        }}
-                                      />
-                                      {isUpdatingDriversLicense && <CircularProgress size={16} />}
-                                    </Stack>
-                                  </TableCell>
-                                  <TableCell align="center">
-                                    <Stack
-                                      direction="row"
-                                      spacing={1}
-                                      alignItems="center"
-                                      justifyContent="center"
-                                    >
-                                      <Switch
-                                        checked={Boolean(member.rosterMember.submittedWaiver)}
-                                        onChange={() => handleToggleWaiver(member)}
-                                        disabled={isUpdatingWaiver}
-                                        inputProps={{
-                                          'aria-label': `Toggle waiver for ${fullName}`,
-                                        }}
-                                      />
-                                      {isUpdatingWaiver && <CircularProgress size={16} />}
-                                    </Stack>
-                                  </TableCell>
-                                  <TableCell>
-                                    {teamsWithWaiver.length === 0 ? (
-                                      <Typography variant="body2" color="text.secondary">
-                                        —
-                                      </Typography>
-                                    ) : (
-                                      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                                        {teamsWithWaiver.map((team) => (
-                                          <Chip
-                                            key={team.teamSeasonId}
-                                            size="small"
-                                            color={
-                                              team.teamSeasonId === selectedTeamSeasonId
-                                                ? 'primary'
-                                                : 'default'
-                                            }
-                                            variant={
-                                              team.teamSeasonId === selectedTeamSeasonId
-                                                ? 'filled'
-                                                : 'outlined'
-                                            }
-                                            label={`${team.leagueName} / ${team.teamName}`}
-                                          />
-                                        ))}
-                                      </Stack>
-                                    )}
-                                  </TableCell>
-                                </TableRow>
-                              );
-                            })}
-                          </TableBody>
-                        </Table>
-                      </TableContainer>
+                {rosterLoading ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                    <CircularProgress />
+                  </Box>
+                ) : rosterError ? (
+                  <Alert severity="error">{rosterError}</Alert>
+                ) : (
+                  <>
+                    {leagueSummary && (
+                      <SummaryCards
+                        inLeague={leagueSummary.inLeague}
+                        anotherLeague={leagueSummary.anotherLeague}
+                        noWaiver={leagueSummary.noWaiver}
+                        total={leagueSummary.total}
+                        label="League Waiver Summary"
+                        firstStatLabel="Waiver in This League"
+                      />
                     )}
-                  </Paper>
+
+                    {teamSummary && selectedTeamSeasonId && (
+                      <SummaryCards
+                        inLeague={teamSummary.inLeague}
+                        anotherLeague={teamSummary.anotherLeague}
+                        noWaiver={teamSummary.noWaiver}
+                        total={teamSummary.total}
+                        label="Team Waiver Summary"
+                        firstStatLabel="Waiver in This Team"
+                      />
+                    )}
+
+                    {selectedTeamSeasonId && (
+                      <Paper variant="outlined">
+                        {sortedMembers.length === 0 ? (
+                          <Box sx={{ p: 3 }}>
+                            <Typography color="text.secondary">No players on this team.</Typography>
+                          </Box>
+                        ) : (
+                          <TableContainer>
+                            <Table>
+                              <TableHead>
+                                <TableRow>
+                                  <TableCell>Player</TableCell>
+                                  <TableCell align="center" sx={{ width: 220 }}>
+                                    Submitted Drivers License
+                                  </TableCell>
+                                  <TableCell align="center" sx={{ width: 200 }}>
+                                    Waiver for This Team
+                                  </TableCell>
+                                  <TableCell>All Teams Waiver Submitted</TableCell>
+                                </TableRow>
+                              </TableHead>
+                              <TableBody>
+                                {sortedMembers.map((member) => {
+                                  const rosterMemberId = member.rosterMember.id;
+                                  const contact = member.rosterMember.player.contact;
+                                  const fullName =
+                                    `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() ||
+                                    'Unknown';
+                                  const teamsWithWaiver = member.seasonTeams.filter(
+                                    (team) => team.submittedWaiver,
+                                  );
+                                  const isUpdatingDriversLicense =
+                                    updatingDriversLicenseIds.has(rosterMemberId);
+                                  const isUpdatingWaiver = updatingWaiverIds.has(rosterMemberId);
+
+                                  const waiverOnOtherTeam = member.seasonTeams.some(
+                                    (t) =>
+                                      t.teamSeasonId !== selectedTeamSeasonId && t.submittedWaiver,
+                                  );
+                                  const disableWaiverToggle =
+                                    waiverOnOtherTeam && !member.rosterMember.submittedWaiver;
+
+                                  return (
+                                    <TableRow key={rosterMemberId} hover>
+                                      <TableCell>{fullName}</TableCell>
+                                      <TableCell align="center">
+                                        <Stack
+                                          direction="row"
+                                          spacing={1}
+                                          alignItems="center"
+                                          justifyContent="center"
+                                        >
+                                          <Switch
+                                            checked={Boolean(
+                                              member.rosterMember.player.submittedDriversLicense,
+                                            )}
+                                            onChange={() => void handleToggleDriversLicense(member)}
+                                            disabled={isUpdatingDriversLicense}
+                                            inputProps={{
+                                              'aria-label': `Toggle submitted drivers license for ${fullName}`,
+                                            }}
+                                          />
+                                          {isUpdatingDriversLicense && (
+                                            <CircularProgress size={16} />
+                                          )}
+                                        </Stack>
+                                      </TableCell>
+                                      <TableCell align="center">
+                                        <Stack
+                                          direction="row"
+                                          spacing={1}
+                                          alignItems="center"
+                                          justifyContent="center"
+                                        >
+                                          <Tooltip
+                                            title={
+                                              disableWaiverToggle
+                                                ? 'This player already has a waiver on another team'
+                                                : ''
+                                            }
+                                          >
+                                            <span>
+                                              <Switch
+                                                checked={Boolean(
+                                                  member.rosterMember.submittedWaiver,
+                                                )}
+                                                onChange={() => void handleToggleWaiver(member)}
+                                                disabled={isUpdatingWaiver || disableWaiverToggle}
+                                                inputProps={{
+                                                  'aria-label': `Toggle waiver for ${fullName}`,
+                                                }}
+                                              />
+                                            </span>
+                                          </Tooltip>
+                                          {isUpdatingWaiver && <CircularProgress size={16} />}
+                                        </Stack>
+                                      </TableCell>
+                                      <TableCell>
+                                        {teamsWithWaiver.length === 0 ? (
+                                          <Typography variant="body2" color="text.secondary">
+                                            —
+                                          </Typography>
+                                        ) : (
+                                          <Stack
+                                            direction="row"
+                                            spacing={1}
+                                            flexWrap="wrap"
+                                            useFlexGap
+                                          >
+                                            {teamsWithWaiver.map((team) => (
+                                              <Chip
+                                                key={team.teamSeasonId}
+                                                size="small"
+                                                color={
+                                                  team.teamSeasonId === selectedTeamSeasonId
+                                                    ? 'primary'
+                                                    : 'default'
+                                                }
+                                                variant={
+                                                  team.teamSeasonId === selectedTeamSeasonId
+                                                    ? 'filled'
+                                                    : 'outlined'
+                                                }
+                                                label={`${team.leagueName} / ${team.teamName}`}
+                                              />
+                                            ))}
+                                          </Stack>
+                                        )}
+                                      </TableCell>
+                                    </TableRow>
+                                  );
+                                })}
+                              </TableBody>
+                            </Table>
+                          </TableContainer>
+                        )}
+                      </Paper>
+                    )}
+                  </>
                 )}
               </Stack>
             )}
           </>
         )}
       </Container>
+
+      <Dialog open={multiRegOpen} onClose={handleCloseMultiReg} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Multiple Registrations Check
+          <IconButton
+            aria-label="close"
+            onClick={handleCloseMultiReg}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          {multiRegLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : multiRegError ? (
+            <Alert severity="error">{multiRegError}</Alert>
+          ) : multiRegPlayers === null ? null : multiRegPlayers.length === 0 ? (
+            <Alert severity="success">No players with multiple registrations found.</Alert>
+          ) : (
+            <Stack spacing={2}>
+              <Typography variant="body2" color="text.secondary">
+                {multiRegPlayers.length} player{multiRegPlayers.length !== 1 ? 's' : ''} with
+                waivers on multiple teams:
+              </Typography>
+              {multiRegPlayers.map((player) => (
+                <Box key={player.contactId}>
+                  <Typography variant="subtitle2">{player.fullName}</Typography>
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 0.5 }}>
+                    {player.waiverTeams.map((wt, idx) => (
+                      <Chip
+                        key={idx}
+                        size="small"
+                        color="warning"
+                        label={`${wt.leagueName} / ${wt.teamName}`}
+                      />
+                    ))}
+                  </Stack>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -276,25 +276,9 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
   const handleToggleDriversLicense = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
     const rosterMemberId = member.rosterMember.id;
-    const previousValue = Boolean(member.rosterMember.player.submittedDriversLicense);
-    const nextValue = !previousValue;
+    const contactId = member.rosterMember.player.contact.id;
+    const nextValue = !member.rosterMember.player.submittedDriversLicense;
 
-    setLocalTeamWaiverData((prev) =>
-      prev.map((teamData) => ({
-        ...teamData,
-        members: teamData.members.map((m) =>
-          m.rosterMember.id === rosterMemberId
-            ? {
-                ...m,
-                rosterMember: {
-                  ...m.rosterMember,
-                  player: { ...m.rosterMember.player, submittedDriversLicense: nextValue },
-                },
-              }
-            : m,
-        ),
-      })),
-    );
     setUpdateError(null);
     setUpdatingDriversLicenseIds((prev) => new Set(prev).add(rosterMemberId));
 
@@ -311,26 +295,23 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
         throwOnError: false,
       });
       unwrapApiResult(result, 'Failed to update submitted drivers license status');
-    } catch (err: unknown) {
       setLocalTeamWaiverData((prev) =>
         prev.map((teamData) => ({
           ...teamData,
           members: teamData.members.map((m) =>
-            m.rosterMember.id === rosterMemberId
+            m.rosterMember.player.contact.id === contactId
               ? {
                   ...m,
                   rosterMember: {
                     ...m.rosterMember,
-                    player: {
-                      ...m.rosterMember.player,
-                      submittedDriversLicense: previousValue,
-                    },
+                    player: { ...m.rosterMember.player, submittedDriversLicense: nextValue },
                   },
                 }
               : m,
           ),
         })),
       );
+    } catch (err: unknown) {
       setUpdateError(
         err instanceof Error ? err.message : 'Failed to update submitted drivers license status',
       );
@@ -346,27 +327,10 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
   const handleToggleWaiver = async (member: WaiverMember) => {
     if (!currentSeasonId || !selectedTeamSeasonId) return;
     const rosterMemberId = member.rosterMember.id;
-    const previousValue = Boolean(member.rosterMember.submittedWaiver);
-    const nextValue = !previousValue;
+    const contactId = member.rosterMember.player.contact.id;
+    const teamSeasonId = selectedTeamSeasonId;
+    const nextValue = !member.rosterMember.submittedWaiver;
 
-    setLocalTeamWaiverData((prev) =>
-      prev.map((teamData) => ({
-        ...teamData,
-        members: teamData.members.map((m) =>
-          m.rosterMember.id === rosterMemberId
-            ? {
-                ...m,
-                rosterMember: { ...m.rosterMember, submittedWaiver: nextValue },
-                seasonTeams: m.seasonTeams.map((team) =>
-                  team.teamSeasonId === selectedTeamSeasonId
-                    ? { ...team, submittedWaiver: nextValue }
-                    : team,
-                ),
-              }
-            : m,
-        ),
-      })),
-    );
     setUpdateError(null);
     setUpdatingWaiverIds((prev) => new Set(prev).add(rosterMemberId));
 
@@ -376,32 +340,32 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
         path: {
           accountId,
           seasonId: currentSeasonId,
-          teamSeasonId: selectedTeamSeasonId,
+          teamSeasonId,
           rosterMemberId,
         },
         body: { submittedWaiver: nextValue },
         throwOnError: false,
       });
       unwrapApiResult(result, 'Failed to update waiver status');
-    } catch (err: unknown) {
       setLocalTeamWaiverData((prev) =>
         prev.map((teamData) => ({
           ...teamData,
-          members: teamData.members.map((m) =>
-            m.rosterMember.id === rosterMemberId
-              ? {
-                  ...m,
-                  rosterMember: { ...m.rosterMember, submittedWaiver: previousValue },
-                  seasonTeams: m.seasonTeams.map((team) =>
-                    team.teamSeasonId === selectedTeamSeasonId
-                      ? { ...team, submittedWaiver: previousValue }
-                      : team,
-                  ),
-                }
-              : m,
-          ),
+          members: teamData.members.map((m) => {
+            if (m.rosterMember.player.contact.id !== contactId) return m;
+            return {
+              ...m,
+              rosterMember:
+                m.rosterMember.id === rosterMemberId
+                  ? { ...m.rosterMember, submittedWaiver: nextValue }
+                  : m.rosterMember,
+              seasonTeams: m.seasonTeams.map((team) =>
+                team.teamSeasonId === teamSeasonId ? { ...team, submittedWaiver: nextValue } : team,
+              ),
+            };
+          }),
         })),
       );
+    } catch (err: unknown) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to update waiver status');
     } finally {
       setUpdatingWaiverIds((prev) => {

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -60,8 +60,8 @@ type TeamWaiverDataItem = { teamSeasonId: string; members: WaiverMember[] };
 
 function computeLeagueSummary(data: TeamWaiverDataItem[], leagueSeasonId: string) {
   const seenContactIds = new Set<string>();
-  let inLeague = 0;
-  let anotherLeague = 0;
+  let withWaiver = 0;
+  let otherWaiver = 0;
   let noWaiver = 0;
 
   for (const team of data) {
@@ -76,57 +76,59 @@ function computeLeagueSummary(data: TeamWaiverDataItem[], leagueSeasonId: string
       const hasWaiverAnywhere = member.seasonTeams.some((t) => t.submittedWaiver);
 
       if (hasWaiverInLeague) {
-        inLeague++;
+        withWaiver++;
       } else if (hasWaiverAnywhere) {
-        anotherLeague++;
+        otherWaiver++;
       } else {
         noWaiver++;
       }
     }
   }
 
-  return { inLeague, anotherLeague, noWaiver, total: seenContactIds.size };
+  return { withWaiver, otherWaiver, noWaiver, total: seenContactIds.size };
 }
 
-function computeTeamSummary(members: WaiverMember[], leagueSeasonId: string) {
-  let inLeague = 0;
-  let anotherLeague = 0;
+function computeTeamSummary(members: WaiverMember[], teamSeasonId: string) {
+  let withWaiver = 0;
+  let otherWaiver = 0;
   let noWaiver = 0;
 
   for (const member of members) {
-    const hasWaiverInLeague = member.seasonTeams.some(
-      (t) => t.leagueSeasonId === leagueSeasonId && t.submittedWaiver,
+    const hasWaiverOnTeam = member.seasonTeams.some(
+      (t) => t.teamSeasonId === teamSeasonId && t.submittedWaiver,
     );
     const hasWaiverAnywhere = member.seasonTeams.some((t) => t.submittedWaiver);
 
-    if (hasWaiverInLeague) {
-      inLeague++;
+    if (hasWaiverOnTeam) {
+      withWaiver++;
     } else if (hasWaiverAnywhere) {
-      anotherLeague++;
+      otherWaiver++;
     } else {
       noWaiver++;
     }
   }
 
-  return { inLeague, anotherLeague, noWaiver, total: members.length };
+  return { withWaiver, otherWaiver, noWaiver, total: members.length };
 }
 
 interface SummaryCardsProps {
-  inLeague: number;
-  anotherLeague: number;
+  withWaiver: number;
+  otherWaiver: number;
   noWaiver: number;
   total: number;
   label: string;
   firstStatLabel: string;
+  secondStatLabel: string;
 }
 
 function SummaryCards({
-  inLeague,
-  anotherLeague,
+  withWaiver,
+  otherWaiver,
   noWaiver,
   total,
   label,
   firstStatLabel,
+  secondStatLabel,
 }: SummaryCardsProps) {
   return (
     <Box>
@@ -137,7 +139,7 @@ function SummaryCards({
         <Card variant="outlined" sx={{ flex: 1 }}>
           <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="h5" color="success.main" align="center">
-              {inLeague}
+              {withWaiver}
             </Typography>
             <Typography variant="caption" color="text.secondary" align="center" display="block">
               {firstStatLabel}
@@ -147,10 +149,10 @@ function SummaryCards({
         <Card variant="outlined" sx={{ flex: 1 }}>
           <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="h5" color="warning.main" align="center">
-              {anotherLeague}
+              {otherWaiver}
             </Typography>
             <Typography variant="caption" color="text.secondary" align="center" display="block">
-              Waiver for Another League
+              {secondStatLabel}
             </Typography>
           </CardContent>
         </Card>
@@ -270,7 +272,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
 
   const teamSummary =
     selectedTeamSeasonId && selectedLeagueSeasonId
-      ? computeTeamSummary(displayMembers, selectedLeagueSeasonId)
+      ? computeTeamSummary(displayMembers, selectedTeamSeasonId)
       : null;
 
   const handleToggleDriversLicense = async (member: WaiverMember) => {
@@ -650,23 +652,25 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                   <>
                     {leagueSummary && (
                       <SummaryCards
-                        inLeague={leagueSummary.inLeague}
-                        anotherLeague={leagueSummary.anotherLeague}
+                        withWaiver={leagueSummary.withWaiver}
+                        otherWaiver={leagueSummary.otherWaiver}
                         noWaiver={leagueSummary.noWaiver}
                         total={leagueSummary.total}
                         label="League Waiver Summary"
                         firstStatLabel="Waiver in This League"
+                        secondStatLabel="Waiver for Another League"
                       />
                     )}
 
                     {teamSummary && selectedTeamSeasonId && (
                       <SummaryCards
-                        inLeague={teamSummary.inLeague}
-                        anotherLeague={teamSummary.anotherLeague}
+                        withWaiver={teamSummary.withWaiver}
+                        otherWaiver={teamSummary.otherWaiver}
                         noWaiver={teamSummary.noWaiver}
                         total={teamSummary.total}
                         label="Team Waiver Summary"
                         firstStatLabel="Waiver in This Team"
+                        secondStatLabel="Waiver for Another Team"
                       />
                     )}
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/useLeagueWaiverData.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/useLeagueWaiverData.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  getTeamRosterWaiverSummaries,
+  type TeamRosterWaiverSummaries,
+} from '@draco/shared-api-client';
+import { useApiClient } from '../../../../hooks/useApiClient';
+import { unwrapApiResult } from '../../../../utils/apiResult';
+import { type TeamOption } from './useSeasonLeaguesAndTeams';
+
+export type WaiverMember = TeamRosterWaiverSummaries['members'][number];
+
+export interface TeamWaiverData {
+  teamSeasonId: string;
+  members: WaiverMember[];
+}
+
+interface UseLeagueWaiverDataResult {
+  teamWaiverData: TeamWaiverData[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useLeagueWaiverData(
+  accountId: string,
+  seasonId: string | null,
+  leagueSeasonId: string,
+  teamsByLeague: Map<string, TeamOption[]>,
+): UseLeagueWaiverDataResult {
+  const apiClient = useApiClient();
+  const [teamWaiverData, setTeamWaiverData] = useState<TeamWaiverData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!accountId || !seasonId || !leagueSeasonId) {
+      setTeamWaiverData([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const teams = teamsByLeague.get(leagueSeasonId) ?? [];
+
+    if (teams.length === 0) {
+      setTeamWaiverData([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const results = await Promise.all(
+          teams.map((team) =>
+            getTeamRosterWaiverSummaries({
+              client: apiClient,
+              path: {
+                accountId,
+                seasonId,
+                teamSeasonId: team.teamSeasonId,
+              },
+              signal: controller.signal,
+              throwOnError: false,
+            }),
+          ),
+        );
+
+        if (controller.signal.aborted) return;
+
+        const data: TeamWaiverData[] = results.map((result, index) => {
+          const teamData = unwrapApiResult(result, 'Failed to load roster');
+          return {
+            teamSeasonId: teams[index].teamSeasonId,
+            members: teamData.members,
+          };
+        });
+
+        setTeamWaiverData(data);
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load roster data');
+        setTeamWaiverData([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, seasonId, leagueSeasonId, teamsByLeague, apiClient]);
+
+  return { teamWaiverData, loading, error };
+}

--- a/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
@@ -80,6 +80,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
   const [searchLoading, setSearchLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [seasonTeamWaivers, setSeasonTeamWaivers] = useState<RosterMemberSeasonTeamWaiver[]>([]);
+  const [seasonTeamWaiversLoaded, setSeasonTeamWaiversLoaded] = useState(false);
 
   // Use custom hooks for debouncing and delayed loading
   const debouncedSearchInput = useDebouncedValue(searchInput, 400);
@@ -274,6 +275,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
     setSignMultiplePlayers(false);
     setError(null);
     setSeasonTeamWaivers([]);
+    setSeasonTeamWaiversLoaded(false);
     reset(getDefaultFormValues());
 
     if (abortControllerRef.current) {
@@ -288,6 +290,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
     }
 
     const controller = new AbortController();
+    setSeasonTeamWaiversLoaded(false);
 
     const loadWaiverSummaries = async () => {
       try {
@@ -308,6 +311,10 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
       } catch {
         if (controller.signal.aborted) return;
         setSeasonTeamWaivers([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setSeasonTeamWaiversLoaded(true);
+        }
       }
     };
 
@@ -483,6 +490,11 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
     Boolean(enableWaiverTracking) &&
     otherTeamsWithWaiver.length > 0 &&
     !currentTeamHasWaiver;
+  const waiverSummaryPending =
+    mode === 'edit' &&
+    Boolean(enableWaiverTracking) &&
+    Boolean(rosterMemberId) &&
+    !seasonTeamWaiversLoaded;
 
   return (
     <Dialog open={open} onClose={isSubmitting ? undefined : onClose} maxWidth="sm" fullWidth>
@@ -631,6 +643,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
                           onChange={(event) => field.onChange(event.target.checked)}
                           disabled={
                             waiverLockedToOtherTeam ||
+                            waiverSummaryPending ||
                             (isSigningNewPlayer && (!selectedPlayer || loadingPlayerRoster)) ||
                             isSubmitting
                           }

--- a/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
@@ -24,10 +24,16 @@ import {
   SignRosterMemberType,
   UpdateRosterMemberType,
 } from '@draco/shared-schemas';
+import {
+  getTeamRosterWaiverSummaries,
+  type RosterMemberSeasonTeamWaiver,
+} from '@draco/shared-api-client';
 import { useRosterPlayer, RosterPlayerMutationResult } from '../../hooks/roster/useRosterPlayer';
+import { useApiClient } from '../../hooks/useApiClient';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { useDelayedLoading } from '../../hooks/useDelayedLoading';
 import { getContactDisplayName } from '../../utils/contactUtils';
+import { unwrapApiResult } from '../../utils/apiResult';
 import { Controller, Resolver, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -66,11 +72,14 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
   enableWaiverTracking = true,
   enableIdentificationTracking = true,
 }) => {
+  const apiClient = useApiClient();
+
   // Search states - contained within this component
   const [searchInput, setSearchInput] = useState('');
   const [availablePlayers, setAvailablePlayers] = useState<BaseContactType[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [seasonTeamWaivers, setSeasonTeamWaivers] = useState<RosterMemberSeasonTeamWaiver[]>([]);
 
   // Use custom hooks for debouncing and delayed loading
   const debouncedSearchInput = useDebouncedValue(searchInput, 400);
@@ -264,6 +273,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
     setLoadingPlayerRoster(false);
     setSignMultiplePlayers(false);
     setError(null);
+    setSeasonTeamWaivers([]);
     reset(getDefaultFormValues());
 
     if (abortControllerRef.current) {
@@ -271,6 +281,51 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
       abortControllerRef.current = null;
     }
   }, [open, reset]);
+
+  useEffect(() => {
+    if (!open || mode !== 'edit' || !enableWaiverTracking || !rosterMemberId) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const loadWaiverSummaries = async () => {
+      try {
+        const result = await getTeamRosterWaiverSummaries({
+          client: apiClient,
+          path: { accountId, seasonId, teamSeasonId },
+          signal: controller.signal,
+          throwOnError: false,
+        });
+
+        if (controller.signal.aborted) return;
+
+        const data = unwrapApiResult(result, 'Failed to load waiver summaries');
+        const match = data.members.find((m) => m.rosterMember.id === rosterMemberId);
+
+        if (controller.signal.aborted) return;
+        setSeasonTeamWaivers(match?.seasonTeams ?? []);
+      } catch {
+        if (controller.signal.aborted) return;
+        setSeasonTeamWaivers([]);
+      }
+    };
+
+    void loadWaiverSummaries();
+
+    return () => {
+      controller.abort();
+    };
+  }, [
+    open,
+    mode,
+    enableWaiverTracking,
+    rosterMemberId,
+    accountId,
+    seasonId,
+    teamSeasonId,
+    apiClient,
+  ]);
 
   // Handle player selection
   const handlePlayerSelect = async (newValue: BaseContactType | null) => {
@@ -417,6 +472,18 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
 
   const handleDialogSubmit = submitForm(onValidSubmit);
 
+  const otherTeamsWithWaiver = seasonTeamWaivers.filter(
+    (t) => t.teamSeasonId !== teamSeasonId && t.submittedWaiver,
+  );
+  const currentTeamHasWaiver = seasonTeamWaivers.some(
+    (t) => t.teamSeasonId === teamSeasonId && t.submittedWaiver,
+  );
+  const waiverLockedToOtherTeam =
+    mode === 'edit' &&
+    Boolean(enableWaiverTracking) &&
+    otherTeamsWithWaiver.length > 0 &&
+    !currentTeamHasWaiver;
+
   return (
     <Dialog open={open} onClose={isSubmitting ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
@@ -556,19 +623,27 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
                 name="submittedWaiver"
                 control={control}
                 render={({ field }) => (
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={field.value ?? false}
-                        onChange={(event) => field.onChange(event.target.checked)}
-                        disabled={
-                          (isSigningNewPlayer && (!selectedPlayer || loadingPlayerRoster)) ||
-                          isSubmitting
-                        }
-                      />
-                    }
-                    label="Submitted Waiver"
-                  />
+                  <Box>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={field.value ?? false}
+                          onChange={(event) => field.onChange(event.target.checked)}
+                          disabled={
+                            waiverLockedToOtherTeam ||
+                            (isSigningNewPlayer && (!selectedPlayer || loadingPlayerRoster)) ||
+                            isSubmitting
+                          }
+                        />
+                      }
+                      label="Submitted Waiver"
+                    />
+                    {waiverLockedToOtherTeam && (
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        {`Waiver already submitted for ${otherTeamsWithWaiver.map((t) => `${t.leagueName} / ${t.teamName}`).join('; ')}`}
+                      </Typography>
+                    )}
+                  </Box>
                 )}
               />
             ) : null}


### PR DESCRIPTION
Introduce server-side support for exporting submitted-waiver rosters. This adds two new endpoints (team and league waiver exports) to OpenAPI, registers paths in the exports path registry, and implements route handlers that stream CSV blobs. Backend changes include new repository methods (findTeamWaiverRosterForExport, findLeagueWaiverRosterForExport) and a dbWaiverExportData type, updates to Prisma export selects to include submitted waiver and team/league info, and IRosterRepository interface additions. The csv export service and generator were extended to produce waiver CSVs (Team column, filters out null/empty emails, ordering), and comprehensive tests were added/updated covering team/league waiver exports and existing roster exports. Also added planning docs for waiver features and updated OpenAPI (json/yaml) paths. Summary: API + repo + service + route + type + test + OpenAPI changes to enable waiver CSV exports.