### PR TITLE
Add missing-waivers CSV export endpoints and UI

### DIFF
--- a/docs/email-recipient-service-refactor-plan.md
+++ b/docs/email-recipient-service-refactor-plan.md
@@ -1,0 +1,120 @@
+# Email Recipient Service Refactor Plan
+
+## Background
+
+`frontend-next/services/emailRecipientService.ts` is the only service in the frontend that:
+
+- Returns a custom `AsyncResult<T>` (`{ success: true, data } | { success: false, error }`) from every public method instead of throwing.
+- Wraps every API call in `executeRequest` → `withRetry` + `safeAsync` → `logError` from `utils/errorHandling.ts`.
+- Treats transient network conditions as "retryable" and auto-retries up to `config.maxRetries` (default 3) times, each with exponential backoff.
+
+Every other service in the codebase calls generated OpenAPI operations directly, lets errors throw, and relies on the caller's `useEffect` (with `AbortController`) to discard results on unmount / dep change.
+
+## Problem the refactor addresses
+
+This service's pipeline has three observed downsides:
+
+1. **Intentional `AbortController` aborts are treated as errors.** When a consumer's effect aborts an in-flight request, the rejection flows into `safeAsync`, which normalizes it to `UNKNOWN_ERROR` and logs a MEDIUM SEVERITY warning. A narrow fix (detect abort in `safeAsync` / `withRetry`) already shipped to stop the log noise, but the root issue is that the wrapper considers every rejection a logged error.
+2. **Retries are silent and can multiply load.** A transient 503 gets retried three times before the consumer sees it, with no UI signal in between. Consumers have no way to opt out.
+3. **Consumers work around the wrapper.** `useContactFetching.ts` and `useEmailRecipients.ts` both branch on `result.success`, immediately re-throwing or mapping `result.error.message` back into a plain string for display. The `AsyncResult` shape adds ceremony without adding information the caller actually uses.
+
+## Goals
+
+- Bring `emailRecipientService` in line with the rest of the codebase: methods throw, callers handle errors in their `useEffect` with `AbortController`.
+- Remove the custom retry layer. If retry is ever wanted, it should be opt-in at the call site, not default.
+- Remove the centralized `logError` hop for this service. Error reporting is the consumer's job.
+- Delete or relocate the `utils/errorHandling.ts` machinery if `emailRecipientService` was its only consumer.
+
+## Non-goals
+
+- Changing backend error shapes.
+- Touching the email compose UI flow or business logic.
+- Changing how other services handle errors.
+- Changing the shared `ApiClientError` / `unwrapApiResult` helpers.
+
+## Scope
+
+### Files that change
+
+| File | Change |
+|---|---|
+| `services/emailRecipientService.ts` | All 11 public methods switch from `AsyncResult<T>` to `Promise<T>` (throw on error). Drop `executeRequest`, `withRetry`, `safeAsync`, `logError`. Drop per-method pre-validation that currently returns an `AsyncResult` error — throw instead, or move the validation to the caller if it is actually caller input. |
+| `services/__tests__/emailRecipientService.test.ts` | Rewrite. Tests currently assert the `AsyncResult` shape and the retry/log behavior. After the refactor, assert the promise resolves / rejects with `ApiClientError` (or the appropriate thrown error). Retry-specific tests are deleted. |
+| `hooks/useEmailRecipients.ts` | Remove `result.success` branching. Wrap calls in `try/catch` inside effects. Thread `signal?: AbortSignal` through the service where consumers hold an `AbortController`. |
+| `components/emails/recipients/hooks/useContactFetching.ts` | Same treatment as `useEmailRecipients.ts`. This is the heaviest consumer — three call sites (`fetchContacts` x2, `searchContacts`). |
+| `components/emails/recipients/TeamRosterRecipientPanel.tsx` | Replace `if (result.success) { ... } else { setError(result.error.message) }` with `try/catch`; keep the existing `AbortController` pattern. |
+| `components/emails/compose/GroupBadgeEditDialog.tsx` | Same as above for `fetchGroupContacts`. |
+
+### Files to investigate for deletion
+
+| File | Reason |
+|---|---|
+| `utils/errorHandling.ts` | If `emailRecipientService` is the only caller of `safeAsync`, `safe`, `withRetry`, `logError`, `normalizeError`, `createEmailRecipientError`, `handleApiError` — delete. Grep before removing. |
+| `types/errors.ts` | Same — if `EmailRecipientError`, `EmailRecipientErrorCode`, `AsyncResult`, `Result`, `ErrorSeverity`, the type guards (`isEmailRecipientError`, `isNetworkError`, etc.) are only consumed inside `emailRecipientService` and `utils/errorHandling.ts`, delete. |
+
+Grep before deleting: `AsyncResult`, `Result<`, `EmailRecipientError`, `safeAsync`, `withRetry`, `logError` across the whole `frontend-next` tree.
+
+## Migration strategy
+
+1. **Add `signal?: AbortSignal` parameters** to every service method that a consumer calls from inside a `useEffect`. Several already have one (`fetchTeamRosterContacts`, `fetchGroupContacts`); the rest need to be added. Thread straight through to the generated client call.
+2. **Flip one method at a time, bottom-up.** Start with a leaf method with a single caller (`fetchTeamRosterContacts` → `TeamRosterRecipientPanel`). Change the method to return `Promise<T>` and throw, update the one caller's `try/catch`, re-run type-check + the relevant Vitest file. Repeat for each method.
+3. **Delete `executeRequest` last.** Once no method references it, remove it plus the `config` / `configureErrorHandling` / `enableRetries` wiring on the service class.
+4. **Rewrite tests as each method migrates.** Don't defer — the existing tests will fail the moment a method stops returning `AsyncResult`.
+5. **Delete `utils/errorHandling.ts` and `types/errors.ts` last,** only after grep confirms no remaining consumers.
+
+## Consumer `try/catch` template
+
+```typescript
+useEffect(() => {
+  if (!accountId) return;
+  const controller = new AbortController();
+
+  const loadContacts = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchTeamRosterContacts(
+        accountId,
+        token,
+        seasonId,
+        teamSeasonId,
+        { signal: controller.signal },
+      );
+      if (controller.signal.aborted) return;
+      setContacts(data);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setError(err instanceof Error ? err.message : 'Failed to load roster contacts');
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  };
+
+  void loadContacts();
+  return () => controller.abort();
+}, [accountId, seasonId, teamSeasonId, token]);
+```
+
+This matches the AbortController pattern documented in `frontend-next/AGENTS.md` and used throughout the codebase (e.g. `hooks/usePendingPhotoSubmissions.ts`, `components/team/TeamManagersWidget.tsx`).
+
+## Risk assessment
+
+- **Blast radius:** five files plus the 470-line test file. All within the email compose feature.
+- **Regression surface:** the email compose flow, the advanced recipient dialog, the group badge edit dialog, and the hierarchical recipient tree. Covered by the service test file today and by e2e tests in `frontend-next/e2e/tests/account/communications-compose-attachments.spec.ts`.
+- **Silent behavior change:** consumers currently get up to 3 retries on transient errors. After the refactor, they get one attempt. This is a deliberate behavior change — document it in the PR and confirm with stakeholders before merging.
+
+## Effort estimate
+
+- Service rewrite: ~half day.
+- Consumer updates: ~half day (three `try/catch` sites are trivial; `useContactFetching.ts` and `useEmailRecipients.ts` are the time sinks).
+- Test rewrite: ~half to one day depending on how much of the existing coverage is worth keeping vs. deleting.
+- Cleanup of `utils/errorHandling.ts` and `types/errors.ts`: ~an hour once grep confirms they're unused.
+
+Total: 1.5–2 working days. No database or backend changes.
+
+## Open questions
+
+- Is the retry behavior load-bearing anywhere in production? If so, the three call sites that were relying on it need explicit retry logic after the refactor.
+- Should `ApiClientError` grow a `isAbort` getter so consumers can distinguish abort from real failures without string matching? (Follow-up, not required for this refactor.)
+- Does any telemetry / monitoring rely on the `MEDIUM SEVERITY ERROR:` log line emitted by `logError`? If so, replace it with equivalent reporting at the consumer layer before deleting the logger.

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -48441,6 +48441,200 @@
         }
       }
     },
+    "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/missing/export": {
+      "get": {
+        "description": "Export team players missing a submitted waiver to CSV file",
+        "summary": "Export team players missing a waiver",
+        "operationId": "exportTeamMissingWaivers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Exports"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/missing/export": {
+      "get": {
+        "description": "Export league players missing a submitted waiver to CSV file (ordered by team, includes players without an email)",
+        "summary": "Export league players missing a waiver",
+        "operationId": "exportLeagueMissingWaivers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Exports"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "leagueSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export": {
       "get": {
         "description": "Export team roster to CSV file",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -34431,6 +34431,101 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/missing/export:
+    get:
+      description: Export team players missing a submitted waiver to CSV file
+      summary: Export team players missing a waiver
+      operationId: exportTeamMissingWaivers
+      security:
+        - bearerAuth: []
+      tags:
+        - Exports
+      parameters:
+        - *a14
+        - *a15
+        - name: teamSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: CSV file export
+          content:
+            text/csv: *a16
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/missing/export:
+    get:
+      description: Export league players missing a submitted waiver to CSV file
+        (ordered by team, includes players without an email)
+      summary: Export league players missing a waiver
+      operationId: exportLeagueMissingWaivers
+      security:
+        - bearerAuth: []
+      tags:
+        - Exports
+      parameters:
+        - *a14
+        - *a15
+        - name: leagueSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: CSV file export
+          content:
+            text/csv: *a16
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
   /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export:
     get:
       description: Export team roster to CSV file

--- a/draco-nodejs/backend/src/openapi/paths/exports/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/exports/index.ts
@@ -94,6 +94,47 @@ export const registerExportsEndpoints = ({ registry, schemaRefs }: RegisterConte
 
   registry.registerPath({
     method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/waivers/missing/export',
+    description: 'Export team players missing a submitted waiver to CSV file',
+    summary: 'Export team players missing a waiver',
+    operationId: 'exportTeamMissingWaivers',
+    security: [{ bearerAuth: [] }],
+    tags: ['Exports'],
+    parameters: [
+      ...pathParams,
+      {
+        name: 'teamSeasonId',
+        in: 'path' as const,
+        required: true,
+        schema: { type: 'string' as const, format: 'number' },
+      },
+    ],
+    responses: csvResponse,
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/leagues/{leagueSeasonId}/roster/waivers/missing/export',
+    description:
+      'Export league players missing a submitted waiver to CSV file (ordered by team, includes players without an email)',
+    summary: 'Export league players missing a waiver',
+    operationId: 'exportLeagueMissingWaivers',
+    security: [{ bearerAuth: [] }],
+    tags: ['Exports'],
+    parameters: [
+      ...pathParams,
+      {
+        name: 'leagueSeasonId',
+        in: 'path' as const,
+        required: true,
+        schema: { type: 'string' as const, format: 'number' },
+      },
+    ],
+    responses: csvResponse,
+  });
+
+  registry.registerPath({
+    method: 'get',
     path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/export',
     description: 'Export team roster to CSV file',
     summary: 'Export team roster',

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
@@ -488,4 +488,91 @@ export class PrismaRosterRepository implements IRosterRepository {
 
     return { leagueName: leagueSeason.league.name, members };
   }
+
+  async findTeamMissingWaiverRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    teamSeasonId: bigint,
+  ): Promise<{ teamName: string; members: dbWaiverExportData[] }> {
+    const teamSeason = await this.prisma.teamsseason.findFirst({
+      where: {
+        id: teamSeasonId,
+        leagueseason: {
+          seasonid: seasonId,
+          league: { accountid: accountId },
+        },
+      },
+      select: { name: true },
+    });
+
+    if (!teamSeason) {
+      throw new NotFoundError('Team season not found');
+    }
+
+    const members = await this.prisma.rosterseason.findMany({
+      where: {
+        teamseasonid: teamSeasonId,
+        inactive: false,
+        roster: {
+          rosterseason: {
+            none: {
+              submittedwaiver: true,
+              inactive: false,
+              teamsseason: { leagueseason: { seasonid: seasonId } },
+            },
+          },
+        },
+      },
+      select: this.waiverExportSelect,
+      orderBy: [
+        { roster: { contacts: { lastname: 'asc' } } },
+        { roster: { contacts: { firstname: 'asc' } } },
+      ],
+    });
+
+    return { teamName: teamSeason.name, members };
+  }
+
+  async findLeagueMissingWaiverRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbWaiverExportData[] }> {
+    const leagueSeason = await this.prisma.leagueseason.findFirst({
+      where: {
+        id: leagueSeasonId,
+        seasonid: seasonId,
+        league: { accountid: accountId },
+      },
+      select: { league: { select: { name: true } } },
+    });
+
+    if (!leagueSeason) {
+      throw new NotFoundError('League season not found');
+    }
+
+    const members = await this.prisma.rosterseason.findMany({
+      where: {
+        teamsseason: { leagueseasonid: leagueSeasonId },
+        inactive: false,
+        roster: {
+          rosterseason: {
+            none: {
+              submittedwaiver: true,
+              inactive: false,
+              teamsseason: { leagueseason: { seasonid: seasonId } },
+            },
+          },
+        },
+      },
+      select: this.waiverExportSelect,
+      orderBy: [
+        { teamsseason: { name: 'asc' } },
+        { roster: { contacts: { lastname: 'asc' } } },
+        { roster: { contacts: { firstname: 'asc' } } },
+      ],
+    });
+
+    return { leagueName: leagueSeason.league.name, members };
+  }
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
@@ -78,4 +78,14 @@ export interface IRosterRepository {
     seasonId: bigint,
     leagueSeasonId: bigint,
   ): Promise<{ leagueName: string; members: dbWaiverExportData[] }>;
+  findTeamMissingWaiverRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    teamSeasonId: bigint,
+  ): Promise<{ teamName: string; members: dbWaiverExportData[] }>;
+  findLeagueMissingWaiverRosterForExport(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<{ leagueName: string; members: dbWaiverExportData[] }>;
 }

--- a/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/exports.test.ts
@@ -82,6 +82,8 @@ const csvExportServiceMock = {
   exportSeasonManagers: vi.fn(),
   exportTeamWaivers: vi.fn(),
   exportLeagueWaivers: vi.fn(),
+  exportTeamMissingWaivers: vi.fn(),
+  exportLeagueMissingWaivers: vi.fn(),
 };
 
 let app: Express;
@@ -369,6 +371,54 @@ describe('Exports routes', () => {
     });
   });
 
+  describe('GET /teams/:teamSeasonId/roster/waivers/missing/export', () => {
+    it('exports team missing waivers as CSV', async () => {
+      const csvBuffer = Buffer.from('Full Name,Email,Team\nJohn Doe,,Tigers');
+      csvExportServiceMock.exportTeamMissingWaivers.mockResolvedValue({
+        buffer: csvBuffer,
+        fileName: 'tigers-missing-waivers.csv',
+      });
+
+      const { res } = await runRoute('get', '/teams/:teamSeasonId/roster/waivers/missing/export', {
+        params: { accountId: '1', seasonId: '1', teamSeasonId: '75' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toBe('text/csv');
+      expect(res.headers['Content-Disposition']).toContain('tigers-missing-waivers.csv');
+      expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportTeamMissingWaivers).toHaveBeenCalledWith(1n, 1n, 75n);
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+  });
+
+  describe('GET /leagues/:leagueSeasonId/roster/waivers/missing/export', () => {
+    it('exports league missing waivers as CSV', async () => {
+      const csvBuffer = Buffer.from('Full Name,Email,Team\nJane Smith,,Panthers');
+      csvExportServiceMock.exportLeagueMissingWaivers.mockResolvedValue({
+        buffer: csvBuffer,
+        fileName: 'spring-league-missing-waivers.csv',
+      });
+
+      const { res } = await runRoute(
+        'get',
+        '/leagues/:leagueSeasonId/roster/waivers/missing/export',
+        {
+          params: { accountId: '1', seasonId: '1', leagueSeasonId: '50' },
+          headers: { authorization: 'Bearer token' },
+        },
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toBe('text/csv');
+      expect(res.headers['Content-Disposition']).toContain('spring-league-missing-waivers.csv');
+      expect(res.body).toEqual(csvBuffer);
+      expect(csvExportServiceMock.exportLeagueMissingWaivers).toHaveBeenCalledWith(1n, 1n, 50n);
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+  });
+
   describe('authorization', () => {
     it('requires manage-users permission for team waivers export', async () => {
       csvExportServiceMock.exportTeamWaivers.mockResolvedValue({
@@ -448,6 +498,34 @@ describe('Exports routes', () => {
 
       await runRoute('get', '/managers/export', {
         params: { accountId: '1', seasonId: '1' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+
+    it('requires manage-users permission for team missing waivers export', async () => {
+      csvExportServiceMock.exportTeamMissingWaivers.mockResolvedValue({
+        buffer: Buffer.from(''),
+        fileName: 'test.csv',
+      });
+
+      await runRoute('get', '/teams/:teamSeasonId/roster/waivers/missing/export', {
+        params: { accountId: '1', seasonId: '1', teamSeasonId: '75' },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(lastPermissionRequested).toBe('manage-users');
+    });
+
+    it('requires manage-users permission for league missing waivers export', async () => {
+      csvExportServiceMock.exportLeagueMissingWaivers.mockResolvedValue({
+        buffer: Buffer.from(''),
+        fileName: 'test.csv',
+      });
+
+      await runRoute('get', '/leagues/:leagueSeasonId/roster/waivers/missing/export', {
+        params: { accountId: '1', seasonId: '1', leagueSeasonId: '50' },
         headers: { authorization: 'Bearer token' },
       });
 

--- a/draco-nodejs/backend/src/routes/exports.ts
+++ b/draco-nodejs/backend/src/routes/exports.ts
@@ -58,6 +58,62 @@ router.get(
 );
 
 router.get(
+  '/teams/:teamSeasonId/roster/waivers/missing/export',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('manage-users'),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'teamSeasonId',
+    );
+
+    const result = await csvExportService.exportTeamMissingWaivers(
+      accountId,
+      seasonId,
+      teamSeasonId,
+    );
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      contentDisposition(result.fileName, { type: 'attachment' }),
+    );
+    res.send(result.buffer);
+  }),
+);
+
+router.get(
+  '/leagues/:leagueSeasonId/roster/waivers/missing/export',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('manage-users'),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, leagueSeasonId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'leagueSeasonId',
+    );
+
+    const result = await csvExportService.exportLeagueMissingWaivers(
+      accountId,
+      seasonId,
+      leagueSeasonId,
+    );
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      contentDisposition(result.fileName, { type: 'attachment' }),
+    );
+    res.send(result.buffer);
+  }),
+);
+
+router.get(
   '/leagues/:leagueSeasonId/roster/export',
   authenticateToken,
   routeProtection.enforceAccountBoundary(),

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -36,6 +36,10 @@ class RosterRepositoryStub implements IRosterRepository {
   findSeasonRosterForExport = vi.fn<IRosterRepository['findSeasonRosterForExport']>();
   findTeamWaiverRosterForExport = vi.fn<IRosterRepository['findTeamWaiverRosterForExport']>();
   findLeagueWaiverRosterForExport = vi.fn<IRosterRepository['findLeagueWaiverRosterForExport']>();
+  findTeamMissingWaiverRosterForExport =
+    vi.fn<IRosterRepository['findTeamMissingWaiverRosterForExport']>();
+  findLeagueMissingWaiverRosterForExport =
+    vi.fn<IRosterRepository['findLeagueMissingWaiverRosterForExport']>();
 }
 
 class ManagerRepositoryStub implements IManagerRepository {
@@ -986,6 +990,200 @@ describe('CsvExportService', () => {
           'Export limit exceeded: 15000 rows requested, maximum is 10000',
         );
       }
+    });
+  });
+
+  describe('exportTeamMissingWaivers', () => {
+    it('should export team missing waivers with correct filename', async () => {
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [createMockWaiverExportData()],
+      });
+
+      const result = await service.exportTeamMissingWaivers(1n, 1n, 100n);
+
+      expect(result.fileName).toBe('panthers-missing-waivers.csv');
+      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(rosterRepository.findTeamMissingWaiverRosterForExport).toHaveBeenCalledWith(
+        1n,
+        1n,
+        100n,
+      );
+    });
+
+    it('should include player data in CSV', async () => {
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [
+          createMockWaiverExportData({
+            firstname: 'John',
+            lastname: 'Doe',
+            email: 'john@example.com',
+            streetaddress: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62701',
+            teamName: 'Panthers',
+          }),
+        ],
+      });
+
+      const result = await service.exportTeamMissingWaivers(1n, 1n, 100n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('John Doe');
+      expect(csvContent).toContain('john@example.com');
+      expect(csvContent).toContain('123 Main St');
+      expect(csvContent).toContain('Springfield');
+      expect(csvContent).toContain('IL');
+      expect(csvContent).toContain('62701');
+      expect(csvContent).toContain('Panthers');
+    });
+
+    it('should include players with null email (unlike regular waiver export)', async () => {
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [
+          createMockWaiverExportData({ firstname: 'No', lastname: 'Email', email: null }),
+          createMockWaiverExportData({
+            firstname: 'Has',
+            lastname: 'Email',
+            email: 'has@example.com',
+          }),
+        ],
+      });
+
+      const result = await service.exportTeamMissingWaivers(1n, 1n, 100n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('No Email');
+      expect(csvContent).toContain('Has Email');
+    });
+
+    it('should include players with empty email', async () => {
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Panthers',
+        members: [createMockWaiverExportData({ firstname: 'Empty', lastname: 'Email', email: '' })],
+      });
+
+      const result = await service.exportTeamMissingWaivers(1n, 1n, 100n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Empty Email');
+    });
+
+    it('should handle empty list', async () => {
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Empty Team',
+        members: [],
+      });
+
+      const result = await service.exportTeamMissingWaivers(1n, 1n, 100n);
+
+      expect(result.fileName).toBe('empty-team-missing-waivers.csv');
+      expect(result.buffer.toString()).toBe('');
+    });
+
+    it('should throw PayloadTooLargeError when missing waivers exceed 10,000 rows', async () => {
+      const largeDataset = Array.from({ length: 10001 }, (_, i) =>
+        createMockWaiverExportData({ firstname: `User${i}` }),
+      );
+      rosterRepository.findTeamMissingWaiverRosterForExport.mockResolvedValue({
+        teamName: 'Large Team',
+        members: largeDataset,
+      });
+
+      await expect(service.exportTeamMissingWaivers(1n, 1n, 100n)).rejects.toThrow(
+        PayloadTooLargeError,
+      );
+    });
+  });
+
+  describe('exportLeagueMissingWaivers', () => {
+    it('should export league missing waivers with correct filename', async () => {
+      rosterRepository.findLeagueMissingWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [createMockWaiverExportData()],
+      });
+
+      const result = await service.exportLeagueMissingWaivers(1n, 1n, 50n);
+
+      expect(result.fileName).toBe('spring-league-missing-waivers.csv');
+      expect(rosterRepository.findLeagueMissingWaiverRosterForExport).toHaveBeenCalledWith(
+        1n,
+        1n,
+        50n,
+      );
+    });
+
+    it('should include team name in exported data', async () => {
+      rosterRepository.findLeagueMissingWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [
+          createMockWaiverExportData({
+            teamName: 'Tigers',
+            firstname: 'Alice',
+            lastname: 'Jones',
+          }),
+          createMockWaiverExportData({
+            teamName: 'Panthers',
+            firstname: 'Bob',
+            lastname: 'Smith',
+          }),
+        ],
+      });
+
+      const result = await service.exportLeagueMissingWaivers(1n, 1n, 50n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('Tigers');
+      expect(csvContent).toContain('Panthers');
+    });
+
+    it('should include players with null email (unlike regular waiver export)', async () => {
+      rosterRepository.findLeagueMissingWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Spring League',
+        members: [
+          createMockWaiverExportData({ firstname: 'No', lastname: 'Email', email: null }),
+          createMockWaiverExportData({
+            firstname: 'Has',
+            lastname: 'Email',
+            email: 'has@example.com',
+          }),
+        ],
+      });
+
+      const result = await service.exportLeagueMissingWaivers(1n, 1n, 50n);
+      const csvContent = result.buffer.toString();
+
+      expect(csvContent).toContain('No Email');
+      expect(csvContent).toContain('Has Email');
+    });
+
+    it('should handle empty league missing waiver list', async () => {
+      rosterRepository.findLeagueMissingWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Empty League',
+        members: [],
+      });
+
+      const result = await service.exportLeagueMissingWaivers(1n, 1n, 50n);
+
+      expect(result.fileName).toBe('empty-league-missing-waivers.csv');
+      expect(result.buffer.toString()).toBe('');
+    });
+
+    it('should throw PayloadTooLargeError when league missing waivers exceed 10,000 rows', async () => {
+      const largeDataset = Array.from({ length: 10001 }, (_, i) =>
+        createMockWaiverExportData({ firstname: `User${i}` }),
+      );
+      rosterRepository.findLeagueMissingWaiverRosterForExport.mockResolvedValue({
+        leagueName: 'Large League',
+        members: largeDataset,
+      });
+
+      await expect(service.exportLeagueMissingWaivers(1n, 1n, 50n)).rejects.toThrow(
+        PayloadTooLargeError,
+      );
     });
   });
 

--- a/draco-nodejs/backend/src/services/csvExportService.ts
+++ b/draco-nodejs/backend/src/services/csvExportService.ts
@@ -132,6 +132,57 @@ export class CsvExportService {
     };
   }
 
+  async exportTeamMissingWaivers(
+    accountId: bigint,
+    seasonId: bigint,
+    teamSeasonId: bigint,
+  ): Promise<CsvExportResult> {
+    const startTime = Date.now();
+    const { teamName, members } = await this.rosterRepository.findTeamMissingWaiverRosterForExport(
+      accountId,
+      seasonId,
+      teamSeasonId,
+    );
+    const rows = this.mapMissingWaiversToExportRows(members);
+    this.checkExportLimit(rows.length, 'team missing waivers', teamName);
+    const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
+    const sanitizedName = this.sanitizeFileName(teamName);
+    this.logExportMetrics('team missing waivers', teamName, rows.length, buffer.length, startTime);
+    return {
+      buffer,
+      fileName: `${sanitizedName}-missing-waivers.csv`,
+    };
+  }
+
+  async exportLeagueMissingWaivers(
+    accountId: bigint,
+    seasonId: bigint,
+    leagueSeasonId: bigint,
+  ): Promise<CsvExportResult> {
+    const startTime = Date.now();
+    const { leagueName, members } =
+      await this.rosterRepository.findLeagueMissingWaiverRosterForExport(
+        accountId,
+        seasonId,
+        leagueSeasonId,
+      );
+    const rows = this.mapMissingWaiversToExportRows(members);
+    this.checkExportLimit(rows.length, 'league missing waivers', leagueName);
+    const buffer = await generateCsv(rows, WAIVER_EXPORT_HEADERS);
+    const sanitizedName = this.sanitizeFileName(leagueName);
+    this.logExportMetrics(
+      'league missing waivers',
+      leagueName,
+      rows.length,
+      buffer.length,
+      startTime,
+    );
+    return {
+      buffer,
+      fileName: `${sanitizedName}-missing-waivers.csv`,
+    };
+  }
+
   async exportSeasonRoster(accountId: bigint, seasonId: bigint): Promise<CsvExportResult> {
     const startTime = Date.now();
     const { seasonName, members } = await this.rosterRepository.findSeasonRosterForExport(
@@ -295,24 +346,30 @@ export class CsvExportService {
     });
   }
 
+  private mapWaiverItemToExportRow(item: dbWaiverExportData): WaiverExportRow {
+    const contact = item.roster.contacts;
+    return {
+      fullName: this.formatFullName(contact.firstname, contact.middlename, contact.lastname),
+      email: contact.email ?? '',
+      streetAddress: contact.streetaddress ?? '',
+      city: contact.city ?? '',
+      state: contact.state ?? '',
+      zip: contact.zip ?? '',
+      team: item.teamsseason.name,
+    };
+  }
+
   private mapWaiversToExportRows(data: dbWaiverExportData[]): WaiverExportRow[] {
     return data
       .filter((item) => {
         const email = item.roster.contacts.email;
         return email !== null && email.trim() !== '';
       })
-      .map((item) => {
-        const contact = item.roster.contacts;
-        return {
-          fullName: this.formatFullName(contact.firstname, contact.middlename, contact.lastname),
-          email: contact.email ?? '',
-          streetAddress: contact.streetaddress ?? '',
-          city: contact.city ?? '',
-          state: contact.state ?? '',
-          zip: contact.zip ?? '',
-          team: item.teamsseason.name,
-        };
-      });
+      .map((item) => this.mapWaiverItemToExportRow(item));
+  }
+
+  private mapMissingWaiversToExportRows(data: dbWaiverExportData[]): WaiverExportRow[] {
+    return data.map((item) => this.mapWaiverItemToExportRow(item));
   }
 
   private mapManagersToExportRows(data: dbManagerExportData[]): ManagerExportRow[] {

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/NoWaiverPlayersDialog.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/NoWaiverPlayersDialog.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+
+export interface NoWaiverPlayer {
+  contactId: string;
+  fullName: string;
+  teams: Array<{ leagueName: string; teamName: string }>;
+}
+
+interface NoWaiverPlayersDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  players: NoWaiverPlayer[];
+  onExport: () => void;
+  exporting: boolean;
+  exportError: string | null;
+}
+
+export default function NoWaiverPlayersDialog({
+  open,
+  onClose,
+  title,
+  players,
+  onExport,
+  exporting,
+  exportError,
+}: NoWaiverPlayersDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {title}
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        {exportError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {exportError}
+          </Alert>
+        )}
+        {players.length === 0 ? (
+          <Alert severity="success">No players are missing a waiver.</Alert>
+        ) : (
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {players.length} player{players.length !== 1 ? 's' : ''} with no waiver:
+            </Typography>
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ width: '40%', fontWeight: 'bold' }}>Name</TableCell>
+                    <TableCell sx={{ fontWeight: 'bold' }}>Team</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {players.map((player) => (
+                    <TableRow key={player.contactId}>
+                      <TableCell sx={{ verticalAlign: 'top', wordBreak: 'break-word' }}>
+                        {player.fullName}
+                      </TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                          {player.teams.map((team, idx) => (
+                            <Chip
+                              key={idx}
+                              size="small"
+                              color="error"
+                              variant="outlined"
+                              label={`${team.leagueName} / ${team.teamName}`}
+                            />
+                          ))}
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={exporting ? <CircularProgress size={16} /> : <FileDownloadIcon />}
+          onClick={onExport}
+          disabled={exporting || players.length === 0}
+          aria-label="Export CSV"
+        >
+          Export CSV
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/WaiversClient.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Button,
   Card,
+  CardActionArea,
   CardContent,
   Chip,
   CircularProgress,
@@ -32,7 +33,9 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import {
+  exportLeagueMissingWaivers,
   exportLeagueWaivers,
+  exportTeamMissingWaivers,
   exportTeamWaivers,
   getTeamRosterWaiverSummaries,
   updateRosterMember,
@@ -44,6 +47,7 @@ import { useCurrentSeason } from '../../../../hooks/useCurrentSeason';
 import { unwrapApiResult } from '../../../../utils/apiResult';
 import { downloadBlob } from '../../../../utils/downloadUtils';
 import { useLeagueWaiverData, type WaiverMember } from './useLeagueWaiverData';
+import NoWaiverPlayersDialog, { type NoWaiverPlayer } from './NoWaiverPlayersDialog';
 import { useSeasonLeaguesAndTeams } from './useSeasonLeaguesAndTeams';
 
 interface WaiversClientProps {
@@ -62,7 +66,6 @@ function computeLeagueSummary(data: TeamWaiverDataItem[], leagueSeasonId: string
   const seenContactIds = new Set<string>();
   let withWaiver = 0;
   let otherWaiver = 0;
-  let noWaiver = 0;
 
   for (const team of data) {
     for (const member of team.members) {
@@ -79,19 +82,25 @@ function computeLeagueSummary(data: TeamWaiverDataItem[], leagueSeasonId: string
         withWaiver++;
       } else if (hasWaiverAnywhere) {
         otherWaiver++;
-      } else {
-        noWaiver++;
       }
     }
   }
 
-  return { withWaiver, otherWaiver, noWaiver, total: seenContactIds.size };
+  const noWaiverMembers = getLeagueNoWaiverMembers(data);
+
+  return {
+    withWaiver,
+    otherWaiver,
+    noWaiver: noWaiverMembers.length,
+    total: seenContactIds.size,
+  };
 }
 
 function computeTeamSummary(members: WaiverMember[], teamSeasonId: string) {
   let withWaiver = 0;
   let otherWaiver = 0;
-  let noWaiver = 0;
+
+  const noWaiverMembers = getTeamNoWaiverMembers(members);
 
   for (const member of members) {
     const hasWaiverOnTeam = member.seasonTeams.some(
@@ -103,12 +112,34 @@ function computeTeamSummary(members: WaiverMember[], teamSeasonId: string) {
       withWaiver++;
     } else if (hasWaiverAnywhere) {
       otherWaiver++;
-    } else {
-      noWaiver++;
     }
   }
 
-  return { withWaiver, otherWaiver, noWaiver, total: members.length };
+  return { withWaiver, otherWaiver, noWaiver: noWaiverMembers.length, total: members.length };
+}
+
+export function getLeagueNoWaiverMembers(data: TeamWaiverDataItem[]): WaiverMember[] {
+  const seenContactIds = new Set<string>();
+  const result: WaiverMember[] = [];
+
+  for (const team of data) {
+    for (const member of team.members) {
+      const contactId = member.rosterMember.player.contact.id;
+      if (seenContactIds.has(contactId)) continue;
+      seenContactIds.add(contactId);
+
+      const hasWaiverAnywhere = member.seasonTeams.some((t) => t.submittedWaiver);
+      if (!hasWaiverAnywhere) {
+        result.push(member);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function getTeamNoWaiverMembers(members: WaiverMember[]): WaiverMember[] {
+  return members.filter((member) => !member.seasonTeams.some((t) => t.submittedWaiver));
 }
 
 interface SummaryCardsProps {
@@ -119,6 +150,7 @@ interface SummaryCardsProps {
   label: string;
   firstStatLabel: string;
   secondStatLabel: string;
+  onNoWaiverClick?: () => void;
 }
 
 function SummaryCards({
@@ -129,6 +161,7 @@ function SummaryCards({
   label,
   firstStatLabel,
   secondStatLabel,
+  onNoWaiverClick,
 }: SummaryCardsProps) {
   return (
     <Box>
@@ -157,14 +190,31 @@ function SummaryCards({
           </CardContent>
         </Card>
         <Card variant="outlined" sx={{ flex: 1 }}>
-          <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-            <Typography variant="h5" color="error.main" align="center">
-              {noWaiver}
-            </Typography>
-            <Typography variant="caption" color="text.secondary" align="center" display="block">
-              No Waiver
-            </Typography>
-          </CardContent>
+          {onNoWaiverClick ? (
+            <CardActionArea
+              onClick={onNoWaiverClick}
+              aria-label="View players with no waiver"
+              sx={{ height: '100%' }}
+            >
+              <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                <Typography variant="h5" color="error.main" align="center">
+                  {noWaiver}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" align="center" display="block">
+                  No Waiver
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+          ) : (
+            <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+              <Typography variant="h5" color="error.main" align="center">
+                {noWaiver}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" align="center" display="block">
+                No Waiver
+              </Typography>
+            </CardContent>
+          )}
         </Card>
         <Card variant="outlined" sx={{ flex: 1 }}>
           <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
@@ -231,6 +281,10 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
 
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+
+  const [noWaiverScope, setNoWaiverScope] = useState<'league' | 'team' | null>(null);
+  const [missingExportLoading, setMissingExportLoading] = useState(false);
+  const [missingExportError, setMissingExportError] = useState<string | null>(null);
 
   const teamsForSelectedLeague = selectedLeagueSeasonId
     ? (teamsByLeague.get(selectedLeagueSeasonId) ?? [])
@@ -504,6 +558,85 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
     }
   };
 
+  const handleExportMissingWaivers = async () => {
+    if (!currentSeasonId || !noWaiverScope) return;
+    setMissingExportLoading(true);
+    setMissingExportError(null);
+    try {
+      if (noWaiverScope === 'team' && selectedTeamSeasonId) {
+        const selectedTeam = teamsForSelectedLeague.find(
+          (t) => t.teamSeasonId === selectedTeamSeasonId,
+        );
+        const result = await exportTeamMissingWaivers({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: currentSeasonId,
+            teamSeasonId: selectedTeamSeasonId,
+          },
+          throwOnError: false,
+          parseAs: 'blob',
+        });
+        const blob = unwrapApiResult(result, 'Failed to export missing waivers') as Blob;
+        const teamName = selectedTeam?.teamName ?? 'team';
+        const sanitizedName = teamName.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+        downloadBlob(blob, `${sanitizedName}-missing-waivers.csv`);
+      } else if (noWaiverScope === 'league' && selectedLeagueSeasonId) {
+        const selectedLeague = leagues.find((l) => l.leagueSeasonId === selectedLeagueSeasonId);
+        const result = await exportLeagueMissingWaivers({
+          client: apiClient,
+          path: {
+            accountId,
+            seasonId: currentSeasonId,
+            leagueSeasonId: selectedLeagueSeasonId,
+          },
+          throwOnError: false,
+          parseAs: 'blob',
+        });
+        const blob = unwrapApiResult(result, 'Failed to export missing waivers') as Blob;
+        const leagueName = selectedLeague?.leagueName ?? 'league';
+        const sanitizedName = leagueName.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+        downloadBlob(blob, `${sanitizedName}-missing-waivers.csv`);
+      }
+    } catch (err) {
+      setMissingExportError(
+        err instanceof Error ? err.message : 'Failed to export missing waivers',
+      );
+    } finally {
+      setMissingExportLoading(false);
+    }
+  };
+
+  const noWaiverPlayers: NoWaiverPlayer[] =
+    noWaiverScope === 'league'
+      ? getLeagueNoWaiverMembers(localTeamWaiverData).map((member) => {
+          const contact = member.rosterMember.player.contact;
+          const fullName =
+            `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() || 'Unknown';
+          const teams = member.seasonTeams
+            .filter((t) => t.leagueSeasonId === selectedLeagueSeasonId)
+            .map((t) => ({ leagueName: t.leagueName, teamName: t.teamName }));
+          return { contactId: contact.id, fullName, teams };
+        })
+      : noWaiverScope === 'team'
+        ? getTeamNoWaiverMembers(displayMembers).map((member) => {
+            const contact = member.rosterMember.player.contact;
+            const fullName =
+              `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() || 'Unknown';
+            const teams = member.seasonTeams
+              .filter((t) => t.teamSeasonId === selectedTeamSeasonId)
+              .map((t) => ({ leagueName: t.leagueName, teamName: t.teamName }));
+            return { contactId: contact.id, fullName, teams };
+          })
+        : [];
+
+  const noWaiverDialogTitle =
+    noWaiverScope === 'league'
+      ? `Players With No Waiver — ${leagues.find((l) => l.leagueSeasonId === selectedLeagueSeasonId)?.leagueName ?? 'League'}`
+      : noWaiverScope === 'team'
+        ? `Players With No Waiver — ${teamsForSelectedLeague.find((t) => t.teamSeasonId === selectedTeamSeasonId)?.teamName ?? 'Team'}`
+        : 'Players With No Waiver';
+
   return (
     <main className="min-h-screen bg-background">
       <AccountPageHeader accountId={accountId}>
@@ -659,6 +792,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                         label="League Waiver Summary"
                         firstStatLabel="Waiver in This League"
                         secondStatLabel="Waiver for Another League"
+                        onNoWaiverClick={() => setNoWaiverScope('league')}
                       />
                     )}
 
@@ -671,6 +805,7 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
                         label="Team Waiver Summary"
                         firstStatLabel="Waiver in This Team"
                         secondStatLabel="Waiver for Another Team"
+                        onNoWaiverClick={() => setNoWaiverScope('team')}
                       />
                     )}
 
@@ -865,6 +1000,19 @@ export default function WaiversClient({ accountId }: WaiversClientProps) {
           )}
         </DialogContent>
       </Dialog>
+
+      <NoWaiverPlayersDialog
+        open={noWaiverScope !== null}
+        onClose={() => {
+          setNoWaiverScope(null);
+          setMissingExportError(null);
+        }}
+        title={noWaiverDialogTitle}
+        players={noWaiverPlayers}
+        onExport={() => void handleExportMissingWaivers()}
+        exporting={missingExportLoading}
+        exportError={missingExportError}
+      />
     </main>
   );
 }

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/__tests__/NoWaiverPlayersDialog.test.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/__tests__/NoWaiverPlayersDialog.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NoWaiverPlayersDialog, { type NoWaiverPlayer } from '../NoWaiverPlayersDialog';
+
+const makePlayers = (count: number): NoWaiverPlayer[] =>
+  Array.from({ length: count }, (_, i) => ({
+    contactId: `contact-${i}`,
+    fullName: `Player ${i + 1}`,
+    teams: [{ leagueName: 'League A', teamName: `Team ${i + 1}` }],
+  }));
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  title: 'Players With No Waiver — League A',
+  players: makePlayers(3),
+  onExport: vi.fn(),
+  exporting: false,
+  exportError: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NoWaiverPlayersDialog', () => {
+  it('renders the dialog title', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} />);
+    expect(screen.getByText('Players With No Waiver — League A')).toBeInTheDocument();
+  });
+
+  it('shows player list when players are present', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} />);
+    expect(screen.getByText('Player 1')).toBeInTheDocument();
+    expect(screen.getByText('Player 2')).toBeInTheDocument();
+    expect(screen.getByText('Player 3')).toBeInTheDocument();
+  });
+
+  it('shows player count text', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} />);
+    expect(screen.getByText('3 players with no waiver:')).toBeInTheDocument();
+  });
+
+  it('uses singular "player" for count of 1', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} players={makePlayers(1)} />);
+    expect(screen.getByText('1 player with no waiver:')).toBeInTheDocument();
+  });
+
+  it('renders team chips for each player', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} players={makePlayers(1)} />);
+    expect(screen.getByText('League A / Team 1')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no players', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} players={[]} />);
+    expect(screen.getByText('No players are missing a waiver.')).toBeInTheDocument();
+  });
+
+  it('calls onExport when Export CSV button is clicked', async () => {
+    const onExport = vi.fn();
+    render(<NoWaiverPlayersDialog {...defaultProps} onExport={onExport} />);
+    await userEvent.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(onExport).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Export CSV button when players list is empty', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} players={[]} />);
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+  });
+
+  it('disables Export CSV button while exporting', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} exporting={true} />);
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+  });
+
+  it('shows CircularProgress spinner while exporting', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} exporting={true} />);
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+  });
+
+  it('shows export error alert when exportError is set', () => {
+    render(
+      <NoWaiverPlayersDialog {...defaultProps} exportError="Failed to export missing waivers" />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to export missing waivers');
+  });
+
+  it('calls onClose when close icon button is clicked', async () => {
+    const onClose = vi.fn();
+    render(<NoWaiverPlayersDialog {...defaultProps} onClose={onClose} />);
+    await userEvent.click(screen.getByRole('button', { name: 'close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render dialog content when closed', () => {
+    render(<NoWaiverPlayersDialog {...defaultProps} open={false} />);
+    expect(screen.queryByText('Players With No Waiver — League A')).not.toBeInTheDocument();
+  });
+});

--- a/draco-nodejs/frontend-next/app/account/[accountId]/waivers/__tests__/waiverHelpers.test.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/waivers/__tests__/waiverHelpers.test.ts
@@ -1,0 +1,156 @@
+import { getLeagueNoWaiverMembers, getTeamNoWaiverMembers } from '../WaiversClient';
+import type { WaiverMember } from '../useLeagueWaiverData';
+
+type SeasonTeam = WaiverMember['seasonTeams'][number];
+type RosterMember = WaiverMember['rosterMember'];
+
+function makeSeasonTeam(overrides: Partial<SeasonTeam> = {}): SeasonTeam {
+  return {
+    teamSeasonId: 'team-1',
+    teamId: 'team-def-1',
+    leagueSeasonId: 'league-1',
+    leagueName: 'League A',
+    teamName: 'Team 1',
+    submittedWaiver: false,
+    ...overrides,
+  };
+}
+
+function makeRosterMember(contactId: string, overrides: Partial<RosterMember> = {}): RosterMember {
+  return {
+    id: `rm-${contactId}`,
+    submittedWaiver: false,
+    player: {
+      id: `player-${contactId}`,
+      firstYear: 2024,
+      submittedDriversLicense: false,
+      contact: {
+        id: contactId,
+        firstName: 'First',
+        lastName: 'Last',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeMember(contactId: string, seasonTeams: SeasonTeam[]): WaiverMember {
+  return {
+    rosterMember: makeRosterMember(contactId),
+    seasonTeams,
+  };
+}
+
+describe('getTeamNoWaiverMembers', () => {
+  it('returns members who have no submitted waiver on any season team', () => {
+    const noWaiverMember = makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]);
+    const waiverMember = makeMember('c2', [makeSeasonTeam({ submittedWaiver: true })]);
+
+    const result = getTeamNoWaiverMembers([noWaiverMember, waiverMember]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rosterMember.player.contact.id).toBe('c1');
+  });
+
+  it('excludes members who have a waiver on any season team even if not the current team', () => {
+    const memberWithWaiverElsewhere = makeMember('c1', [
+      makeSeasonTeam({ teamSeasonId: 'team-1', submittedWaiver: false }),
+      makeSeasonTeam({ teamSeasonId: 'team-2', submittedWaiver: true }),
+    ]);
+
+    const result = getTeamNoWaiverMembers([memberWithWaiverElsewhere]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when all members have waivers', () => {
+    const members = [
+      makeMember('c1', [makeSeasonTeam({ submittedWaiver: true })]),
+      makeMember('c2', [makeSeasonTeam({ submittedWaiver: true })]),
+    ];
+
+    expect(getTeamNoWaiverMembers(members)).toHaveLength(0);
+  });
+
+  it('returns all members when none have waivers', () => {
+    const members = [
+      makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]),
+      makeMember('c2', [makeSeasonTeam({ submittedWaiver: false })]),
+    ];
+
+    expect(getTeamNoWaiverMembers(members)).toHaveLength(2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(getTeamNoWaiverMembers([])).toHaveLength(0);
+  });
+});
+
+describe('getLeagueNoWaiverMembers', () => {
+  it('returns deduplicated members with no waiver anywhere', () => {
+    const noWaiverMember = makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]);
+    const waiverMember = makeMember('c2', [makeSeasonTeam({ submittedWaiver: true })]);
+
+    const data = [{ teamSeasonId: 'team-1', members: [noWaiverMember, waiverMember] }];
+
+    const result = getLeagueNoWaiverMembers(data);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rosterMember.player.contact.id).toBe('c1');
+  });
+
+  it('deduplicates members who appear on multiple teams', () => {
+    const member = makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]);
+    const data = [
+      { teamSeasonId: 'team-1', members: [member] },
+      { teamSeasonId: 'team-2', members: [member] },
+    ];
+
+    const result = getLeagueNoWaiverMembers(data);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('first occurrence wins for deduplication', () => {
+    const memberTeam1 = makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]);
+    const memberTeam2 = makeMember('c1', [makeSeasonTeam({ submittedWaiver: true })]);
+    const data = [
+      { teamSeasonId: 'team-1', members: [memberTeam1] },
+      { teamSeasonId: 'team-2', members: [memberTeam2] },
+    ];
+
+    const result = getLeagueNoWaiverMembers(data);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(memberTeam1);
+  });
+
+  it('excludes member who has waiver on any team', () => {
+    const member = makeMember('c1', [
+      makeSeasonTeam({ teamSeasonId: 'team-1', submittedWaiver: false }),
+      makeSeasonTeam({ teamSeasonId: 'team-2', submittedWaiver: true }),
+    ]);
+    const data = [{ teamSeasonId: 'team-1', members: [member] }];
+
+    expect(getLeagueNoWaiverMembers(data)).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(getLeagueNoWaiverMembers([])).toHaveLength(0);
+  });
+
+  it('handles multiple teams with multiple members correctly', () => {
+    const m1 = makeMember('c1', [makeSeasonTeam({ submittedWaiver: false })]);
+    const m2 = makeMember('c2', [makeSeasonTeam({ submittedWaiver: true })]);
+    const m3 = makeMember('c3', [makeSeasonTeam({ submittedWaiver: false })]);
+    const data = [
+      { teamSeasonId: 'team-1', members: [m1, m2] },
+      { teamSeasonId: 'team-2', members: [m3] },
+    ];
+
+    const result = getLeagueNoWaiverMembers(data);
+    expect(result).toHaveLength(2);
+    const ids = result.map((m) => m.rosterMember.player.contact.id);
+    expect(ids).toContain('c1');
+    expect(ids).toContain('c3');
+  });
+});


### PR DESCRIPTION
Add backend API, repository, service, and tests for exporting players missing waivers, and wire up frontend UI to view and export missing-waiver lists.

Backend: updated OpenAPI (json/yaml) and path registry to expose two new GET endpoints for team and league missing-waivers CSV export; added route handlers in routes/exports.ts; implemented repository methods in PrismaRosterRepository; added CsvExportService methods (exportTeamMissingWaivers, exportLeagueMissingWaivers) with CSV generation and mapping logic; extended IRosterRepository interface; and added unit tests for the new export flows.

Frontend: added NoWaiverPlayersDialog component, updated WaiversClient to compute and surface "no waiver" counts, show a dialog of players with no waivers, and call the new generated export operations (exportTeamMissingWaivers / exportLeagueMissingWaivers) to download CSVs; added related frontend tests and helpers.

Other: added docs/email-recipient-service-refactor-plan.md (refactor plan for emailRecipientService).