### PR TITLE
Add fieldDetails and fix recipient counting

### DIFF
--- a/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
@@ -91,12 +91,34 @@ const runRoute = async (
     throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
   }
 
-  const layerRoute = (layer as { route: { stack: Array<{ handle: unknown }> } }).route;
-  const handlers = layerRoute.stack.map(
-    (s) => s.handle as (req: Request, res: Response, next: NextFunction) => unknown,
-  );
+  type MinimalRequest = {
+    method: string;
+    params: Record<string, string>;
+    body: unknown;
+    query: Record<string, unknown>;
+    headers: Record<string, string>;
+    get: (headerName: string) => string | undefined;
+    user?: Request['user'];
+    accountBoundary?: Request['accountBoundary'];
+  };
 
-  const req = {
+  type MockResponse = {
+    body: unknown;
+    statusCode: number;
+    headers: Record<string, unknown>;
+    status(code: number): MockResponse;
+    json(payload: unknown): MockResponse;
+    send(payload: unknown): MockResponse;
+    set(field: string, value: unknown): MockResponse;
+    setHeader(field: string, value: unknown): void;
+  };
+
+  type RouteHandler = (req: MinimalRequest, res: MockResponse, next: NextFunction) => unknown;
+
+  const layerRoute = (layer as { route: { stack: Array<{ handle: unknown }> } }).route;
+  const handlers = layerRoute.stack.map((s) => s.handle as RouteHandler);
+
+  const req: MinimalRequest = {
     method: method.toUpperCase(),
     params,
     body,
@@ -106,38 +128,32 @@ const runRoute = async (
       const key = headerName.toLowerCase();
       return headers[headerName] ?? headers[key];
     },
-  } as unknown as Request;
-
-  type MockResponse = Response & {
-    body: unknown;
-    statusCode: number;
-    headers: Record<string, unknown>;
   };
 
-  const res = {
+  const res: MockResponse = {
     statusCode: 200,
-    headers: {} as Record<string, unknown>,
-    body: undefined as unknown,
+    headers: {},
+    body: undefined,
     status(code: number) {
-      (this as MockResponse).statusCode = code;
+      this.statusCode = code;
       return this;
     },
     json(payload: unknown) {
-      (this as MockResponse).body = payload;
+      this.body = payload;
       return this;
     },
     send(payload: unknown) {
-      (this as MockResponse).body = payload;
+      this.body = payload;
       return this;
     },
     set(field: string, value: unknown) {
-      (this as MockResponse).headers[field] = value;
+      this.headers[field] = value;
       return this;
     },
     setHeader(field: string, value: unknown) {
-      (this as MockResponse).headers[field] = value;
+      this.headers[field] = value;
     },
-  } as unknown as MockResponse;
+  };
 
   let caughtError: unknown = null;
 
@@ -277,12 +293,9 @@ describe('Accounts player classifieds routes', () => {
       expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).not.toHaveBeenCalled();
     });
 
-    it('allows an authenticated non-member to use a valid access-code format', async () => {
-      // Pre-existing route behavior: when an authenticated user fails the boundary
-      // and falls back via access code, the handler short-circuits on req.user and
-      // returns contact info without verifying the access code against the classified.
-      // This test pins the current behavior so the gate change does not regress it.
+    it('requires server-side access-code verification when an authenticated non-member supplies an access code', async () => {
       boundaryBehavior = 'deny';
+      playerClassifiedServiceMock.verifyTeamsWantedAccess.mockResolvedValue({});
       playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
 
       const { res, error } = await runRoute('get', path, {
@@ -293,7 +306,32 @@ describe('Accounts player classifieds routes', () => {
 
       expect(error).toBeNull();
       expect(res.statusCode).toBe(200);
+      expect(playerClassifiedServiceMock.verifyTeamsWantedAccess).toHaveBeenCalledWith(
+        42n,
+        VALID_ACCESS_CODE,
+        1n,
+      );
       expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).toHaveBeenCalledWith(42n, 1n);
+    });
+
+    it('does not return contact info when an authenticated non-member access-code verification fails', async () => {
+      boundaryBehavior = 'deny';
+      let verifyCalled = false;
+      playerClassifiedServiceMock.verifyTeamsWantedAccess.mockImplementation(async () => {
+        verifyCalled = true;
+        throw new AuthorizationError('Invalid access code');
+      });
+
+      await runRoute('get', path, {
+        params,
+        query: { accessCode: VALID_ACCESS_CODE },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(verifyCalled).toBe(true);
+      expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).not.toHaveBeenCalled();
     });
 
     it('returns contact info for an unauthenticated request with a valid access code', async () => {

--- a/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
@@ -187,7 +187,11 @@ const runRoute = async (
               }
             });
         } else if (!settled) {
-          queueMicrotask(() => {
+          // asyncHandler-wrapped handlers return void while their internal
+          // Promise.resolve(fn).catch(next) chain is still pending. setImmediate
+          // runs after all queued microtasks, so any next(err) from an async
+          // rejection has fired and caughtError is populated before we resolve.
+          setImmediate(() => {
             if (!settled) {
               settled = true;
               resolve();
@@ -314,23 +318,24 @@ describe('Accounts player classifieds routes', () => {
       expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).toHaveBeenCalledWith(42n, 1n);
     });
 
-    it('does not return contact info when an authenticated non-member access-code verification fails', async () => {
+    it('rejects an authenticated non-member when access-code verification fails', async () => {
       boundaryBehavior = 'deny';
-      let verifyCalled = false;
-      playerClassifiedServiceMock.verifyTeamsWantedAccess.mockImplementation(async () => {
-        verifyCalled = true;
-        throw new AuthorizationError('Invalid access code');
-      });
+      playerClassifiedServiceMock.verifyTeamsWantedAccess.mockRejectedValue(
+        new AuthorizationError('Invalid access code'),
+      );
 
-      await runRoute('get', path, {
+      const { error } = await runRoute('get', path, {
         params,
         query: { accessCode: VALID_ACCESS_CODE },
         headers: { authorization: 'Bearer token' },
       });
 
-      await new Promise((resolve) => setImmediate(resolve));
-
-      expect(verifyCalled).toBe(true);
+      expect(error).toBeInstanceOf(AuthorizationError);
+      expect(playerClassifiedServiceMock.verifyTeamsWantedAccess).toHaveBeenCalledWith(
+        42n,
+        VALID_ACCESS_CODE,
+        1n,
+      );
       expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).not.toHaveBeenCalled();
     });
 

--- a/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
+++ b/draco-nodejs/backend/src/routes/__tests__/accounts-player-classifieds.test.ts
@@ -1,0 +1,357 @@
+import express, {
+  type Express,
+  type Request,
+  type Response,
+  type NextFunction,
+  type Router,
+} from 'express';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { ServiceFactory } from '../../services/serviceFactory.js';
+import { AuthorizationError } from '../../utils/customErrors.js';
+
+vi.mock('../../middleware/authMiddleware.js', () => ({
+  authenticateToken: (req: Request, _res: Response, next: NextFunction) => {
+    req.user = { id: 'user-1', username: 'tester' };
+    next();
+  },
+}));
+
+vi.mock('../../middleware/rateLimitMiddleware.js', () => ({
+  teamsWantedRateLimit: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+const VALID_ACCESS_CODE = 'abcdefghij1234567890';
+
+type BoundaryBehavior = 'allow' | 'deny';
+type PermissionBehavior = 'allow' | 'deny';
+
+let boundaryBehavior: BoundaryBehavior = 'allow';
+let permissionBehavior: PermissionBehavior = 'allow';
+let lastPermissionRequested: string | null = null;
+
+const createRouteProtectionMock = () => {
+  const enforceAccountBoundary = () => (req: Request, _res: Response, next: NextFunction) => {
+    if (boundaryBehavior === 'deny') {
+      next(new AuthorizationError('Access denied to this account'));
+      return;
+    }
+    const accountId = req.params.accountId ? BigInt(req.params.accountId as string) : 1n;
+    req.accountBoundary = {
+      accountId,
+      contactId: 2n,
+      enforced: true,
+    };
+    next();
+  };
+
+  const requirePermission =
+    (permission: string) => (_req: Request, _res: Response, next: NextFunction) => {
+      lastPermissionRequested = permission;
+      if (permissionBehavior === 'deny') {
+        next(new AuthorizationError(`Permission '${permission}' required`));
+        return;
+      }
+      next();
+    };
+
+  return { enforceAccountBoundary, requirePermission };
+};
+
+const playerClassifiedServiceMock = {
+  getTeamsWantedContactInfo: vi.fn(),
+  verifyTeamsWantedAccess: vi.fn(),
+  updateTeamsWanted: vi.fn(),
+  deleteTeamsWanted: vi.fn(),
+};
+
+let app: Express;
+let router: Router;
+
+const runRoute = async (
+  method: 'get' | 'post' | 'put' | 'delete',
+  path: string,
+  {
+    params = {},
+    body = {},
+    query = {},
+    headers = {},
+  }: {
+    params?: Record<string, string>;
+    body?: unknown;
+    query?: Record<string, unknown>;
+    headers?: Record<string, string>;
+  },
+) => {
+  const layer = router.stack.find((stackLayer: unknown) => {
+    const l = stackLayer as { route?: { path: string; methods: Record<string, boolean> } };
+    return Boolean(l.route && l.route.path === path && l.route.methods[method]);
+  });
+
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+
+  const layerRoute = (layer as { route: { stack: Array<{ handle: unknown }> } }).route;
+  const handlers = layerRoute.stack.map(
+    (s) => s.handle as (req: Request, res: Response, next: NextFunction) => unknown,
+  );
+
+  const req = {
+    method: method.toUpperCase(),
+    params,
+    body,
+    query,
+    headers,
+    get(headerName: string) {
+      const key = headerName.toLowerCase();
+      return headers[headerName] ?? headers[key];
+    },
+  } as unknown as Request;
+
+  type MockResponse = Response & {
+    body: unknown;
+    statusCode: number;
+    headers: Record<string, unknown>;
+  };
+
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, unknown>,
+    body: undefined as unknown,
+    status(code: number) {
+      (this as MockResponse).statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      (this as MockResponse).body = payload;
+      return this;
+    },
+    send(payload: unknown) {
+      (this as MockResponse).body = payload;
+      return this;
+    },
+    set(field: string, value: unknown) {
+      (this as MockResponse).headers[field] = value;
+      return this;
+    },
+    setHeader(field: string, value: unknown) {
+      (this as MockResponse).headers[field] = value;
+    },
+  } as unknown as MockResponse;
+
+  let caughtError: unknown = null;
+
+  for (const handler of handlers) {
+    if (caughtError) break;
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const next: NextFunction = (err?: unknown) => {
+        if (settled) return;
+        settled = true;
+        if (err) caughtError = err;
+        resolve();
+      };
+
+      try {
+        const result = handler(req, res, next);
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          (result as Promise<unknown>)
+            .then(() => {
+              if (!settled) {
+                settled = true;
+                resolve();
+              }
+            })
+            .catch((error) => {
+              if (!settled) {
+                settled = true;
+                caughtError = error;
+                resolve();
+              }
+            });
+        } else if (!settled) {
+          queueMicrotask(() => {
+            if (!settled) {
+              settled = true;
+              resolve();
+            }
+          });
+        }
+      } catch (error) {
+        if (!settled) {
+          settled = true;
+          caughtError = error;
+          resolve();
+        }
+      }
+    });
+  }
+
+  return { req, res, error: caughtError };
+};
+
+describe('Accounts player classifieds routes', () => {
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'test-secret'; // pragma: allowlist secret
+
+    vi.spyOn(ServiceFactory, 'getRouteProtection').mockReturnValue(
+      createRouteProtectionMock() as never,
+    );
+    vi.spyOn(ServiceFactory, 'getPlayerClassifiedService').mockReturnValue(
+      playerClassifiedServiceMock as never,
+    );
+
+    const routerModule = await import('../accounts-player-classifieds.js');
+    router = routerModule.default;
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/accounts/:accountId/player-classifieds', router);
+  });
+
+  beforeEach(() => {
+    boundaryBehavior = 'allow';
+    permissionBehavior = 'allow';
+    lastPermissionRequested = null;
+    Object.values(playerClassifiedServiceMock).forEach((fn) => {
+      if (typeof fn === 'function') {
+        (fn as ReturnType<typeof vi.fn>).mockReset();
+      }
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET /teams-wanted/:classifiedId/contact', () => {
+    const path = '/teams-wanted/:classifiedId/contact';
+    const params = { accountId: '1', classifiedId: '42' };
+    const contactInfo = { email: 'p@example.com', phone: '555-1234' };
+
+    it('returns contact info for an authenticated account member without manage permission', async () => {
+      // Account boundary passes (member), but the manage permission would be denied.
+      // The contact route must NOT require that permission.
+      boundaryBehavior = 'allow';
+      permissionBehavior = 'deny';
+      playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
+
+      const { res, error } = await runRoute('get', path, {
+        params,
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(error).toBeNull();
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(contactInfo);
+      expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).toHaveBeenCalledWith(42n, 1n);
+      expect(lastPermissionRequested).toBeNull();
+    });
+
+    it('returns contact info for an AccountAdmin', async () => {
+      boundaryBehavior = 'allow';
+      permissionBehavior = 'allow';
+      playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
+
+      const { res, error } = await runRoute('get', path, {
+        params,
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(error).toBeNull();
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(contactInfo);
+    });
+
+    it('rejects an authenticated non-member without an access code', async () => {
+      boundaryBehavior = 'deny';
+      playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
+
+      const { error } = await runRoute('get', path, {
+        params,
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(error).toBeTruthy();
+      expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).not.toHaveBeenCalled();
+    });
+
+    it('allows an authenticated non-member to use a valid access-code format', async () => {
+      // Pre-existing route behavior: when an authenticated user fails the boundary
+      // and falls back via access code, the handler short-circuits on req.user and
+      // returns contact info without verifying the access code against the classified.
+      // This test pins the current behavior so the gate change does not regress it.
+      boundaryBehavior = 'deny';
+      playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
+
+      const { res, error } = await runRoute('get', path, {
+        params,
+        query: { accessCode: VALID_ACCESS_CODE },
+        headers: { authorization: 'Bearer token' },
+      });
+
+      expect(error).toBeNull();
+      expect(res.statusCode).toBe(200);
+      expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).toHaveBeenCalledWith(42n, 1n);
+    });
+
+    it('returns contact info for an unauthenticated request with a valid access code', async () => {
+      playerClassifiedServiceMock.verifyTeamsWantedAccess.mockResolvedValue({});
+      playerClassifiedServiceMock.getTeamsWantedContactInfo.mockResolvedValue(contactInfo);
+
+      const { res, error } = await runRoute('get', path, {
+        params,
+        query: { accessCode: VALID_ACCESS_CODE },
+      });
+
+      expect(error).toBeNull();
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(contactInfo);
+    });
+
+    it('rejects an unauthenticated request without an access code', async () => {
+      const { error } = await runRoute('get', path, { params });
+
+      expect(error).toBeTruthy();
+      expect(playerClassifiedServiceMock.getTeamsWantedContactInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('moderation routes still require player-classified.manage or an access code', () => {
+    it('PUT /teams-wanted/:classifiedId falls back to access-code requirement when the permission is denied', async () => {
+      boundaryBehavior = 'allow';
+      permissionBehavior = 'deny';
+
+      const { error } = await runRoute('put', '/teams-wanted/:classifiedId', {
+        params: { accountId: '1', classifiedId: '42' },
+        headers: { authorization: 'Bearer token' },
+        body: {
+          name: 'Test',
+          experience: 'Beginner',
+          positionsPlayed: 'Pitcher',
+          birthDate: new Date('1995-01-01').toISOString(),
+        },
+      });
+
+      expect(error).toBeTruthy();
+      expect(lastPermissionRequested).toBe('player-classified.manage');
+      expect(playerClassifiedServiceMock.updateTeamsWanted).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /teams-wanted/:classifiedId falls back to access-code requirement when the permission is denied', async () => {
+      boundaryBehavior = 'allow';
+      permissionBehavior = 'deny';
+
+      const { error } = await runRoute('delete', '/teams-wanted/:classifiedId', {
+        params: { accountId: '1', classifiedId: '42' },
+        headers: { authorization: 'Bearer token' },
+        body: {},
+      });
+
+      expect(error).toBeTruthy();
+      expect(lastPermissionRequested).toBe('player-classified.manage');
+      expect(playerClassifiedServiceMock.deleteTeamsWanted).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
+++ b/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
@@ -61,6 +61,11 @@ const requireAccessCodeForRequest = (req: Request): string => {
   return parseAccessCodeValue(candidate);
 };
 
+const clearAuthenticatedUser = (req: Request): void => {
+  (req as Request & { user?: unknown }).user = undefined;
+  (req as Request & { accountBoundary?: unknown }).accountBoundary = undefined;
+};
+
 const createTeamsWantedAuthMiddleware = () => {
   return (req: Request, res: Response, next: NextFunction): void => {
     const authHeader = req.headers.authorization;
@@ -68,6 +73,7 @@ const createTeamsWantedAuthMiddleware = () => {
 
     const fallbackToAccessCode = () => {
       try {
+        clearAuthenticatedUser(req);
         requireAccessCodeForRequest(req);
         next();
       } catch (error) {
@@ -116,6 +122,7 @@ const createTeamsWantedContactAuthMiddleware = () => {
 
     const fallbackToAccessCode = () => {
       try {
+        clearAuthenticatedUser(req);
         requireAccessCodeForRequest(req);
         next();
       } catch (error) {

--- a/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
+++ b/draco-nodejs/backend/src/routes/accounts-player-classifieds.ts
@@ -109,6 +109,43 @@ const createTeamsWantedAuthMiddleware = () => {
   };
 };
 
+const createTeamsWantedContactAuthMiddleware = () => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const authHeader = req.headers.authorization;
+    const hasToken = typeof authHeader === 'string' && authHeader.startsWith('Bearer ');
+
+    const fallbackToAccessCode = () => {
+      try {
+        requireAccessCodeForRequest(req);
+        next();
+      } catch (error) {
+        next(error);
+      }
+    };
+
+    if (!hasToken) {
+      fallbackToAccessCode();
+      return;
+    }
+
+    authenticateToken(req, res, (authError?: unknown) => {
+      if (authError) {
+        fallbackToAccessCode();
+        return;
+      }
+
+      routeProtection.enforceAccountBoundary()(req, res, (boundaryError?: unknown) => {
+        if (boundaryError) {
+          fallbackToAccessCode();
+          return;
+        }
+
+        next();
+      });
+    });
+  };
+};
+
 /**
  * POST /api/accounts/:accountId/player-classifieds/players-wanted
  * Create a new players wanted classified
@@ -399,12 +436,12 @@ router.get(
  *
  * GET /api/accounts/:accountId/player-classifieds/teams-wanted/:classifiedId/contact
  * Retrieve the contact information for a teams wanted classified
- * Requires either authentication with 'player-classified.manage' permission
+ * Requires either authentication as a member of the account
  * or a valid access code for the classified
  */
 router.get(
   '/teams-wanted/:classifiedId/contact',
-  createTeamsWantedAuthMiddleware(),
+  createTeamsWantedContactAuthMiddleware(),
   teamsWantedRateLimit,
   asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const { accountId, classifiedId } = extractClassifiedParams(req.params);

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -57,6 +57,17 @@ import Button from '@mui/material/Button';
 import type { DiscordLinkStatusType } from '@draco/shared-schemas';
 import { useCurrentSeason } from '../../../../../../../hooks/useCurrentSeason';
 
+const normalizeCoordinate = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toString();
+  }
+  return null;
+};
+
 interface TeamPageProps {
   accountId: string;
   seasonId: string;
@@ -369,8 +380,8 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
             rainoutNumber: game.field.rainoutNumber ?? null,
             comment: game.field.comment ?? null,
             directions: game.field.directions ?? null,
-            latitude: typeof game.field.latitude === 'string' ? game.field.latitude : null,
-            longitude: typeof game.field.longitude === 'string' ? game.field.longitude : null,
+            latitude: normalizeCoordinate(game.field.latitude),
+            longitude: normalizeCoordinate(game.field.longitude),
           }
         : null,
       hasGameRecap: game.hasGameRecap ?? false,

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -357,6 +357,22 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
       fieldId: game.field?.id ?? null,
       fieldName: game.field?.name ?? null,
       fieldShortName: game.field?.shortName ?? null,
+      fieldDetails: game.field
+        ? {
+            id: game.field.id ?? null,
+            name: game.field.name ?? null,
+            shortName: game.field.shortName ?? null,
+            address: game.field.address ?? null,
+            city: game.field.city ?? null,
+            state: game.field.state ?? null,
+            zip: game.field.zip ?? null,
+            rainoutNumber: game.field.rainoutNumber ?? null,
+            comment: game.field.comment ?? null,
+            directions: game.field.directions ?? null,
+            latitude: typeof game.field.latitude === 'string' ? game.field.latitude : null,
+            longitude: typeof game.field.longitude === 'string' ? game.field.longitude : null,
+          }
+        : null,
       hasGameRecap: game.hasGameRecap ?? false,
       gameRecaps: [],
       gameType: game.gameType ? Number(game.gameType) : undefined,

--- a/draco-nodejs/frontend-next/components/emails/recipients/AdvancedRecipientDialog.tsx
+++ b/draco-nodejs/frontend-next/components/emails/recipients/AdvancedRecipientDialog.tsx
@@ -842,19 +842,26 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
       // Legacy callback pattern - build contact details and simplified state
       const allSelectedContactDetails: RecipientContact[] = [];
       const allContactIds = new Set<string>();
+      let hierarchicalContactCount = 0;
 
-      // Process all groups in mergedContactGroups (includes both manual and hierarchical)
-      mergedContactGroups.forEach((groups) => {
+      // Process all groups in mergedContactGroups (includes both manual and hierarchical).
+      // Hierarchical groups (season/league/division/team) store the hierarchy node id in
+      // `group.ids`, not individual contact ids, so we rely on `group.totalCount` for
+      // their recipient totals and assume the resolved emails are server-side valid.
+      mergedContactGroups.forEach((groups, groupType) => {
+        if (hierarchicalGroupTypes.has(groupType)) {
+          groups.forEach((group) => {
+            hierarchicalContactCount += group.totalCount;
+          });
+          return;
+        }
+
         groups.forEach((group) => {
           group.ids.forEach((contactId) => {
             if (!allContactIds.has(contactId)) {
               allContactIds.add(contactId);
 
-              // Get contact details
               const contact = getContactDetails(contactId);
-
-              // Note: Manager data conversion removed since 'managers' is no longer a group type
-              // Managers are handled via the managersOnly flag on hierarchical groups
 
               if (contact) {
                 allSelectedContactDetails.push(contact);
@@ -866,7 +873,9 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
 
       // Create simplified state for the compose page
       const validContactsCount = allSelectedContactDetails.filter((c) => c.hasValidEmail).length;
-      const totalRecipients = allSelectedContactDetails.length + totalWorkoutSelected;
+      const totalIndividualContacts = allSelectedContactDetails.length;
+      const totalRecipients =
+        totalIndividualContacts + hierarchicalContactCount + totalWorkoutSelected;
       const validWorkoutCount = totalWorkoutSelected; // assume workout registrants already filtered to valid emails server-side
       const validTeamsWantedCount = totalTeamsWantedSelected; // assume resolved emails will be valid server-side
       const validUmpireCount = totalUmpireSelected; // assume umpire emails are valid
@@ -878,12 +887,20 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
         workoutManagersOnly,
         totalRecipients: totalRecipients + totalTeamsWantedSelected + totalUmpireSelected,
         validEmailCount:
-          validContactsCount + validWorkoutCount + validTeamsWantedCount + validUmpireCount,
+          validContactsCount +
+          hierarchicalContactCount +
+          validWorkoutCount +
+          validTeamsWantedCount +
+          validUmpireCount,
         invalidEmailCount:
           totalRecipients +
           totalTeamsWantedSelected +
           totalUmpireSelected -
-          (validContactsCount + validWorkoutCount + validTeamsWantedCount + validUmpireCount),
+          (validContactsCount +
+            hierarchicalContactCount +
+            validWorkoutCount +
+            validTeamsWantedCount +
+            validUmpireCount),
         searchQuery: '',
         activeTab: 'contacts',
         expandedSections: new Set(),

--- a/draco-nodejs/frontend-next/components/emails/recipients/AdvancedRecipientDialog.tsx
+++ b/draco-nodejs/frontend-next/components/emails/recipients/AdvancedRecipientDialog.tsx
@@ -139,6 +139,70 @@ export function buildSelectedIndividualIds(
   return new Set<string>(individualsGroups.flatMap((g) => Array.from(g.ids)));
 }
 
+export const HIERARCHICAL_GROUP_TYPES: ReadonlySet<GroupType> = new Set<GroupType>([
+  'season',
+  'league',
+  'division',
+  'team',
+]);
+
+export interface AggregatedRecipientCounts {
+  individualContactDetails: RecipientContact[];
+  hierarchicalContactCount: number;
+  totalRecipients: number;
+  validEmailCount: number;
+  invalidEmailCount: number;
+}
+
+export function aggregateRecipientCounts(
+  mergedContactGroups: Map<GroupType, ContactGroup[]>,
+  workoutCount: number,
+  teamsWantedCount: number,
+  umpireCount: number,
+  getContact: (contactId: string) => RecipientContact | null | undefined,
+): AggregatedRecipientCounts {
+  const seenContactIds = new Set<string>();
+  const individualContactDetails: RecipientContact[] = [];
+  let hierarchicalContactCount = 0;
+
+  mergedContactGroups.forEach((groups, groupType) => {
+    if (HIERARCHICAL_GROUP_TYPES.has(groupType)) {
+      groups.forEach((group) => {
+        hierarchicalContactCount += group.totalCount;
+      });
+      return;
+    }
+
+    groups.forEach((group) => {
+      group.ids.forEach((contactId) => {
+        if (seenContactIds.has(contactId)) {
+          return;
+        }
+        seenContactIds.add(contactId);
+        const contact = getContact(contactId);
+        if (contact) {
+          individualContactDetails.push(contact);
+        }
+      });
+    });
+  });
+
+  const validIndividualCount = individualContactDetails.filter((c) => c.hasValidEmail).length;
+  const totalIndividualCount = individualContactDetails.length;
+  const totalRecipients =
+    totalIndividualCount + hierarchicalContactCount + workoutCount + teamsWantedCount + umpireCount;
+  const validEmailCount =
+    validIndividualCount + hierarchicalContactCount + workoutCount + teamsWantedCount + umpireCount;
+
+  return {
+    individualContactDetails,
+    hierarchicalContactCount,
+    totalRecipients,
+    validEmailCount,
+    invalidEmailCount: totalRecipients - validEmailCount,
+  };
+}
+
 /**
  * Wrapper component that provides the ManagerStateProvider context
  */
@@ -805,12 +869,6 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
 
     // Define which group types are manual (preserved) vs hierarchical (replaced)
     const manualGroupTypes: Set<GroupType> = new Set(['individuals']);
-    const hierarchicalGroupTypes: Set<GroupType> = new Set([
-      'season',
-      'league',
-      'division',
-      'team',
-    ]);
 
     // Start with a copy of selectedGroups, but filter out old hierarchical groups
     const mergedContactGroups = new Map<GroupType, ContactGroup[]>();
@@ -825,7 +883,7 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
 
     // Add/replace hierarchical ContactGroups (replace old hierarchical groups)
     hierarchicalContactGroups.forEach((contactGroups: ContactGroup[], groupType: GroupType) => {
-      if (contactGroups.length > 0 && hierarchicalGroupTypes.has(groupType)) {
+      if (contactGroups.length > 0 && HIERARCHICAL_GROUP_TYPES.has(groupType)) {
         // Replace any existing hierarchical groups of this type
         mergedContactGroups.set(groupType, contactGroups);
       }
@@ -839,75 +897,30 @@ const AdvancedRecipientDialog: React.FC<AdvancedRecipientDialogProps> = ({
     }
 
     if (onApply) {
-      // Legacy callback pattern - build contact details and simplified state
-      const allSelectedContactDetails: RecipientContact[] = [];
-      const allContactIds = new Set<string>();
-      let hierarchicalContactCount = 0;
+      const aggregated = aggregateRecipientCounts(
+        mergedContactGroups,
+        totalWorkoutSelected,
+        totalTeamsWantedSelected,
+        totalUmpireSelected,
+        getContactDetails,
+      );
 
-      // Process all groups in mergedContactGroups (includes both manual and hierarchical).
-      // Hierarchical groups (season/league/division/team) store the hierarchy node id in
-      // `group.ids`, not individual contact ids, so we rely on `group.totalCount` for
-      // their recipient totals and assume the resolved emails are server-side valid.
-      mergedContactGroups.forEach((groups, groupType) => {
-        if (hierarchicalGroupTypes.has(groupType)) {
-          groups.forEach((group) => {
-            hierarchicalContactCount += group.totalCount;
-          });
-          return;
-        }
-
-        groups.forEach((group) => {
-          group.ids.forEach((contactId) => {
-            if (!allContactIds.has(contactId)) {
-              allContactIds.add(contactId);
-
-              const contact = getContactDetails(contactId);
-
-              if (contact) {
-                allSelectedContactDetails.push(contact);
-              }
-            }
-          });
-        });
-      });
-
-      // Create simplified state for the compose page
-      const validContactsCount = allSelectedContactDetails.filter((c) => c.hasValidEmail).length;
-      const totalIndividualContacts = allSelectedContactDetails.length;
-      const totalRecipients =
-        totalIndividualContacts + hierarchicalContactCount + totalWorkoutSelected;
-      const validWorkoutCount = totalWorkoutSelected; // assume workout registrants already filtered to valid emails server-side
-      const validTeamsWantedCount = totalTeamsWantedSelected; // assume resolved emails will be valid server-side
-      const validUmpireCount = totalUmpireSelected; // assume umpire emails are valid
       const simplifiedState: SimplifiedRecipientSelectionState = {
         selectedGroups: mergedContactGroups,
         selectedWorkoutRecipients: workoutSelections,
         selectedTeamsWantedRecipients: teamsWantedSelections,
         selectedUmpireRecipients: umpireSelections,
         workoutManagersOnly,
-        totalRecipients: totalRecipients + totalTeamsWantedSelected + totalUmpireSelected,
-        validEmailCount:
-          validContactsCount +
-          hierarchicalContactCount +
-          validWorkoutCount +
-          validTeamsWantedCount +
-          validUmpireCount,
-        invalidEmailCount:
-          totalRecipients +
-          totalTeamsWantedSelected +
-          totalUmpireSelected -
-          (validContactsCount +
-            hierarchicalContactCount +
-            validWorkoutCount +
-            validTeamsWantedCount +
-            validUmpireCount),
+        totalRecipients: aggregated.totalRecipients,
+        validEmailCount: aggregated.validEmailCount,
+        invalidEmailCount: aggregated.invalidEmailCount,
         searchQuery: '',
         activeTab: 'contacts',
         expandedSections: new Set(),
         groupSearchQueries: {},
       };
 
-      onApply(simplifiedState, allSelectedContactDetails);
+      onApply(simplifiedState, aggregated.individualContactDetails);
       onClose();
       return;
     }

--- a/draco-nodejs/frontend-next/components/emails/recipients/__tests__/aggregateRecipientCounts.test.ts
+++ b/draco-nodejs/frontend-next/components/emails/recipients/__tests__/aggregateRecipientCounts.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateRecipientCounts, HIERARCHICAL_GROUP_TYPES } from '../AdvancedRecipientDialog';
+import type {
+  ContactGroup,
+  GroupType,
+  RecipientContact,
+} from '../../../../types/emails/recipients';
+
+function makeGroup(
+  ids: string[],
+  groupType: GroupType,
+  totalCount: number = ids.length,
+): ContactGroup {
+  return {
+    groupType,
+    groupName: `Test ${groupType}`,
+    ids: new Set(ids),
+    totalCount,
+    managersOnly: false,
+  };
+}
+
+function makeContact(id: string, hasValidEmail: boolean): RecipientContact {
+  return {
+    id,
+    firstName: 'First',
+    lastName: 'Last',
+    email: hasValidEmail ? `${id}@example.com` : '',
+    hasValidEmail,
+  } as RecipientContact;
+}
+
+function lookupFrom(contacts: RecipientContact[]) {
+  const byId = new Map(contacts.map((c) => [c.id, c]));
+  return (contactId: string) => byId.get(contactId);
+}
+
+describe('aggregateRecipientCounts', () => {
+  it('returns zero counts for an empty selection', () => {
+    const result = aggregateRecipientCounts(new Map(), 0, 0, 0, () => undefined);
+    expect(result.individualContactDetails).toEqual([]);
+    expect(result.hierarchicalContactCount).toBe(0);
+    expect(result.totalRecipients).toBe(0);
+    expect(result.validEmailCount).toBe(0);
+    expect(result.invalidEmailCount).toBe(0);
+  });
+
+  it('counts individual contacts and resolves their details', () => {
+    const contacts = [makeContact('a', true), makeContact('b', false), makeContact('c', true)];
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['individuals', [makeGroup(['a', 'b', 'c'], 'individuals')]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, lookupFrom(contacts));
+
+    expect(result.individualContactDetails).toHaveLength(3);
+    expect(result.totalRecipients).toBe(3);
+    expect(result.validEmailCount).toBe(2);
+    expect(result.invalidEmailCount).toBe(1);
+    expect(result.hierarchicalContactCount).toBe(0);
+  });
+
+  it('dedupes individuals that appear in multiple individuals groups', () => {
+    const contacts = [makeContact('a', true), makeContact('b', true)];
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['individuals', [makeGroup(['a', 'b'], 'individuals'), makeGroup(['b'], 'individuals')]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, lookupFrom(contacts));
+
+    expect(result.individualContactDetails.map((c) => c.id).sort()).toEqual(['a', 'b']);
+    expect(result.totalRecipients).toBe(2);
+    expect(result.validEmailCount).toBe(2);
+    expect(result.invalidEmailCount).toBe(0);
+  });
+
+  it('uses group.totalCount for hierarchical groups instead of ids.size', () => {
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['team', [makeGroup(['team-1'], 'team', 12), makeGroup(['team-2'], 'team', 8)]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, () => undefined);
+
+    expect(result.hierarchicalContactCount).toBe(20);
+    expect(result.individualContactDetails).toEqual([]);
+    expect(result.totalRecipients).toBe(20);
+    expect(result.validEmailCount).toBe(20);
+    expect(result.invalidEmailCount).toBe(0);
+  });
+
+  it('treats every hierarchical group type as hierarchical', () => {
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['season', [makeGroup(['s-1'], 'season', 5)]],
+      ['league', [makeGroup(['l-1'], 'league', 7)]],
+      ['division', [makeGroup(['d-1'], 'division', 3)]],
+      ['team', [makeGroup(['t-1'], 'team', 4)]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, () => undefined);
+
+    expect(HIERARCHICAL_GROUP_TYPES.size).toBe(4);
+    expect(result.hierarchicalContactCount).toBe(5 + 7 + 3 + 4);
+    expect(result.individualContactDetails).toEqual([]);
+  });
+
+  it('combines individuals, hierarchical groups, workouts, teams-wanted, and umpires', () => {
+    const contacts = [makeContact('a', true), makeContact('b', false)];
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['individuals', [makeGroup(['a', 'b'], 'individuals')]],
+      ['team', [makeGroup(['t-1'], 'team', 10)]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 3, 2, 1, lookupFrom(contacts));
+
+    // individuals: 2 (1 valid, 1 invalid)
+    // hierarchical: 10 (all assumed valid)
+    // workouts: 3, teamsWanted: 2, umpires: 1 (all assumed valid)
+    expect(result.totalRecipients).toBe(2 + 10 + 3 + 2 + 1);
+    expect(result.validEmailCount).toBe(1 + 10 + 3 + 2 + 1);
+    expect(result.invalidEmailCount).toBe(1);
+    expect(result.hierarchicalContactCount).toBe(10);
+    expect(result.individualContactDetails.map((c) => c.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('does not dedupe individuals against hierarchical ids (they are different id spaces)', () => {
+    // The individuals group lists contact id 'a'; the team hierarchical group has node id 'a'
+    // with totalCount 5. Hierarchical groups must NOT consume the contact-id slot.
+    const contacts = [makeContact('a', true)];
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['individuals', [makeGroup(['a'], 'individuals')]],
+      ['team', [makeGroup(['a'], 'team', 5)]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, lookupFrom(contacts));
+
+    expect(result.individualContactDetails).toHaveLength(1);
+    expect(result.hierarchicalContactCount).toBe(5);
+    expect(result.totalRecipients).toBe(6);
+  });
+
+  it('omits individuals whose contact details cannot be resolved', () => {
+    const contacts = [makeContact('a', true)];
+    const groups = new Map<GroupType, ContactGroup[]>([
+      ['individuals', [makeGroup(['a', 'missing'], 'individuals')]],
+    ]);
+
+    const result = aggregateRecipientCounts(groups, 0, 0, 0, lookupFrom(contacts));
+
+    expect(result.individualContactDetails).toHaveLength(1);
+    expect(result.individualContactDetails[0].id).toBe('a');
+    // totalRecipients still uses the resolved details count
+    expect(result.totalRecipients).toBe(1);
+  });
+});

--- a/draco-nodejs/frontend-next/types/emails/compose.ts
+++ b/draco-nodejs/frontend-next/types/emails/compose.ts
@@ -125,7 +125,6 @@ export interface EmailComposeConfig {
   // Limits
   maxAttachments: number;
   maxAttachmentSize: number;
-  maxRecipients: number;
 
   scope?: 'account' | 'team';
   allowAttachments?: boolean;
@@ -248,7 +247,6 @@ export const DEFAULT_COMPOSE_CONFIG: EmailComposeConfig = {
   enableRealTimeValidation: true,
   maxAttachments: 10,
   maxAttachmentSize: 25 * 1024 * 1024,
-  maxRecipients: 500,
   scope: 'account',
   allowAttachments: true,
   allowAdvancedRecipients: true,
@@ -325,15 +323,6 @@ export function validateComposeData(
     errors.push({
       field: 'recipients',
       message: 'At least one recipient is required',
-      severity: 'error',
-    });
-  }
-
-  // Recipient limit validation
-  if (state.recipientState && state.recipientState.totalRecipients > config.maxRecipients) {
-    errors.push({
-      field: 'recipients',
-      message: `Too many recipients. Maximum ${config.maxRecipients} allowed.`,
       severity: 'error',
     });
   }


### PR DESCRIPTION
Add a detailed fieldDetails object to TeamPage game mapping to surface full field metadata (address, city, state, zip, rainoutNumber, comment, directions, latitude/longitude). Update AdvancedRecipientDialog to properly account for hierarchical contact groups by summing group.totalCount (hierarchicalContactCount), deduplicating individual contacts, and including hierarchical counts in total/valid/invalid recipient calculations (removed legacy manager conversion). Remove the maxRecipients property and its client-side validation from email compose types/defaults, moving recipient limit enforcement out of this validation path.