### PR TITLE
Simplify onChange for player number field

### DIFF
--- a/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
@@ -574,15 +574,7 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
                   label="Player Number"
                   type="text"
                   value={field.value ?? ''}
-                  onChange={(event) => {
-                    const { value } = event.target;
-                    if (value === '') {
-                      field.onChange(undefined);
-                      return;
-                    }
-
-                    field.onChange(value);
-                  }}
+                  onChange={(event) => field.onChange(event.target.value)}
                   inputProps={{ maxLength: 2, inputMode: 'numeric' }}
                   fullWidth
                   variant="outlined"


### PR DESCRIPTION
Replace verbose onChange handler with a direct event.target.value pass-through. Removes the special-case logic that converted an empty string to undefined, simplifying the component and improving readability. This changes how empty input is reported (previously undefined, now an empty string).