### PR TITLE
Add account-level games MCP tool; fix local-date filtering and scores

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,6 +261,15 @@
         "line_number": 6
       }
     ],
+    "draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "draco-nodejs/mcp-server/src/__tests__/tools/getMyBattingStats.test.ts": [
       {
         "type": "Secret Keyword",
@@ -424,5 +433,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-23T00:18:18Z"
+  "generated_at": "2026-05-30T03:00:03Z"
 }

--- a/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
@@ -74,6 +74,12 @@ function parsedText(result: { content: unknown[] }) {
   return JSON.parse(first.text);
 }
 
+function seasonGamesResponse(games: ReturnType<typeof game>[], total?: number) {
+  return {
+    data: { games, pagination: { page: 1, limit: 100, total: total ?? games.length } },
+  };
+}
+
 describe('getAccountGamesHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -101,6 +107,24 @@ describe('getAccountGamesHandler', () => {
       const schema = z.object(getAccountGamesInputSchema);
       expect(() => schema.parse({ account_id: 'acc-1', limit: 101 })).toThrow();
     });
+
+    it('rejects a malformed from date', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() => schema.parse({ account_id: 'acc-1', from: 'not-a-date' })).toThrow();
+    });
+
+    it('rejects impossible calendar dates', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() => schema.parse({ account_id: 'acc-1', to: '2026-02-30' })).toThrow();
+      expect(() => schema.parse({ account_id: 'acc-1', to: '2026-13-01' })).toThrow();
+    });
+
+    it('accepts a valid YYYY-MM-DD date', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() =>
+        schema.parse({ account_id: 'acc-1', from: '2026-05-29', to: '2026-05-31' }),
+      ).not.toThrow();
+    });
   });
 
   describe('account-wide query', () => {
@@ -112,7 +136,7 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'America/Chicago' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [game()] } });
+      mockListSeasonGames.mockResolvedValueOnce(seasonGamesResponse([game()]));
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', range: 'today' }),
@@ -140,28 +164,26 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({
-        data: {
-          games: [
-            game({
-              id: 'final',
-              gameDate: '2026-05-10T19:00:00Z',
-              gameStatus: 1,
-              gameStatusText: 'Final',
-              homeScore: 7,
-              visitorScore: 3,
-            }),
-            game({
-              id: 'scheduled',
-              gameDate: '2026-05-12T19:00:00Z',
-              gameStatus: 0,
-              gameStatusText: 'Scheduled',
-              homeScore: 0,
-              visitorScore: 0,
-            }),
-          ],
-        },
-      });
+      mockListSeasonGames.mockResolvedValueOnce(
+        seasonGamesResponse([
+          game({
+            id: 'final',
+            gameDate: '2026-05-10T19:00:00Z',
+            gameStatus: 1,
+            gameStatusText: 'Final',
+            homeScore: 7,
+            visitorScore: 3,
+          }),
+          game({
+            id: 'scheduled',
+            gameDate: '2026-05-12T19:00:00Z',
+            gameStatus: 0,
+            gameStatusText: 'Scheduled',
+            homeScore: 0,
+            visitorScore: 0,
+          }),
+        ]),
+      );
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01' }),
@@ -180,7 +202,7 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [] } });
+      mockListSeasonGames.mockResolvedValueOnce(seasonGamesResponse([]));
 
       await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', season_id: 'season-99', range: 'today' }),
@@ -202,14 +224,12 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'America/Chicago' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({
-        data: {
-          games: [
-            game({ id: 'today-evening', gameDate: '2026-05-15T23:00:00-05:00' }),
-            game({ id: 'tomorrow-early', gameDate: '2026-05-16T10:00:00-05:00' }),
-          ],
-        },
-      });
+      mockListSeasonGames.mockResolvedValueOnce(
+        seasonGamesResponse([
+          game({ id: 'today-evening', gameDate: '2026-05-15T23:00:00-05:00' }),
+          game({ id: 'tomorrow-early', gameDate: '2026-05-16T10:00:00-05:00' }),
+        ]),
+      );
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', range: 'today' }),
@@ -227,14 +247,12 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({
-        data: {
-          games: [
-            game({ id: 'g-adult', league: { id: 'lg-adult', name: '18+ Adult' } }),
-            game({ id: 'g-youth', league: { id: 'lg-youth', name: 'Youth 12U' } }),
-          ],
-        },
-      });
+      mockListSeasonGames.mockResolvedValueOnce(
+        seasonGamesResponse([
+          game({ id: 'g-adult', league: { id: 'lg-adult', name: '18+ Adult' } }),
+          game({ id: 'g-youth', league: { id: 'lg-youth', name: 'Youth 12U' } }),
+        ]),
+      );
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01', league_id: 'lg-adult' }),
@@ -253,15 +271,13 @@ describe('getAccountGamesHandler', () => {
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({
-        data: {
-          games: [
-            game({ id: 'later', gameDate: '2026-05-20T19:00:00Z' }),
-            game({ id: 'earlier', gameDate: '2026-05-18T19:00:00Z' }),
-            game({ id: 'latest', gameDate: '2026-05-22T19:00:00Z' }),
-          ],
-        },
-      });
+      mockListSeasonGames.mockResolvedValueOnce(
+        seasonGamesResponse([
+          game({ id: 'later', gameDate: '2026-05-20T19:00:00Z' }),
+          game({ id: 'earlier', gameDate: '2026-05-18T19:00:00Z' }),
+          game({ id: 'latest', gameDate: '2026-05-22T19:00:00Z' }),
+        ]),
+      );
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01', limit: 2 }),
@@ -273,13 +289,88 @@ describe('getAccountGamesHandler', () => {
     });
   });
 
+  describe('pagination', () => {
+    it('pages through every backend page in the window before filtering', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) =>
+        game({ id: `g-${i}`, gameDate: '2026-05-15T18:00:00Z' }),
+      );
+      const page2 = Array.from({ length: 50 }, (_, i) =>
+        game({ id: `g-${100 + i}`, gameDate: '2026-05-15T18:00:00Z' }),
+      );
+
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames
+        .mockResolvedValueOnce({
+          data: { games: page1, pagination: { page: 1, limit: 100, total: 150 } },
+        })
+        .mockResolvedValueOnce({
+          data: { games: page2, pagination: { page: 2, limit: 100, total: 150 } },
+        });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({
+          account_id: 'acc-1',
+          from: '2026-05-15',
+          to: '2026-05-15',
+          limit: 100,
+        }),
+      );
+
+      expect(mockListSeasonGames).toHaveBeenCalledTimes(2);
+      expect(mockListSeasonGames).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ query: expect.objectContaining({ page: 1, limit: 100 }) }),
+      );
+      expect(mockListSeasonGames).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ query: expect.objectContaining({ page: 2, limit: 100 }) }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(100);
+      expect(body.truncated).toBe(false);
+    });
+
+    it('caps at the max page count and flags the result as truncated', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      for (let p = 1; p <= 20; p += 1) {
+        const pageGames = Array.from({ length: 100 }, (_, i) =>
+          game({ id: `p${p}-${i}`, gameDate: '2026-05-15T18:00:00Z' }),
+        );
+        mockListSeasonGames.mockResolvedValueOnce({
+          data: { games: pageGames, pagination: { page: p, limit: 100, total: 3000 } },
+        });
+      }
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({
+          account_id: 'acc-1',
+          from: '2026-05-15',
+          to: '2026-05-15',
+          limit: 100,
+        }),
+      );
+
+      expect(mockListSeasonGames).toHaveBeenCalledTimes(20);
+      const body = parsedText(result);
+      expect(body.truncated).toBe(true);
+      expect(body.summary).toContain('may be incomplete');
+    });
+  });
+
   describe('empty results', () => {
     it('returns a friendly summary when no games match (including hidden schedules)', async () => {
       mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
       mockGetAccountById.mockResolvedValueOnce({
         data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
-      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [] } });
+      mockListSeasonGames.mockResolvedValueOnce(seasonGamesResponse([]));
 
       const result = await withCtx(() =>
         getAccountGamesHandler({ account_id: 'acc-1', range: 'tonight' }),

--- a/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { requestContext } from '../../auth/perRequestContext.js';
+
+vi.mock('../../config/env.js', () => ({
+  env: {
+    JWT_SECRET: 'test-secret',
+    MCP_AUDIENCE: 'mcp',
+    OAUTH_ISSUER: 'https://test.draco.com',
+    MCP_PORT: 3010,
+    BACKEND_BASE_URL: 'http://localhost:3001',
+    OAUTH_RESOURCE_METADATA_URL: 'http://localhost:3001/.well-known/oauth-protected-resource',
+    LOG_LEVEL: 'info',
+    NODE_ENV: 'test',
+    MCP_RATE_LIMIT_PER_MIN: 60,
+    MCP_RATE_LIMIT_PER_HOUR: 600,
+  },
+}));
+
+const mockGetCurrentSeason = vi.fn();
+const mockListSeasonGames = vi.fn();
+const mockGetAccountById = vi.fn();
+
+vi.mock('@draco/shared-api-client', () => ({
+  getCurrentSeason: mockGetCurrentSeason,
+  listSeasonGames: mockListSeasonGames,
+  getAccountById: mockGetAccountById,
+}));
+
+vi.mock('../../sdkClient/createDracoClient.js', () => ({
+  getDracoClient: vi.fn(() => ({ __mockClient: true })),
+}));
+
+const mockAuditLog = vi.fn();
+vi.mock('../../logging/auditLogger.js', () => ({
+  auditLog: mockAuditLog,
+}));
+
+const { getAccountGamesHandler, getAccountGamesInputSchema } =
+  await import('../../tools/getAccountGames.js');
+
+const fixtureCtx = {
+  userId: 'user-123',
+  accessToken: 'tok',
+  scopes: ['mcp:read'],
+  requestId: 'req-abc',
+  cache: new Map(),
+};
+
+function withCtx<T>(fn: () => Promise<T>): Promise<T> {
+  return requestContext.run({ ...fixtureCtx, cache: new Map() }, fn);
+}
+
+function game(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'game-1',
+    gameDate: '2026-05-15T19:00:00-05:00',
+    homeTeam: { id: 'ht-1', name: 'Tigers' },
+    visitorTeam: { id: 'vt-1', name: 'Bears' },
+    league: { id: 'lg-adult', name: '18+ Adult' },
+    field: { id: 'f-1', name: 'North Field', shortName: 'NF' },
+    homeScore: 0,
+    visitorScore: 0,
+    gameStatus: 0,
+    gameStatusText: 'Scheduled' as const,
+    gameType: 0,
+    ...overrides,
+  };
+}
+
+function parsedText(result: { content: unknown[] }) {
+  const first = result.content[0] as { text: string };
+  return JSON.parse(first.text);
+}
+
+describe('getAccountGamesHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('input schema validation', () => {
+    it('requires account_id', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() => schema.parse({})).toThrow();
+    });
+
+    it('accepts account_id alone and defaults the limit', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      const parsed = schema.parse({ account_id: 'acc-1' });
+      expect(parsed.limit).toBe(25);
+    });
+
+    it('rejects an unknown range value', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() => schema.parse({ account_id: 'acc-1', range: 'next_year' })).toThrow();
+    });
+
+    it('rejects limit > 100', () => {
+      const schema = z.object(getAccountGamesInputSchema);
+      expect(() => schema.parse({ account_id: 'acc-1', limit: 101 })).toThrow();
+    });
+  });
+
+  describe('account-wide query', () => {
+    it('resolves the current season and queries season games with a padded date window', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-15T18:00:00.000Z'));
+
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'America/Chicago' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [game()] } });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', range: 'today' }),
+      );
+
+      expect(mockGetCurrentSeason).toHaveBeenCalledTimes(1);
+      expect(mockListSeasonGames).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { accountId: 'acc-1', seasonId: 'season-1' },
+          query: expect.objectContaining({
+            startDate: '2026-05-14T00:00:00.000Z',
+            endDate: '2026-05-16T23:59:59.999Z',
+            sortOrder: 'asc',
+          }),
+        }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(1);
+      expect(body.games[0].league_name).toBe('18+ Adult');
+    });
+
+    it('surfaces runs for completed games and null for unplayed games', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({
+        data: {
+          games: [
+            game({
+              id: 'final',
+              gameDate: '2026-05-10T19:00:00Z',
+              gameStatus: 1,
+              gameStatusText: 'Final',
+              homeScore: 7,
+              visitorScore: 3,
+            }),
+            game({
+              id: 'scheduled',
+              gameDate: '2026-05-12T19:00:00Z',
+              gameStatus: 0,
+              gameStatusText: 'Scheduled',
+              homeScore: 0,
+              visitorScore: 0,
+            }),
+          ],
+        },
+      });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01' }),
+      );
+
+      const body = parsedText(result);
+      const final = body.games.find((g: { game_id: string }) => g.game_id === 'final');
+      const scheduled = body.games.find((g: { game_id: string }) => g.game_id === 'scheduled');
+      expect(final.home_score).toBe(7);
+      expect(final.visitor_score).toBe(3);
+      expect(scheduled.home_score).toBeNull();
+      expect(scheduled.visitor_score).toBeNull();
+    });
+
+    it('uses an explicit season_id without calling getCurrentSeason', async () => {
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [] } });
+
+      await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', season_id: 'season-99', range: 'today' }),
+      );
+
+      expect(mockGetCurrentSeason).not.toHaveBeenCalled();
+      expect(mockListSeasonGames).toHaveBeenCalledWith(
+        expect.objectContaining({ path: { accountId: 'acc-1', seasonId: 'season-99' } }),
+      );
+    });
+  });
+
+  describe('local-date filtering', () => {
+    it('drops games that fall outside the requested local day', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-15T18:00:00.000Z'));
+
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'America/Chicago' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({
+        data: {
+          games: [
+            game({ id: 'today-evening', gameDate: '2026-05-15T23:00:00-05:00' }),
+            game({ id: 'tomorrow-early', gameDate: '2026-05-16T10:00:00-05:00' }),
+          ],
+        },
+      });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', range: 'today' }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(1);
+      expect(body.games[0].game_id).toBe('today-evening');
+    });
+  });
+
+  describe('league filtering', () => {
+    it('keeps only games in the requested league_season_id', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({
+        data: {
+          games: [
+            game({ id: 'g-adult', league: { id: 'lg-adult', name: '18+ Adult' } }),
+            game({ id: 'g-youth', league: { id: 'lg-youth', name: 'Youth 12U' } }),
+          ],
+        },
+      });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01', league_id: 'lg-adult' }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(1);
+      expect(body.games[0].game_id).toBe('g-adult');
+      expect(body.summary).toContain('in the selected league');
+    });
+  });
+
+  describe('result shaping and limits', () => {
+    it('sorts by date ascending and caps at the requested limit', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({
+        data: {
+          games: [
+            game({ id: 'later', gameDate: '2026-05-20T19:00:00Z' }),
+            game({ id: 'earlier', gameDate: '2026-05-18T19:00:00Z' }),
+            game({ id: 'latest', gameDate: '2026-05-22T19:00:00Z' }),
+          ],
+        },
+      });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', from: '2026-05-01', limit: 2 }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(2);
+      expect(body.games.map((g: { game_id: string }) => g.game_id)).toEqual(['earlier', 'later']);
+    });
+  });
+
+  describe('empty results', () => {
+    it('returns a friendly summary when no games match (including hidden schedules)', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockResolvedValueOnce({ data: { games: [] } });
+
+      const result = await withCtx(() =>
+        getAccountGamesHandler({ account_id: 'acc-1', range: 'tonight' }),
+      );
+
+      const body = parsedText(result);
+      expect(body.count).toBe(0);
+      expect(body.summary).toBe('No games scheduled today.');
+    });
+  });
+
+  describe('error mapping', () => {
+    it('maps SDK 401 to McpError InvalidRequest', async () => {
+      mockGetCurrentSeason.mockRejectedValueOnce(
+        Object.assign(new Error('Unauthorized'), { response: { status: 401 } }),
+      );
+
+      await expect(
+        withCtx(() => getAccountGamesHandler({ account_id: 'acc-1' })),
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidRequest });
+    });
+
+    it('logs error status and throws McpError on 500', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: { id: 'season-1', name: 'Spring' } });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+      mockListSeasonGames.mockRejectedValueOnce(
+        Object.assign(new Error('boom'), { response: { status: 500 } }),
+      );
+
+      await expect(
+        withCtx(() => getAccountGamesHandler({ account_id: 'acc-1' })),
+      ).rejects.toBeInstanceOf(McpError);
+      expect(mockAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'error', tool: 'get_account_games', accountId: 'acc-1' }),
+      );
+    });
+  });
+});

--- a/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/getAccountGames.test.ts
@@ -285,6 +285,9 @@ describe('getAccountGamesHandler', () => {
 
       const body = parsedText(result);
       expect(body.count).toBe(2);
+      expect(body.matched).toBe(3);
+      expect(body.summary).toContain('3 games scheduled');
+      expect(body.summary).toContain('showing the first 2');
       expect(body.games.map((g: { game_id: string }) => g.game_id)).toEqual(['earlier', 'later']);
     });
   });
@@ -330,6 +333,7 @@ describe('getAccountGamesHandler', () => {
       );
 
       const body = parsedText(result);
+      expect(body.matched).toBe(150);
       expect(body.count).toBe(100);
       expect(body.truncated).toBe(false);
     });

--- a/draco-nodejs/mcp-server/src/__tests__/tools/getTeamSchedule.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/getTeamSchedule.test.ts
@@ -131,15 +131,99 @@ describe('getTeamScheduleHandler', () => {
 
       expect(mockListTeamSeasonSchedule).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: expect.objectContaining({ startDate: '2026-05-01', endDate: '2026-05-31' }),
+          query: expect.objectContaining({
+            startDate: '2026-04-30T00:00:00.000Z',
+            endDate: '2026-06-01T23:59:59.999Z',
+          }),
         }),
       );
+    });
+
+    it('filters on local date so a Friday-night ET game survives to=that Friday', async () => {
+      // Fri 2026-05-29 8:15 PM ET == 2026-05-30 00:15 UTC (next UTC day).
+      const fridayNightGame = {
+        ...fixtureGame,
+        id: 'fri-night',
+        gameDate: '2026-05-30T00:15:00.000Z',
+      };
+      const saturdayGame = {
+        ...fixtureGame,
+        id: 'sat',
+        gameDate: '2026-05-30T18:00:00.000Z',
+      };
+
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: fixtureSeason });
+      mockListTeamSeasonSchedule.mockResolvedValueOnce({
+        data: {
+          games: [fridayNightGame, saturdayGame],
+          pagination: { page: 1, limit: 100, total: 2 },
+        },
+      });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'America/New_York' } } },
+      });
+
+      const result = await withCtx(() =>
+        getTeamScheduleHandler({
+          account_id: 'acc-1',
+          team_season_id: 'ts-1',
+          to: '2026-05-29',
+        }),
+      );
+
+      const body = JSON.parse((result.content[0] as { text: string }).text);
+      expect(body.count).toBe(1);
+      expect(body.games[0].game_id).toBe('fri-night');
+    });
+
+    it('surfaces runs for completed games and null for unplayed games', async () => {
+      mockGetCurrentSeason.mockResolvedValueOnce({ data: fixtureSeason });
+      mockListTeamSeasonSchedule.mockResolvedValueOnce({
+        data: {
+          games: [
+            {
+              ...fixtureGame,
+              id: 'final',
+              gameStatus: 1,
+              gameStatusText: 'Final',
+              homeScore: 5,
+              visitorScore: 2,
+            },
+            {
+              ...fixtureGame,
+              id: 'scheduled',
+              gameDate: '2026-05-12T19:00:00-05:00',
+              gameStatus: 0,
+              gameStatusText: 'Scheduled',
+            },
+          ],
+          pagination: { page: 1, limit: 100, total: 2 },
+        },
+      });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
+      });
+
+      const result = await withCtx(() =>
+        getTeamScheduleHandler({ account_id: 'acc-1', team_season_id: 'ts-1' }),
+      );
+
+      const body = JSON.parse((result.content[0] as { text: string }).text);
+      const final = body.games.find((g: { game_id: string }) => g.game_id === 'final');
+      const scheduled = body.games.find((g: { game_id: string }) => g.game_id === 'scheduled');
+      expect(final.home_score).toBe(5);
+      expect(final.visitor_score).toBe(2);
+      expect(scheduled.home_score).toBeNull();
+      expect(scheduled.visitor_score).toBeNull();
     });
 
     it('returns no-games message for empty schedule', async () => {
       mockGetCurrentSeason.mockResolvedValueOnce({ data: fixtureSeason });
       mockListTeamSeasonSchedule.mockResolvedValueOnce({
         data: { games: [], pagination: { page: 1, limit: 100, total: 0 } },
+      });
+      mockGetAccountById.mockResolvedValueOnce({
+        data: { account: { id: 'acc-1', configuration: { timeZone: 'UTC' } } },
       });
 
       const result = await withCtx(() =>

--- a/draco-nodejs/mcp-server/src/__tests__/tools/getTeamSchedule.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/getTeamSchedule.test.ts
@@ -88,6 +88,16 @@ describe('getTeamScheduleHandler', () => {
         }),
       ).not.toThrow();
     });
+
+    it('rejects malformed or impossible dates', () => {
+      const schema = z.object(getTeamScheduleInputSchema);
+      expect(() =>
+        schema.parse({ account_id: 'acc-1', team_season_id: 'ts-1', from: 'not-a-date' }),
+      ).toThrow();
+      expect(() =>
+        schema.parse({ account_id: 'acc-1', team_season_id: 'ts-1', to: '2026-02-30' }),
+      ).toThrow();
+    });
   });
 
   describe('happy path', () => {

--- a/draco-nodejs/mcp-server/src/__tests__/tools/resolveGameDateWindow.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/resolveGameDateWindow.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveGameDateWindow,
+  localDateBounds,
+  filterGamesByLocalDate,
+  localDateInTimeZone,
+} from '../../tools/helpers/resolveGameDateWindow.js';
+
+describe('localDateInTimeZone', () => {
+  it('returns the local calendar date in the given timezone, not UTC', () => {
+    const instant = '2026-03-09T03:30:00.000Z';
+    expect(localDateInTimeZone(instant, 'America/Chicago')).toBe('2026-03-08');
+    expect(localDateInTimeZone(instant, 'UTC')).toBe('2026-03-09');
+    expect(localDateInTimeZone(instant, 'Pacific/Kiritimati')).toBe('2026-03-09');
+  });
+
+  it('rolls the local date forward for far-east timezones (UTC+14)', () => {
+    const lateUtc = '2026-03-09T11:00:00.000Z';
+    expect(localDateInTimeZone(lateUtc, 'Pacific/Kiritimati')).toBe('2026-03-10');
+    expect(localDateInTimeZone(lateUtc, 'UTC')).toBe('2026-03-09');
+  });
+});
+
+describe('resolveGameDateWindow', () => {
+  describe("range='today'", () => {
+    it('targets the local day and pads the UTC query window by ±1 day', () => {
+      const now = new Date('2026-06-15T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'today', timezone: 'America/Chicago', now });
+
+      expect(win.localStart).toBe('2026-06-15');
+      expect(win.localEnd).toBe('2026-06-15');
+      expect(win.startDate).toBe('2026-06-14T00:00:00.000Z');
+      expect(win.endDate).toBe('2026-06-16T23:59:59.999Z');
+    });
+
+    it("uses the account timezone's calendar day, which can differ from UTC", () => {
+      const now = new Date('2026-06-15T02:00:00.000Z');
+      const chicago = resolveGameDateWindow({ range: 'today', timezone: 'America/Chicago', now });
+      const utc = resolveGameDateWindow({ range: 'today', timezone: 'UTC', now });
+
+      expect(chicago.localStart).toBe('2026-06-14');
+      expect(utc.localStart).toBe('2026-06-15');
+    });
+
+    it('treats tonight as the same local day as today', () => {
+      const now = new Date('2026-06-15T18:00:00.000Z');
+      const today = resolveGameDateWindow({ range: 'today', timezone: 'UTC', now });
+      const tonight = resolveGameDateWindow({ range: 'tonight', timezone: 'UTC', now });
+      expect(tonight.localStart).toBe(today.localStart);
+      expect(tonight.localEnd).toBe(today.localEnd);
+    });
+  });
+
+  describe("range='tomorrow'", () => {
+    it('targets the next local day', () => {
+      const now = new Date('2026-06-15T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'tomorrow', timezone: 'UTC', now });
+      expect(win.localStart).toBe('2026-06-16');
+      expect(win.localEnd).toBe('2026-06-16');
+      expect(win.startDate).toBe('2026-06-15T00:00:00.000Z');
+      expect(win.endDate).toBe('2026-06-17T23:59:59.999Z');
+    });
+
+    it('rolls over month boundaries', () => {
+      const now = new Date('2026-06-30T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'tomorrow', timezone: 'UTC', now });
+      expect(win.localStart).toBe('2026-07-01');
+    });
+  });
+
+  describe("range='this_week'", () => {
+    it('spans seven consecutive local days starting today', () => {
+      const now = new Date('2026-06-15T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'this_week', timezone: 'UTC', now });
+      expect(win.localStart).toBe('2026-06-15');
+      expect(win.localEnd).toBe('2026-06-21');
+      expect(win.startDate).toBe('2026-06-14T00:00:00.000Z');
+      expect(win.endDate).toBe('2026-06-22T23:59:59.999Z');
+    });
+  });
+
+  describe("range='this_weekend'", () => {
+    it('targets the upcoming Saturday and Sunday on a weekday', () => {
+      const wednesday = new Date('2026-06-17T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'this_weekend', timezone: 'UTC', now: wednesday });
+      expect(win.localStart).toBe('2026-06-20');
+      expect(win.localEnd).toBe('2026-06-21');
+    });
+
+    it('includes today and Sunday when today is Saturday', () => {
+      const saturday = new Date('2026-06-20T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'this_weekend', timezone: 'UTC', now: saturday });
+      expect(win.localStart).toBe('2026-06-20');
+      expect(win.localEnd).toBe('2026-06-21');
+    });
+
+    it('includes only today when today is Sunday', () => {
+      const sunday = new Date('2026-06-21T18:00:00.000Z');
+      const win = resolveGameDateWindow({ range: 'this_weekend', timezone: 'UTC', now: sunday });
+      expect(win.localStart).toBe('2026-06-21');
+      expect(win.localEnd).toBe('2026-06-21');
+    });
+  });
+
+  describe('explicit from/to (delegates to localDateBounds)', () => {
+    it('pads the UTC query window while keeping the local bounds tight', () => {
+      const now = new Date('2026-06-15T18:00:00.000Z');
+      const win = resolveGameDateWindow({
+        from: '2026-05-01',
+        to: '2026-05-29',
+        timezone: 'America/New_York',
+        now,
+      });
+      expect(win.localStart).toBe('2026-05-01');
+      expect(win.localEnd).toBe('2026-05-29');
+      expect(win.startDate).toBe('2026-04-30T00:00:00.000Z');
+      expect(win.endDate).toBe('2026-05-30T23:59:59.999Z');
+    });
+  });
+});
+
+describe('localDateBounds', () => {
+  it('pads each provided bound by a day and records the tight local bounds', () => {
+    const win = localDateBounds('2026-05-01', '2026-05-29');
+    expect(win.startDate).toBe('2026-04-30T00:00:00.000Z');
+    expect(win.endDate).toBe('2026-05-30T23:59:59.999Z');
+    expect(win.localStart).toBe('2026-05-01');
+    expect(win.localEnd).toBe('2026-05-29');
+  });
+
+  it('leaves an open-ended bound undefined', () => {
+    expect(localDateBounds('2026-07-01', undefined)).toEqual({
+      startDate: '2026-06-30T00:00:00.000Z',
+      endDate: undefined,
+      localStart: '2026-07-01',
+      localEnd: undefined,
+    });
+    expect(localDateBounds(undefined, '2026-07-31')).toEqual({
+      startDate: undefined,
+      endDate: '2026-08-01T23:59:59.999Z',
+      localStart: undefined,
+      localEnd: '2026-07-31',
+    });
+  });
+});
+
+describe('filterGamesByLocalDate', () => {
+  const tz = 'America/New_York';
+
+  it('returns games unchanged when no bounds are given', () => {
+    const games = [{ gameDate: '2026-05-29T23:30:00-04:00' }];
+    expect(filterGamesByLocalDate(games, tz)).toBe(games);
+  });
+
+  it('keeps a Friday-night ET game whose UTC date is the next day for to=that Friday', () => {
+    // Fri 2026-05-29 8:15 PM ET == 2026-05-30 00:15 UTC.
+    const fridayNightGame = { id: 'fri', gameDate: '2026-05-30T00:15:00.000Z' };
+    const saturdayGame = { id: 'sat', gameDate: '2026-05-30T18:00:00.000Z' };
+
+    expect(localDateInTimeZone(fridayNightGame.gameDate, tz)).toBe('2026-05-29');
+    expect(localDateInTimeZone(saturdayGame.gameDate, tz)).toBe('2026-05-30');
+
+    const kept = filterGamesByLocalDate(
+      [fridayNightGame, saturdayGame],
+      tz,
+      undefined,
+      '2026-05-29',
+    );
+    expect(kept.map((g) => g.id)).toEqual(['fri']);
+  });
+
+  it('excludes games before the local lower bound', () => {
+    const games = [
+      { id: 'apr30', gameDate: '2026-04-30T18:00:00.000Z' },
+      { id: 'may01', gameDate: '2026-05-01T18:00:00.000Z' },
+    ];
+    const kept = filterGamesByLocalDate(games, tz, '2026-05-01', undefined);
+    expect(kept.map((g) => g.id)).toEqual(['may01']);
+  });
+
+  describe('DST boundary (America/Chicago spring forward 2026-03-08)', () => {
+    it('keeps a late-evening local game and drops a genuine next-local-day game', () => {
+      const win = resolveGameDateWindow({
+        range: 'today',
+        timezone: 'America/Chicago',
+        now: new Date('2026-03-08T12:00:00.000Z'),
+      });
+
+      const lateEvening = { id: 'late', gameDate: '2026-03-09T04:30:00.000Z' }; // 23:30 CDT Mar 8
+      const afterMidnight = { id: 'next', gameDate: '2026-03-09T06:00:00.000Z' }; // 01:00 CDT Mar 9
+
+      expect(localDateInTimeZone(lateEvening.gameDate, 'America/Chicago')).toBe('2026-03-08');
+      expect(localDateInTimeZone(afterMidnight.gameDate, 'America/Chicago')).toBe('2026-03-09');
+
+      const kept = filterGamesByLocalDate(
+        [lateEvening, afterMidnight],
+        'America/Chicago',
+        win.localStart,
+        win.localEnd,
+      );
+      expect(kept.map((g) => g.id)).toEqual(['late']);
+    });
+  });
+});

--- a/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
+++ b/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { listSeasonGames } from '@draco/shared-api-client';
+import type { Client } from '@draco/shared-api-client/generated/client';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { getDracoClient } from '../sdkClient/createDracoClient.js';
 import { mapSdkError } from '../sdkClient/errorMapping.js';
@@ -9,6 +10,7 @@ import { resolveCurrentSeason } from './helpers/resolveCurrentSeason.js';
 import { getAccountTimezone } from './helpers/accountTimezone.js';
 import { shapeGames } from './helpers/shapeGames.js';
 import { jsonResult } from './helpers/jsonResult.js';
+import { localDateSchema } from './helpers/dateSchema.js';
 import {
   resolveGameDateWindow,
   filterGamesByLocalDate,
@@ -18,17 +20,51 @@ import {
 const TOOL_NAME = 'get_account_games';
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
-const BACKEND_FETCH_LIMIT = 200;
+const PAGE_SIZE = 100;
+const MAX_PAGES = 20;
 
 export const getAccountGamesInputSchema = {
   account_id: z.string().min(1),
   season_id: z.string().optional(),
   range: z.enum(['today', 'tonight', 'tomorrow', 'this_week', 'this_weekend']).optional(),
-  from: z.string().optional(),
-  to: z.string().optional(),
+  from: localDateSchema.optional(),
+  to: localDateSchema.optional(),
   league_id: z.string().optional(),
   limit: z.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
 };
+
+type SeasonGame = NonNullable<Awaited<ReturnType<typeof listSeasonGames>>['data']>['games'][number];
+
+async function fetchSeasonGamesInWindow(
+  client: Client,
+  accountId: string,
+  seasonId: string,
+  startDate?: string,
+  endDate?: string,
+): Promise<{ games: SeasonGame[]; truncated: boolean }> {
+  const games: SeasonGame[] = [];
+  let page = 1;
+  let total = Number.POSITIVE_INFINITY;
+
+  while (page <= MAX_PAGES && (page - 1) * PAGE_SIZE < total) {
+    const { data } = await listSeasonGames({
+      client,
+      path: { accountId, seasonId },
+      query: { startDate, endDate, page, limit: PAGE_SIZE, sortOrder: 'asc' },
+      throwOnError: true,
+    });
+
+    games.push(...data.games);
+    total = data.pagination.total;
+
+    if (data.games.length === 0) {
+      break;
+    }
+    page += 1;
+  }
+
+  return { games, truncated: games.length < total };
+}
 
 interface GetAccountGamesArgs {
   account_id: string;
@@ -89,19 +125,28 @@ export async function getAccountGamesHandler(args: GetAccountGamesArgs): Promise
       now: new Date(),
     });
 
-    const { data } = await listSeasonGames({
+    const { games: windowGames, truncated } = await fetchSeasonGamesInWindow(
       client,
-      path: { accountId: args.account_id, seasonId },
-      query: {
-        startDate: window.startDate,
-        endDate: window.endDate,
-        limit: BACKEND_FETCH_LIMIT,
-        sortOrder: 'asc',
-      },
-      throwOnError: true,
-    });
+      args.account_id,
+      seasonId,
+      window.startDate,
+      window.endDate,
+    );
 
-    let games = filterGamesByLocalDate(data.games, timezone, window.localStart, window.localEnd);
+    if (truncated) {
+      console.warn(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          event: 'account_games_truncated',
+          tool: TOOL_NAME,
+          accountId: args.account_id,
+          fetched: windowGames.length,
+          maxPages: MAX_PAGES,
+        }),
+      );
+    }
+
+    let games = filterGamesByLocalDate(windowGames, timezone, window.localStart, window.localEnd);
 
     if (args.league_id) {
       games = games.filter((game) => game.league.id === args.league_id);
@@ -123,10 +168,15 @@ export async function getAccountGamesHandler(args: GetAccountGamesArgs): Promise
       requestId: ctx.requestId,
     });
 
+    const summary = truncated
+      ? `${buildSummary(limited.length, args)} (results may be incomplete — too many games in range; narrow the date range or league.)`
+      : buildSummary(limited.length, args);
+
     return jsonResult({
-      summary: buildSummary(limited.length, args),
+      summary,
       timezone,
       count: limited.length,
+      truncated,
       games: shaped,
     });
   } catch (err) {

--- a/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
+++ b/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+import { listSeasonGames } from '@draco/shared-api-client';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { getDracoClient } from '../sdkClient/createDracoClient.js';
+import { mapSdkError } from '../sdkClient/errorMapping.js';
+import { auditLog } from '../logging/auditLogger.js';
+import { getContext } from '../auth/perRequestContext.js';
+import { resolveCurrentSeason } from './helpers/resolveCurrentSeason.js';
+import { getAccountTimezone } from './helpers/accountTimezone.js';
+import { shapeGames } from './helpers/shapeGames.js';
+import { jsonResult } from './helpers/jsonResult.js';
+import {
+  resolveGameDateWindow,
+  filterGamesByLocalDate,
+  type GameDateRange,
+} from './helpers/resolveGameDateWindow.js';
+
+const TOOL_NAME = 'get_account_games';
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const BACKEND_FETCH_LIMIT = 200;
+
+export const getAccountGamesInputSchema = {
+  account_id: z.string().min(1),
+  season_id: z.string().optional(),
+  range: z.enum(['today', 'tonight', 'tomorrow', 'this_week', 'this_weekend']).optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  league_id: z.string().optional(),
+  limit: z.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+};
+
+interface GetAccountGamesArgs {
+  account_id: string;
+  season_id?: string;
+  range?: GameDateRange;
+  from?: string;
+  to?: string;
+  league_id?: string;
+  limit?: number;
+}
+
+function describeWindow(args: GetAccountGamesArgs): string {
+  if (args.from || args.to) {
+    if (args.from && args.to) {
+      return `between ${args.from} and ${args.to}`;
+    }
+    return args.from ? `on or after ${args.from}` : `on or before ${args.to}`;
+  }
+
+  switch (args.range ?? 'today') {
+    case 'tomorrow':
+      return 'tomorrow';
+    case 'this_week':
+      return 'this week';
+    case 'this_weekend':
+      return 'this weekend';
+    default:
+      return 'today';
+  }
+}
+
+function buildSummary(count: number, args: GetAccountGamesArgs): string {
+  const when = describeWindow(args);
+  const league = args.league_id ? ' in the selected league' : '';
+  if (count === 0) {
+    return `No games scheduled ${when}${league}.`;
+  }
+  return `${count} game${count === 1 ? '' : 's'} scheduled ${when}${league}.`;
+}
+
+export async function getAccountGamesHandler(args: GetAccountGamesArgs): Promise<CallToolResult> {
+  const ctx = getContext();
+  const start = Date.now();
+  const client = getDracoClient();
+  const limit = args.limit ?? DEFAULT_LIMIT;
+
+  try {
+    const seasonId =
+      args.season_id ?? (await resolveCurrentSeason(client, args.account_id)).seasonId;
+
+    const timezone = await getAccountTimezone(client, args.account_id);
+
+    const window = resolveGameDateWindow({
+      range: args.range,
+      from: args.from,
+      to: args.to,
+      timezone,
+      now: new Date(),
+    });
+
+    const { data } = await listSeasonGames({
+      client,
+      path: { accountId: args.account_id, seasonId },
+      query: {
+        startDate: window.startDate,
+        endDate: window.endDate,
+        limit: BACKEND_FETCH_LIMIT,
+        sortOrder: 'asc',
+      },
+      throwOnError: true,
+    });
+
+    let games = filterGamesByLocalDate(data.games, timezone, window.localStart, window.localEnd);
+
+    if (args.league_id) {
+      games = games.filter((game) => game.league.id === args.league_id);
+    }
+
+    const sorted = [...games].sort(
+      (a, b) => new Date(a.gameDate).getTime() - new Date(b.gameDate).getTime(),
+    );
+    const limited = sorted.slice(0, limit);
+    const shaped = shapeGames(limited, timezone);
+
+    auditLog({
+      tool: TOOL_NAME,
+      userId: ctx.userId,
+      accountId: args.account_id,
+      durationMs: Date.now() - start,
+      status: 'ok',
+      count: limited.length,
+      requestId: ctx.requestId,
+    });
+
+    return jsonResult({
+      summary: buildSummary(limited.length, args),
+      timezone,
+      count: limited.length,
+      games: shaped,
+    });
+  } catch (err) {
+    auditLog({
+      tool: TOOL_NAME,
+      userId: ctx.userId,
+      accountId: args.account_id,
+      durationMs: Date.now() - start,
+      status: 'error',
+      requestId: ctx.requestId,
+    });
+    mapSdkError(err, { tool: TOOL_NAME });
+  }
+}

--- a/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
+++ b/draco-nodejs/mcp-server/src/tools/getAccountGames.ts
@@ -155,6 +155,7 @@ export async function getAccountGamesHandler(args: GetAccountGamesArgs): Promise
     const sorted = [...games].sort(
       (a, b) => new Date(a.gameDate).getTime() - new Date(b.gameDate).getTime(),
     );
+    const matchedCount = sorted.length;
     const limited = sorted.slice(0, limit);
     const shaped = shapeGames(limited, timezone);
 
@@ -164,17 +165,23 @@ export async function getAccountGamesHandler(args: GetAccountGamesArgs): Promise
       accountId: args.account_id,
       durationMs: Date.now() - start,
       status: 'ok',
-      count: limited.length,
+      count: matchedCount,
       requestId: ctx.requestId,
     });
 
-    const summary = truncated
-      ? `${buildSummary(limited.length, args)} (results may be incomplete — too many games in range; narrow the date range or league.)`
-      : buildSummary(limited.length, args);
+    let summary = buildSummary(matchedCount, args);
+    if (limited.length < matchedCount) {
+      summary += ` (showing the first ${limited.length})`;
+    }
+    if (truncated) {
+      summary +=
+        ' (results may be incomplete — too many games in range; narrow the date range or league.)';
+    }
 
     return jsonResult({
       summary,
       timezone,
+      matched: matchedCount,
       count: limited.length,
       truncated,
       games: shaped,

--- a/draco-nodejs/mcp-server/src/tools/getTeamSchedule.ts
+++ b/draco-nodejs/mcp-server/src/tools/getTeamSchedule.ts
@@ -9,6 +9,7 @@ import { resolveCurrentSeason } from './helpers/resolveCurrentSeason.js';
 import { getAccountTimezone } from './helpers/accountTimezone.js';
 import { shapeGames } from './helpers/shapeGames.js';
 import { jsonResult } from './helpers/jsonResult.js';
+import { localDateBounds, filterGamesByLocalDate } from './helpers/resolveGameDateWindow.js';
 
 const TOOL_NAME = 'get_team_schedule';
 
@@ -38,19 +39,27 @@ export async function getTeamScheduleHandler(args: {
       seasonId = resolved.seasonId;
     }
 
+    const bounds = args.from || args.to ? localDateBounds(args.from, args.to) : undefined;
+
     const { data } = await listTeamSeasonSchedule({
       client,
       path: { accountId: args.account_id, seasonId, teamSeasonId: args.team_season_id },
       query: {
-        startDate: args.from,
-        endDate: args.to,
+        startDate: bounds?.startDate,
+        endDate: bounds?.endDate,
         sortOrder: 'asc',
         limit: 100,
       },
       throwOnError: true,
     });
 
-    const games = data.games;
+    const timezone = await getAccountTimezone(client, args.account_id);
+    const games = filterGamesByLocalDate(
+      data.games,
+      timezone,
+      bounds?.localStart,
+      bounds?.localEnd,
+    );
 
     if (games.length === 0) {
       auditLog({
@@ -69,7 +78,6 @@ export async function getTeamScheduleHandler(args: {
       });
     }
 
-    const timezone = await getAccountTimezone(client, args.account_id);
     const shaped = shapeGames(games, timezone);
 
     auditLog({

--- a/draco-nodejs/mcp-server/src/tools/getTeamSchedule.ts
+++ b/draco-nodejs/mcp-server/src/tools/getTeamSchedule.ts
@@ -9,6 +9,7 @@ import { resolveCurrentSeason } from './helpers/resolveCurrentSeason.js';
 import { getAccountTimezone } from './helpers/accountTimezone.js';
 import { shapeGames } from './helpers/shapeGames.js';
 import { jsonResult } from './helpers/jsonResult.js';
+import { localDateSchema } from './helpers/dateSchema.js';
 import { localDateBounds, filterGamesByLocalDate } from './helpers/resolveGameDateWindow.js';
 
 const TOOL_NAME = 'get_team_schedule';
@@ -17,8 +18,8 @@ export const getTeamScheduleInputSchema = {
   account_id: z.string().min(1),
   team_season_id: z.string().min(1),
   season_id: z.string().optional(),
-  from: z.string().optional(),
-  to: z.string().optional(),
+  from: localDateSchema.optional(),
+  to: localDateSchema.optional(),
 };
 
 export async function getTeamScheduleHandler(args: {

--- a/draco-nodejs/mcp-server/src/tools/helpers/dateSchema.ts
+++ b/draco-nodejs/mcp-server/src/tools/helpers/dateSchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const localDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+  .refine((value) => {
+    const date = new Date(`${value}T00:00:00.000Z`);
+    return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+  }, 'Date must be a valid calendar date (YYYY-MM-DD)');

--- a/draco-nodejs/mcp-server/src/tools/helpers/resolveGameDateWindow.ts
+++ b/draco-nodejs/mcp-server/src/tools/helpers/resolveGameDateWindow.ts
@@ -1,0 +1,138 @@
+export type GameDateRange = 'today' | 'tonight' | 'tomorrow' | 'this_week' | 'this_weekend';
+
+export interface ResolveGameDateWindowInput {
+  range?: GameDateRange;
+  from?: string;
+  to?: string;
+  timezone: string;
+  now: Date;
+}
+
+export interface GameDateWindow {
+  startDate?: string;
+  endDate?: string;
+  localStart?: string;
+  localEnd?: string;
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+export function localDateInTimeZone(value: Date | string, timezone: string): string {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function localWeekdayInTimeZone(date: Date, timezone: string): number {
+  const weekday = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    weekday: 'short',
+  }).format(date);
+  return WEEKDAY_INDEX[weekday] ?? 0;
+}
+
+function addDays(ymd: string, days: number): string {
+  const date = new Date(`${ymd}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function paddedStart(localStart: string): string {
+  return `${addDays(localStart, -1)}T00:00:00.000Z`;
+}
+
+function paddedEnd(localEnd: string): string {
+  return `${addDays(localEnd, 1)}T23:59:59.999Z`;
+}
+
+export function localDateBounds(from?: string, to?: string): GameDateWindow {
+  return {
+    startDate: from ? paddedStart(from) : undefined,
+    endDate: to ? paddedEnd(to) : undefined,
+    localStart: from,
+    localEnd: to,
+  };
+}
+
+function targetLocalDates(
+  range: GameDateRange,
+  today: string,
+  now: Date,
+  timezone: string,
+): string[] {
+  switch (range) {
+    case 'today':
+    case 'tonight':
+      return [today];
+    case 'tomorrow':
+      return [addDays(today, 1)];
+    case 'this_week':
+      return Array.from({ length: 7 }, (_, i) => addDays(today, i));
+    case 'this_weekend': {
+      const dow = localWeekdayInTimeZone(now, timezone);
+      if (dow === 6) {
+        return [today, addDays(today, 1)];
+      }
+      if (dow === 0) {
+        return [today];
+      }
+      const saturdayOffset = 6 - dow;
+      return [addDays(today, saturdayOffset), addDays(today, saturdayOffset + 1)];
+    }
+    default:
+      return [today];
+  }
+}
+
+export function resolveGameDateWindow(input: ResolveGameDateWindowInput): GameDateWindow {
+  const { range, from, to, timezone, now } = input;
+
+  if (from || to) {
+    return localDateBounds(from, to);
+  }
+
+  const today = localDateInTimeZone(now, timezone);
+  const localDates = targetLocalDates(range ?? 'today', today, now, timezone).sort();
+  const localStart = localDates[0];
+  const localEnd = localDates[localDates.length - 1];
+
+  return {
+    startDate: paddedStart(localStart),
+    endDate: paddedEnd(localEnd),
+    localStart,
+    localEnd,
+  };
+}
+
+export function filterGamesByLocalDate<T extends { gameDate: string }>(
+  games: T[],
+  timezone: string,
+  localStart?: string,
+  localEnd?: string,
+): T[] {
+  if (!localStart && !localEnd) {
+    return games;
+  }
+  return games.filter((game) => {
+    const localDate = localDateInTimeZone(game.gameDate, timezone);
+    if (localStart && localDate < localStart) {
+      return false;
+    }
+    if (localEnd && localDate > localEnd) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/draco-nodejs/mcp-server/src/tools/helpers/shapeGames.ts
+++ b/draco-nodejs/mcp-server/src/tools/helpers/shapeGames.ts
@@ -1,5 +1,7 @@
 import { formatGameDate } from './formatGameDate.js';
 
+const COMPLETED_GAME_STATUSES = new Set([1, 4]);
+
 type GameEntry = {
   id: string;
   gameDate: string;
@@ -7,8 +9,11 @@ type GameEntry = {
   visitorTeam: { id: string; name?: string };
   league: { id: string; name: string };
   field?: { name: string } | null;
+  gameStatus?: number;
   gameStatusText?: string;
   gameType?: number;
+  homeScore?: number;
+  visitorScore?: number;
 };
 
 export interface ShapedGame {
@@ -21,18 +26,25 @@ export interface ShapedGame {
   field_name: string | null;
   status: string | null;
   game_type: 'regular' | 'playoff' | 'exhibition';
+  home_score: number | null;
+  visitor_score: number | null;
 }
 
 export function shapeGames(games: GameEntry[], timezone: string): ShapedGame[] {
-  return games.map((g) => ({
-    game_id: g.id,
-    game_date_iso: g.gameDate,
-    game_date_local: formatGameDate(g.gameDate, timezone),
-    home_team: g.homeTeam.name ?? 'Home',
-    visitor_team: g.visitorTeam.name ?? 'Visitor',
-    league_name: g.league.name,
-    field_name: g.field?.name ?? null,
-    status: g.gameStatusText ?? null,
-    game_type: g.gameType === 1 ? 'playoff' : g.gameType === 2 ? 'exhibition' : 'regular',
-  }));
+  return games.map((g) => {
+    const completed = g.gameStatus !== undefined && COMPLETED_GAME_STATUSES.has(g.gameStatus);
+    return {
+      game_id: g.id,
+      game_date_iso: g.gameDate,
+      game_date_local: formatGameDate(g.gameDate, timezone),
+      home_team: g.homeTeam.name ?? 'Home',
+      visitor_team: g.visitorTeam.name ?? 'Visitor',
+      league_name: g.league.name,
+      field_name: g.field?.name ?? null,
+      status: g.gameStatusText ?? null,
+      game_type: g.gameType === 1 ? 'playoff' : g.gameType === 2 ? 'exhibition' : 'regular',
+      home_score: completed ? (g.homeScore ?? null) : null,
+      visitor_score: completed ? (g.visitorScore ?? null) : null,
+    };
+  });
 }

--- a/draco-nodejs/mcp-server/src/tools/index.ts
+++ b/draco-nodejs/mcp-server/src/tools/index.ts
@@ -3,6 +3,7 @@ import { listMyAccountsHandler } from './listMyAccounts.js';
 import { listMyTeamsInputSchema, listMyTeamsHandler } from './listMyTeams.js';
 import { getMyBattingStatsInputSchema, getMyBattingStatsHandler } from './getMyBattingStats.js';
 import { getMyPitchingStatsInputSchema, getMyPitchingStatsHandler } from './getMyPitchingStats.js';
+import { getAccountGamesInputSchema, getAccountGamesHandler } from './getAccountGames.js';
 import { getRecentGamesInputSchema, getRecentGamesHandler } from './getRecentGames.js';
 import { getTeamManagersInputSchema, getTeamManagersHandler } from './getTeamManagers.js';
 import { getTeamRosterInputSchema, getTeamRosterHandler } from './getTeamRoster.js';
@@ -47,6 +48,16 @@ export function registerTools(server: McpServer): void {
       inputSchema: getMyPitchingStatsInputSchema,
     },
     async (args) => getMyPitchingStatsHandler(args),
+  );
+
+  server.registerTool(
+    'get_account_games',
+    {
+      description:
+        "List games scheduled across an entire account for a season, not limited to the user's own teams. Use `range` ('today', 'tonight', 'tomorrow', 'this_week', 'this_weekend') for natural date queries — dates are evaluated in the account's timezone, so to answer \"are there any games tonight?\" pass range='today'. Provide `from`/`to` (YYYY-MM-DD) for an explicit date range instead. To restrict to a specific league (e.g. an \"18+\" league, whose age group is part of the league name), first call list_seasons to find its league_season_id and pass it as `league_id`. Division filtering is not supported. Omit season_id to use the current season.",
+      inputSchema: getAccountGamesInputSchema,
+    },
+    async (args) => getAccountGamesHandler(args),
   );
 
   server.registerTool(


### PR DESCRIPTION
## Summary

Adds an account-wide games MCP tool and fixes two gaps surfaced during real MCP-session usage of the schedule/games tools.

### 1. New tool: `get_account_games`
Lists games across an entire account/season — not just the user's own teams — so the assistant can answer "are there any games tonight?" and "any games in the 18+ league tonight?". Supports natural date ranges (`today`/`tonight`/`tomorrow`/`this_week`/`this_weekend`) evaluated in the account timezone, explicit `from`/`to`, and a `league_id` filter. Reuses the existing `listSeasonGames` endpoint — no backend or shared-schema changes.

### 2. Date filters now match on the account-local date (not UTC)
The backend filters on the stored UTC `gamedate`, so a Friday 8:15 PM ET game (UTC date = Saturday) was silently dropped by an inclusive `to=<that Friday>` bound. Both `get_team_schedule` and `get_account_games` now **pad the backend query window ±1 day and filter precisely by local date** (shared `localDateBounds` / `filterGamesByLocalDate` helpers). The late game is retained as expected.

### 3. Scores are now surfaced
`shapeGames` now emits `home_score` / `visitor_score` — numeric for completed games (Final/Forfeit) and `null` for unplayed games (so an unplayed game never looks like a misleading 0–0). Because all four games tools render through `shapeGames`, this fixes scores everywhere at once.

## Testing
- `pnpm test` (162 pass), `pnpm type-check`, `pnpm lint`, `pnpm build` — all clean in `draco-nodejs/mcp-server`.
- New behavior-proving tests: DST-boundary and UTC+14 cases for the date helper; a "Friday-night ET game survives `to`=that Friday" case in both the helper and `get_team_schedule`; completed-vs-scheduled score assertions in `get_account_games` and `get_team_schedule`.

## Notes
- Division filtering is intentionally out of scope (a game has no single division — it's per-team).
- `.secrets.baseline` updated for a detect-secrets false positive on the `JWT_SECRET: 'test-secret'` test-env mock (same fixture used across existing tool tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)