### PR TITLE
Use account brand and enable AI integrations

### DIFF
--- a/draco-nodejs/frontend-next/app/integrations/IntegrationsClient.tsx
+++ b/draco-nodejs/frontend-next/app/integrations/IntegrationsClient.tsx
@@ -71,7 +71,7 @@ const buildFaqItems = (brandName: string) => [
   {
     question: 'What can the AI see?',
     answer:
-      'Read-only access to your accounts, teams, schedules, stats, and team managers. It cannot make changes, send messages, or see other users’ data.',
+      'Read-only access to your accounts, teams, schedules, stats, and team managers. It cannot make changes or send messages.',
   },
   {
     question: 'What does it cost me?',

--- a/draco-nodejs/frontend-next/app/oauth/authorize/__tests__/page.test.tsx
+++ b/draco-nodejs/frontend-next/app/oauth/authorize/__tests__/page.test.tsx
@@ -69,6 +69,14 @@ vi.mock('@/context/AuthContext', () => ({
   useAuth: () => mockAuthValue,
 }));
 
+vi.mock('@/context/AccountContext', () => ({
+  useAccount: () => ({
+    currentAccount: null,
+    loading: false,
+    initialized: true,
+  }),
+}));
+
 const theme = createTheme();
 
 const renderPage = () =>
@@ -155,7 +163,7 @@ describe('OAuthAuthorizePage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('My MCP Client wants to connect to your Draco account'),
+          screen.getByText('My MCP Client wants to connect to your ezRecSports account'),
         ).toBeInTheDocument();
       });
 
@@ -221,7 +229,7 @@ describe('OAuthAuthorizePage', () => {
 
       expect(screen.getByText('Unknown client identifier')).toBeInTheDocument();
       expect(screen.getByText('invalid_client')).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Return to Draco' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Return to ezRecSports' })).toBeInTheDocument();
     });
   });
 

--- a/draco-nodejs/frontend-next/app/oauth/authorize/__tests__/page.test.tsx
+++ b/draco-nodejs/frontend-next/app/oauth/authorize/__tests__/page.test.tsx
@@ -69,9 +69,13 @@ vi.mock('@/context/AuthContext', () => ({
   useAuth: () => mockAuthValue,
 }));
 
+let mockAccountValue: { currentAccount: { id: string; name: string } | null } = {
+  currentAccount: null,
+};
+
 vi.mock('@/context/AccountContext', () => ({
   useAccount: () => ({
-    currentAccount: null,
+    currentAccount: mockAccountValue.currentAccount,
     loading: false,
     initialized: true,
   }),
@@ -102,6 +106,7 @@ describe('OAuthAuthorizePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuthValue = makeAuthValue();
+    mockAccountValue = { currentAccount: null };
   });
 
   afterEach(() => {
@@ -230,6 +235,56 @@ describe('OAuthAuthorizePage', () => {
       expect(screen.getByText('Unknown client identifier')).toBeInTheDocument();
       expect(screen.getByText('invalid_client')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Return to ezRecSports' })).toBeInTheDocument();
+    });
+  });
+
+  describe('account brand name', () => {
+    it('renders the current account name in the consent heading and error-state link', async () => {
+      mockAccountValue = { currentAccount: { id: 'acct-7', name: 'Northside Little League' } };
+      mockFetch.mockResolvedValue(makeJsonResponse(makeValidateSuccessBody()));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'My MCP Client wants to connect to your Northside Little League account',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('renders the current account name in the error-state Return link', async () => {
+      mockAccountValue = { currentAccount: { id: 'acct-7', name: 'Northside Little League' } };
+      mockFetch.mockResolvedValue(
+        makeJsonResponse(
+          { error: 'invalid_client', error_description: 'Unknown client identifier' },
+          400,
+        ),
+      );
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Authorization request failed')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('link', { name: 'Return to Northside Little League' }),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to ezRecSports when the account name is whitespace', async () => {
+      mockAccountValue = { currentAccount: { id: 'acct-7', name: '   ' } };
+      mockFetch.mockResolvedValue(makeJsonResponse(makeValidateSuccessBody()));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('My MCP Client wants to connect to your ezRecSports account'),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/draco-nodejs/frontend-next/app/oauth/authorize/page.tsx
+++ b/draco-nodejs/frontend-next/app/oauth/authorize/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import NextLink from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useAccount } from '@/context/AccountContext';
 import { useAuth } from '@/context/AuthContext';
 
 interface ValidateSuccessResponse {
@@ -61,9 +62,10 @@ interface DecisionResponse {
 interface OAuthErrorStateProps {
   error: string;
   errorDescription?: string;
+  brandName: string;
 }
 
-function OAuthErrorState({ error, errorDescription }: OAuthErrorStateProps) {
+function OAuthErrorState({ error, errorDescription, brandName }: OAuthErrorStateProps) {
   return (
     <Box
       sx={{
@@ -84,7 +86,7 @@ function OAuthErrorState({ error, errorDescription }: OAuthErrorStateProps) {
             {error}
           </Typography>
           <MuiLink component={NextLink} href="/" underline="hover">
-            Return to Draco
+            Return to {brandName}
           </MuiLink>
         </Stack>
       </Paper>
@@ -96,6 +98,8 @@ function OAuthAuthorizeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, token, initialized: authInitialized, loading: authLoading } = useAuth();
+  const { currentAccount } = useAccount();
+  const brandName = currentAccount?.name ?? 'ezRecSports';
 
   const [validateResult, setValidateResult] = useState<ValidateSuccessResponse | null>(null);
   const [validateError, setValidateError] = useState<{
@@ -285,6 +289,7 @@ function OAuthAuthorizeContent() {
       <OAuthErrorState
         error={validateError.error}
         errorDescription={validateError.error_description}
+        brandName={brandName}
       />
     );
   }
@@ -294,6 +299,7 @@ function OAuthAuthorizeContent() {
       <OAuthErrorState
         error={decisionError.error}
         errorDescription={decisionError.error_description}
+        brandName={brandName}
       />
     );
   }
@@ -317,7 +323,7 @@ function OAuthAuthorizeContent() {
       <Paper elevation={2} sx={{ p: 4, width: '100%', maxWidth: 480 }}>
         <Stack spacing={3}>
           <Typography variant="h5" sx={{ fontWeight: 600 }}>
-            {validateResult.client_name} wants to connect to your Draco account
+            {validateResult.client_name} wants to connect to your {brandName} account
           </Typography>
           <Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>

--- a/draco-nodejs/frontend-next/app/oauth/authorize/page.tsx
+++ b/draco-nodejs/frontend-next/app/oauth/authorize/page.tsx
@@ -18,6 +18,7 @@ import NextLink from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAccount } from '@/context/AccountContext';
 import { useAuth } from '@/context/AuthContext';
+import { DEFAULT_SITE_NAME } from '@/lib/seoConstants';
 
 interface ValidateSuccessResponse {
   rid: string;
@@ -99,7 +100,9 @@ function OAuthAuthorizeContent() {
   const searchParams = useSearchParams();
   const { user, token, initialized: authInitialized, loading: authLoading } = useAuth();
   const { currentAccount } = useAccount();
-  const brandName = currentAccount?.name ?? 'ezRecSports';
+  const trimmedAccountName = currentAccount?.name?.trim();
+  const brandName =
+    trimmedAccountName && trimmedAccountName.length > 0 ? trimmedAccountName : DEFAULT_SITE_NAME;
 
   const [validateResult, setValidateResult] = useState<ValidateSuccessResponse | null>(null);
   const [validateError, setValidateError] = useState<{

--- a/draco-nodejs/frontend-next/constants/featureFlags.ts
+++ b/draco-nodejs/frontend-next/constants/featureFlags.ts
@@ -1,1 +1,1 @@
-export const SHOW_AI_INTEGRATIONS = false;
+export const SHOW_AI_INTEGRATIONS = true;


### PR DESCRIPTION
Use the current account's brand name in the OAuth authorize UI (defaults to 'ezRecSports' when no account). Wire useAccount into the authorize page, pass brandName to OAuthErrorState, and update headings/links to show the account brand. Adjust tests to mock AccountContext and expect the new brand text. Also tweak integrations FAQ copy to remove the 'see other users’ data' phrasing and enable the SHOW_AI_INTEGRATIONS feature flag.