### PR TITLE
Season scheduler: round-robin matchup generation (Phase A)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts",
         "hashed_secret": "64f5667353b1de8440882280b88e4429fa061e50",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 105
       }
     ],
     "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts": [
@@ -157,42 +157,42 @@
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "64f5667353b1de8440882280b88e4429fa061e50",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "376c762c1b28f927595010e98e4ee82d6bc63de3",
         "is_verified": false,
-        "line_number": 1028
+        "line_number": 1029
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "fec13f7a36bfaae0ba315a85c7f01c2e65934c25",
         "is_verified": false,
-        "line_number": 1136
+        "line_number": 1137
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1195
+        "line_number": 1196
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "f2e1e6be297417e5f12d1d5c127632646dd186a6",
         "is_verified": false,
-        "line_number": 1269
+        "line_number": 1270
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "6a9640567ceb83c0ef56e09b9dede0d9bc22a2db",
         "is_verified": false,
-        "line_number": 1295
+        "line_number": 1296
       }
     ],
     "draco-nodejs/backend/src/__tests__/services/oauthService.test.ts": [
@@ -433,5 +433,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T03:00:03Z"
+  "generated_at": "2026-05-30T12:59:26Z"
 }

--- a/docs/season-scheduler-spec.md
+++ b/docs/season-scheduler-spec.md
@@ -195,25 +195,83 @@ Add Vitest coverage for:
 
 ---
 
-## 3. Completion Roadmap *(to be written after Phase 0)*
+## 3. Completion Roadmap
 
-Deferred until §2 is complete. Topics that need decisions before this section can be filled in:
+Decisions in §3/§4 were resolved with the maintainer on 2026-05-29. This roadmap reflects those answers. Phase 0 (§2) remains a prerequisite for shipping any of this to a pilot account; the §2.5 gate is the one outstanding Phase 0 item but does **not** block authoring or building the work below.
 
-- **Constraint coverage** — which of the following are required for real-world use, and are they hard or soft constraints? Examples: team rest days between games, home/away balance, doubleheader rules, travel distance, bye-week handling, division-vs-cross-division pairing requirements, round-robin completeness.
-- **Solver semantics** — soft-constraint scoring, tie-breaking, determinism guarantees, time budget / cancellation.
-- **Conflict diagnostics** — richer "why is this game unscheduled" output and a UI to act on it.
-- **Proposal lifecycle** — should proposals be persisted (named, comparable, re-openable) or remain in-memory only?
-- **Edit before apply** — manual override of an individual assignment in the review UI.
-- **Rollback** — an "undo apply" path on `games`.
-- **Cross-season scheduling** — playoffs or tournaments that span multiple `season` rows.
-- **Performance ceiling** — measured limits on game / field / umpire count and a plan if those are exceeded.
-- **Rollout** — staging pilot accounts, then opt-in production accounts, then general availability; what telemetry is needed to support each step.
+### 3.0 Architecture shift: Generator → Placer
+
+Today the scheduler is a **placer** only: it consumes matchups that already exist as `games` rows (`schedulerProblemSpecService` sources them via `listSeasonGames`) and assigns field/time/umpire. Completion adds a **generator** in front of it.
+
+- **Generator (new, Phase A)** — given a per-league round-robin config, produces the *set* of matchups (home/visitor pairs). It does **not** assign dates, times, fields, or umpires.
+- **Placer (exists today, upgraded in Phase B)** — the current engine; takes matchups + constraints and assigns field/time/umpire.
+
+The two stay separate components (per maintainer decision G-d). The generator's output feeds the placer. Per §2 / B.8, generated matchups are held **in memory** (not written to new DB tables) and only persisted to `games` on apply.
+
+### Phase A — Matchup Generation (independently shippable)
+
+Produces matchups; placement uses the existing "first valid slot" engine until Phase B.
+
+- **A1. Per-league round-robin config.** Each league configures how many times a team plays opponents, with **separate counts for in-division vs. out-of-division (same league)** opponents — e.g. "5 games vs each in-division team, 3 vs each other-division team." Divisions are read from `divisionseason` membership.
+- **A2. Volume modes.** Long-term, three ways to express volume (all requested in G-a): round-robin cycles, target games-per-team, target season length. **Ship round-robin cycles first**; the per-opponent counts in A1 are the cycle multipliers. Other modes are later options.
+- **A3. Home/away.** Driven by the generated counts (G-c). Even count → split home/away evenly. Odd count → alternate and balance across the season using a running per-team home/away tally so totals stay as even as possible (supports the A.2 home/away-balance goal). The odd-count tie-break must be deterministic.
+- **A4. Determinism.** Same config + same team set → same matchup set (stable/seeded ordering), consistent with the existing engine's determinism guarantees.
+- **A5. Output.** An in-memory list of unplaced matchups (home, visitor, league/division context) fed directly into the placer. No new persisted entity (B.8).
+
+### Phase B — Soft-constraint scoring (smarter placement)
+
+Today the placer takes the **first** slot that violates no hard rule. Phase B makes it pick the **best** legal slot: each soft preference contributes a penalty, and the placer chooses the lowest total penalty among valid candidates. Hard constraints are unchanged.
+
+Soft constraints:
+
+- **Team rest days (A.1, soft)** — penalty when two of a team's games fall closer together than a configurable minimum gap; larger penalty the closer they are.
+- **Home/away balance (A.2)** — penalty when an assignment worsens a team's home/away imbalance.
+- **Division / cross-division pairing (A.5, soft)** — best-effort; penalty when the generated target counts cannot be met exactly (they often can't divide evenly).
+
+**Default weights (D.11), fixed initially, configurable later:** rest-days = 3, home/away imbalance = 2, pairing shortfall = 1. Lower total score = better placement. Ties broken by the existing stable sort, preserving determinism.
+
+> Note: this changes the engine from "first valid" to "best valid among candidates," a non-trivial refactor. No solve time budget / cancellation (D.12) — the greedy approach is fast; revisit only if E.14 limits are exceeded.
+
+### Phase C — Persistence, edit, audit
+
+- **C1. Proposal persistence (B.8).** Serialize the in-memory proposal to **localStorage as JSON**, keyed by (account, season), so re-opening the widget restores the last solve. **No backend proposal table.**
+- **C2. Edit before apply (C.9).** Allow manual override of an individual assignment (field/time/umpire) in the review UI before apply. Edits update the stored proposal and are re-validated against hard constraints; a hard-constraint violation is **warned but allowed** (manual override is an intentional admin decision).
+- **C3. Apply audit log (G.19).** Record who applied which assignments and when. This is the one place a small **durable DB table is justified** despite B.8 (audit must survive; localStorage won't do): account, season, applying user, timestamp, and the applied assignments / affected game count. **Requires schema approval before building.**
+- **C4. No rollback (C.10).** No "undo apply" path on `games`.
+
+### Scale (E.14)
+
+The solver must handle realistic league sizes. Proposed ceilings to measure and add a perf test against (numbers TBD pending real data): ~50 teams, ~12 fields, ~30 umpires, a few hundred games per season. If exceeded, revisit the greedy algorithm and D.12.
+
+### Rollout (F.15)
+
+Keep behind the §2.5 gate → enable on a staging pilot account → opt-in production accounts → general availability. Minimal telemetry to gate steps: solve count, unscheduled rate, apply count, error rate. Low priority; revisit when §2.5 lands.
+
+### Sequencing
+
+Phase A → Phase B → Phase C. Phase A is shippable on its own (generate matchups, place with today's engine). Phase B upgrades placement quality. Phase C adds persistence, edit, and audit.
 
 ---
 
-## 4. Open Questions (general)
+## 4. Open Questions — Resolved (2026-05-29)
 
-- Is "umpires-per-game" intended to be a per-league setting rather than per-season? Several leagues currently mix one-umpire and two-umpire formats.
-- Should field availability rules support seasonal overrides (e.g. summer vs spring hours), or is one rule set per field sufficient?
-- The schema stores exclusion windows as full DateTime ranges — should there be a recurring-pattern variant (e.g. "every Monday 6–8pm") to avoid creating dozens of rows?
-- Apply currently writes to `games` directly. Do we need an audit log of who applied which proposal and when?
+| Question | Decision |
+| --- | --- |
+| Constraint: team rest days | **Soft** (Phase B, weight 3). |
+| Constraint: home/away balance | **Required**, soft target (Phase A3 + Phase B, weight 2). |
+| Constraint: doubleheaders | **Config option**, not hardcoded. |
+| Constraint: division/cross-division pairing | **Soft**, best-effort (often can't divide evenly). |
+| "Bye weeks" / "plays once a week" | **Not a thing** — no such concept; do not introduce it. |
+| Round-robin completeness / matchup generation | **In scope** — scheduler must generate matchups (Phase A); generator is separate from the placer. |
+| Round-robin counts | **Per-league**, separate in-division vs. out-of-division counts. |
+| Proposal lifecycle | **localStorage JSON**, keyed by (account, season). No backend proposal schema yet. |
+| Edit before apply | **Yes** — manual override, warn-but-allow on hard-constraint violations. |
+| Rollback / undo apply | **No.** |
+| Apply audit log | **Yes** — small durable DB table (needs schema approval). |
+| Travel distance | **Not relevant.** |
+| Conflict diagnostics | Current single-reason string is **sufficient for now**. |
+| Solve time budget / cancellation | **Not needed now.** |
+| Umpires-per-game per-league | **No change** — stays per-season. |
+| Field availability seasonal overrides | **No.** |
+| Recurring-pattern exclusion windows | **No.** |
+| Cross-season scheduling (playoffs/tournaments) | Still deferred — no decision requested. |

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -23886,6 +23886,73 @@
             },
             "minItems": 1
           },
+          "matchups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "leagueSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "homeTeamSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "visitorTeamSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "requiredUmpires": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "example": 1
+                },
+                "preferredFieldIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "example": "123"
+                  }
+                },
+                "earliestStart": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2024-03-01T18:30:00Z",
+                  "description": "ISO 8601 timestamp string with timezone offset."
+                },
+                "latestEnd": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2024-03-01T18:30:00Z",
+                  "description": "ISO 8601 timestamp string with timezone offset."
+                },
+                "durationMinutes": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "exclusiveMinimum": true
+                }
+              },
+              "required": [
+                "id",
+                "leagueSeasonId",
+                "homeTeamSeasonId",
+                "visitorTeamSeasonId"
+              ],
+              "title": "SchedulerGameRequest"
+            },
+            "minItems": 1,
+            "description": "Optional caller-provided matchups to place instead of DB-sourced games. When present, the backend skips loading existing games and schedules exactly these matchups (used by round-robin matchup generation). gameIds is ignored when matchups is provided."
+          },
           "umpiresPerGame": {
             "type": "integer",
             "minimum": 1,
@@ -23895,7 +23962,7 @@
           }
         },
         "title": "SchedulerSeasonSolveRequest",
-        "description": "DB-sourced solve request. The backend assembles teams/games/fields/umpires/fieldSlots from the database; the caller may provide optional constraint/objective overrides."
+        "description": "DB-sourced solve request. The backend assembles teams/games/fields/umpires/fieldSlots from the database; the caller may provide optional constraint/objective overrides, or supply explicit matchups to place."
       },
       "SchedulerSeasonApplyRequest": {
         "type": "object",
@@ -24085,6 +24152,163 @@
         ],
         "title": "SchedulerSeasonApplyRequest",
         "description": "DB-sourced apply request. Persists the proposed assignments for the season using DB-derived data plus constraint overrides."
+      },
+      "SchedulerGenerateMatchupsRequest": {
+        "type": "object",
+        "properties": {
+          "leagueCounts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "leagueSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "inDivisionGameCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 50,
+                  "example": 5,
+                  "description": "How many times each team plays every other team in its own division."
+                },
+                "crossDivisionGameCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 50,
+                  "example": 3,
+                  "description": "How many times each team plays every other team in the same league but a different division."
+                }
+              },
+              "required": [
+                "leagueSeasonId",
+                "inDivisionGameCount",
+                "crossDivisionGameCount"
+              ],
+              "title": "SchedulerLeagueRoundRobinCount"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "leagueCounts"
+        ],
+        "title": "SchedulerGenerateMatchupsRequest",
+        "description": "Round-robin matchup generation request. For each selected league, specifies the per-opponent game counts for in-division and cross-division pairings. The backend reads the league teams and divisions from the database and returns deterministic, home/away-balanced matchups without persisting them."
+      },
+      "SchedulerGenerateMatchupsResult": {
+        "type": "object",
+        "properties": {
+          "matchups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "leagueSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "homeTeamSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "visitorTeamSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "requiredUmpires": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "example": 1
+                },
+                "preferredFieldIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "example": "123"
+                  }
+                },
+                "earliestStart": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2024-03-01T18:30:00Z",
+                  "description": "ISO 8601 timestamp string with timezone offset."
+                },
+                "latestEnd": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2024-03-01T18:30:00Z",
+                  "description": "ISO 8601 timestamp string with timezone offset."
+                },
+                "durationMinutes": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "exclusiveMinimum": true
+                }
+              },
+              "required": [
+                "id",
+                "leagueSeasonId",
+                "homeTeamSeasonId",
+                "visitorTeamSeasonId"
+              ],
+              "title": "SchedulerGameRequest"
+            }
+          },
+          "summary": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "leagueSeasonId": {
+                  "type": "string",
+                  "minLength": 1,
+                  "example": "123"
+                },
+                "teamCount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "inDivisionGames": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "crossDivisionGames": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "totalGames": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "leagueSeasonId",
+                "teamCount",
+                "inDivisionGames",
+                "crossDivisionGames",
+                "totalGames"
+              ],
+              "title": "SchedulerMatchupGenerationSummary"
+            }
+          }
+        },
+        "required": [
+          "matchups",
+          "summary"
+        ],
+        "title": "SchedulerGenerateMatchupsResult",
+        "description": "Generated round-robin matchups (unplaced; no dates/fields/umpires) plus a per-league summary. Matchups are not persisted; feed them into the solve endpoint to place them."
       },
       "SchedulerSolveResult": {
         "type": "object",
@@ -69049,6 +69273,113 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/scheduler/generate-matchups": {
+      "post": {
+        "operationId": "generateSeasonMatchups",
+        "summary": "Generate round-robin matchups (unplaced)",
+        "description": "Generates deterministic, home/away-balanced round-robin matchups for the selected leagues using the provided per-league in-division and cross-division game counts. Reads teams and divisions from the database. Does not place (no dates/fields/umpires) and does not persist; feed the returned matchups into the solve endpoint to place them.",
+        "tags": [
+          "Scheduler"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchedulerGenerateMatchupsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated matchups with per-league summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulerGenerateMatchupsResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions to generate schedules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Season or league not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
                 }
               }
             }

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -17958,6 +17958,62 @@ components:
             minLength: 1
             example: "123"
           minItems: 1
+        matchups:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                minLength: 1
+                example: "123"
+              leagueSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              homeTeamSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              visitorTeamSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              requiredUmpires:
+                type: integer
+                minimum: 0
+                example: 1
+              preferredFieldIds:
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+                  example: "123"
+              earliestStart:
+                type: string
+                format: date-time
+                example: 2024-03-01T18:30:00Z
+                description: ISO 8601 timestamp string with timezone offset.
+              latestEnd:
+                type: string
+                format: date-time
+                example: 2024-03-01T18:30:00Z
+                description: ISO 8601 timestamp string with timezone offset.
+              durationMinutes:
+                type: integer
+                minimum: 0
+                exclusiveMinimum: true
+            required:
+              - id
+              - leagueSeasonId
+              - homeTeamSeasonId
+              - visitorTeamSeasonId
+            title: SchedulerGameRequest
+          minItems: 1
+          description: Optional caller-provided matchups to place instead of DB-sourced
+            games. When present, the backend skips loading existing games and
+            schedules exactly these matchups (used by round-robin matchup
+            generation). gameIds is ignored when matchups is provided.
         umpiresPerGame:
           type: integer
           minimum: 1
@@ -17969,7 +18025,8 @@ components:
       title: SchedulerSeasonSolveRequest
       description: DB-sourced solve request. The backend assembles
         teams/games/fields/umpires/fieldSlots from the database; the caller may
-        provide optional constraint/objective overrides.
+        provide optional constraint/objective overrides, or supply explicit
+        matchups to place.
     SchedulerSeasonApplyRequest:
       type: object
       properties:
@@ -18112,6 +18169,135 @@ components:
       title: SchedulerSeasonApplyRequest
       description: DB-sourced apply request. Persists the proposed assignments for the
         season using DB-derived data plus constraint overrides.
+    SchedulerGenerateMatchupsRequest:
+      type: object
+      properties:
+        leagueCounts:
+          type: array
+          items:
+            type: object
+            properties:
+              leagueSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              inDivisionGameCount:
+                type: integer
+                minimum: 0
+                maximum: 50
+                example: 5
+                description: How many times each team plays every other team in its own
+                  division.
+              crossDivisionGameCount:
+                type: integer
+                minimum: 0
+                maximum: 50
+                example: 3
+                description: How many times each team plays every other team in the same league
+                  but a different division.
+            required:
+              - leagueSeasonId
+              - inDivisionGameCount
+              - crossDivisionGameCount
+            title: SchedulerLeagueRoundRobinCount
+          minItems: 1
+      required:
+        - leagueCounts
+      title: SchedulerGenerateMatchupsRequest
+      description: Round-robin matchup generation request. For each selected league,
+        specifies the per-opponent game counts for in-division and
+        cross-division pairings. The backend reads the league teams and
+        divisions from the database and returns deterministic,
+        home/away-balanced matchups without persisting them.
+    SchedulerGenerateMatchupsResult:
+      type: object
+      properties:
+        matchups:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                minLength: 1
+                example: "123"
+              leagueSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              homeTeamSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              visitorTeamSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              requiredUmpires:
+                type: integer
+                minimum: 0
+                example: 1
+              preferredFieldIds:
+                type: array
+                items:
+                  type: string
+                  minLength: 1
+                  example: "123"
+              earliestStart:
+                type: string
+                format: date-time
+                example: 2024-03-01T18:30:00Z
+                description: ISO 8601 timestamp string with timezone offset.
+              latestEnd:
+                type: string
+                format: date-time
+                example: 2024-03-01T18:30:00Z
+                description: ISO 8601 timestamp string with timezone offset.
+              durationMinutes:
+                type: integer
+                minimum: 0
+                exclusiveMinimum: true
+            required:
+              - id
+              - leagueSeasonId
+              - homeTeamSeasonId
+              - visitorTeamSeasonId
+            title: SchedulerGameRequest
+        summary:
+          type: array
+          items:
+            type: object
+            properties:
+              leagueSeasonId:
+                type: string
+                minLength: 1
+                example: "123"
+              teamCount:
+                type: integer
+                minimum: 0
+              inDivisionGames:
+                type: integer
+                minimum: 0
+              crossDivisionGames:
+                type: integer
+                minimum: 0
+              totalGames:
+                type: integer
+                minimum: 0
+            required:
+              - leagueSeasonId
+              - teamCount
+              - inDivisionGames
+              - crossDivisionGames
+              - totalGames
+            title: SchedulerMatchupGenerationSummary
+      required:
+        - matchups
+        - summary
+      title: SchedulerGenerateMatchupsResult
+      description: Generated round-robin matchups (unplaced; no dates/fields/umpires)
+        plus a per-league summary. Matchups are not persisted; feed them into
+        the solve endpoint to place them.
     SchedulerSolveResult:
       type: object
       properties:
@@ -46864,6 +47050,75 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthorizationError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/scheduler/generate-matchups:
+    post:
+      operationId: generateSeasonMatchups
+      summary: Generate round-robin matchups (unplaced)
+      description: Generates deterministic, home/away-balanced round-robin matchups
+        for the selected leagues using the provided per-league in-division and
+        cross-division game counts. Reads teams and divisions from the database.
+        Does not place (no dates/fields/umpires) and does not persist; feed the
+        returned matchups into the solve endpoint to place them.
+      tags:
+        - Scheduler
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SchedulerGenerateMatchupsRequest"
+      responses:
+        "200":
+          description: Generated matchups with per-league summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SchedulerGenerateMatchupsResult"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Insufficient permissions to generate schedules
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Season or league not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
         "500":
           description: Internal server error
           content:

--- a/draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts
+++ b/draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts
@@ -85,6 +85,7 @@ vi.mock('../repositories/repositoryFactory.js', () => ({
     getSchedulerSeasonExclusionsRepository: vi.fn(),
     getSchedulerTeamSeasonExclusionsRepository: vi.fn(),
     getSchedulerUmpireExclusionsRepository: vi.fn(),
+    getSchedulerMatchupRepository: vi.fn(),
     getGolfCourseRepository: vi.fn(),
     getGolferRepository: vi.fn(),
     getGolfScoreRepository: vi.fn(),

--- a/draco-nodejs/backend/src/__tests__/oauth.integration.test.ts
+++ b/draco-nodejs/backend/src/__tests__/oauth.integration.test.ts
@@ -88,6 +88,7 @@ vi.mock('../repositories/repositoryFactory.js', () => ({
     getSchedulerSeasonExclusionsRepository: vi.fn(),
     getSchedulerTeamSeasonExclusionsRepository: vi.fn(),
     getSchedulerUmpireExclusionsRepository: vi.fn(),
+    getSchedulerMatchupRepository: vi.fn(),
     getGolfCourseRepository: vi.fn(),
     getGolferRepository: vi.fn(),
     getGolfScoreRepository: vi.fn(),

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -288,6 +288,8 @@ import {
   SchedulerProblemSpecPreviewSchema,
   SchedulerSeasonSolveRequestSchema,
   SchedulerSeasonApplyRequestSchema,
+  SchedulerGenerateMatchupsRequestSchema,
+  SchedulerGenerateMatchupsResultSchema,
   SchedulerSolveResultSchema,
   SchedulerApplyRequestSchema,
   SchedulerApplyResultSchema,
@@ -1292,6 +1294,14 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     'SchedulerSeasonApplyRequest',
     SchedulerSeasonApplyRequestSchema,
   );
+  const SchedulerGenerateMatchupsRequestSchemaRef = registry.register(
+    'SchedulerGenerateMatchupsRequest',
+    SchedulerGenerateMatchupsRequestSchema,
+  );
+  const SchedulerGenerateMatchupsResultSchemaRef = registry.register(
+    'SchedulerGenerateMatchupsResult',
+    SchedulerGenerateMatchupsResultSchema,
+  );
   const SchedulerSolveResultSchemaRef = registry.register(
     'SchedulerSolveResult',
     SchedulerSolveResultSchema,
@@ -1952,6 +1962,8 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     SchedulerProblemSpecPreviewSchemaRef,
     SchedulerSeasonSolveRequestSchemaRef,
     SchedulerSeasonApplyRequestSchemaRef,
+    SchedulerGenerateMatchupsRequestSchemaRef,
+    SchedulerGenerateMatchupsResultSchemaRef,
     SchedulerSolveResultSchemaRef,
     SchedulerApplyRequestSchemaRef,
     SchedulerApplyResultSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/scheduler/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/scheduler/index.ts
@@ -11,6 +11,8 @@ export const registerSchedulerEndpoints = ({ registry, schemaRefs }: RegisterCon
     SchedulerProblemSpecPreviewSchemaRef,
     SchedulerSeasonSolveRequestSchemaRef,
     SchedulerSeasonApplyRequestSchemaRef,
+    SchedulerGenerateMatchupsRequestSchemaRef,
+    SchedulerGenerateMatchupsResultSchemaRef,
     SchedulerSolveResultSchemaRef,
     SchedulerApplyRequestSchemaRef,
     SchedulerApplyResultSchemaRef,
@@ -865,6 +867,67 @@ export const registerSchedulerEndpoints = ({ registry, schemaRefs }: RegisterCon
       403: {
         description: 'Insufficient permissions',
         content: { 'application/json': { schema: AuthorizationErrorSchemaRef } },
+      },
+      500: {
+        description: 'Internal server error',
+        content: { 'application/json': { schema: InternalServerErrorSchemaRef } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/scheduler/generate-matchups',
+    operationId: 'generateSeasonMatchups',
+    summary: 'Generate round-robin matchups (unplaced)',
+    description:
+      'Generates deterministic, home/away-balanced round-robin matchups for the selected leagues using the provided per-league in-division and cross-division game counts. Reads teams and divisions from the database. Does not place (no dates/fields/umpires) and does not persist; feed the returned matchups into the solve endpoint to place them.',
+    tags: ['Scheduler'],
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+    ],
+    request: {
+      body: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: SchedulerGenerateMatchupsRequestSchemaRef,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Generated matchups with per-league summary',
+        content: { 'application/json': { schema: SchedulerGenerateMatchupsResultSchemaRef } },
+      },
+      400: {
+        description: 'Validation error',
+        content: { 'application/json': { schema: ValidationErrorSchemaRef } },
+      },
+      401: {
+        description: 'Authentication required',
+        content: { 'application/json': { schema: AuthenticationErrorSchemaRef } },
+      },
+      403: {
+        description: 'Insufficient permissions to generate schedules',
+        content: { 'application/json': { schema: AuthorizationErrorSchemaRef } },
+      },
+      404: {
+        description: 'Season or league not found',
+        content: { 'application/json': { schema: NotFoundErrorSchemaRef } },
       },
       500: {
         description: 'Internal server error',

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerMatchupRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerMatchupRepository.ts
@@ -1,0 +1,33 @@
+import type { PrismaClient } from '#prisma/client';
+import type { ISchedulerMatchupRepository } from '../interfaces/ISchedulerMatchupRepository.js';
+
+export class PrismaSchedulerMatchupRepository implements ISchedulerMatchupRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listLeagueTeamsWithDivision(
+    leagueSeasonIds: bigint[],
+  ): Promise<
+    Array<{ leagueseasonid: bigint; teamseasonid: bigint; divisionseasonid: bigint | null }>
+  > {
+    const rows = await this.prisma.teamsseason.findMany({
+      where: { leagueseasonid: { in: leagueSeasonIds } },
+      select: { id: true, leagueseasonid: true, divisionseasonid: true },
+    });
+    return rows.map((row) => ({
+      leagueseasonid: row.leagueseasonid,
+      teamseasonid: row.id,
+      divisionseasonid: row.divisionseasonid,
+    }));
+  }
+
+  async listLeagueSeasonIdsBySeasonAndAccount(
+    seasonId: bigint,
+    accountId: bigint,
+  ): Promise<bigint[]> {
+    const rows = await this.prisma.leagueseason.findMany({
+      where: { seasonid: seasonId, league: { accountid: accountId } },
+      select: { id: true },
+    });
+    return rows.map((row) => row.id);
+  }
+}

--- a/draco-nodejs/backend/src/repositories/implementations/index.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/index.ts
@@ -69,3 +69,4 @@ export * from './PrismaLiveScoringRepository.js';
 export * from './PrismaIndividualLiveScoringRepository.js';
 export * from './PrismaBaseballLiveScoringRepository.js';
 export * from './PrismaOauthRepository.js';
+export * from './PrismaSchedulerMatchupRepository.js';

--- a/draco-nodejs/backend/src/repositories/interfaces/ISchedulerMatchupRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/ISchedulerMatchupRepository.ts
@@ -1,0 +1,9 @@
+export interface ISchedulerMatchupRepository {
+  listLeagueTeamsWithDivision(
+    leagueSeasonIds: bigint[],
+  ): Promise<
+    Array<{ leagueseasonid: bigint; teamseasonid: bigint; divisionseasonid: bigint | null }>
+  >;
+
+  listLeagueSeasonIdsBySeasonAndAccount(seasonId: bigint, accountId: bigint): Promise<bigint[]>;
+}

--- a/draco-nodejs/backend/src/repositories/interfaces/index.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/index.ts
@@ -70,3 +70,4 @@ export * from './ILiveScoringRepository.js';
 export * from './IIndividualLiveScoringRepository.js';
 export * from './IBaseballLiveScoringRepository.js';
 export * from './IOauthRepository.js';
+export * from './ISchedulerMatchupRepository.js';

--- a/draco-nodejs/backend/src/repositories/repositoryFactory.ts
+++ b/draco-nodejs/backend/src/repositories/repositoryFactory.ts
@@ -52,6 +52,7 @@ import {
   IInstagramIngestionRepository,
   ISchedulerFieldAvailabilityRulesRepository,
   ISchedulerFieldExclusionDatesRepository,
+  ISchedulerMatchupRepository,
   ISchedulerProblemSpecRepository,
   ISchedulerSeasonConfigRepository,
   ISchedulerSeasonLeagueSelectionsRepository,
@@ -125,6 +126,7 @@ import {
   PrismaInstagramIngestionRepository,
   PrismaSchedulerFieldAvailabilityRulesRepository,
   PrismaSchedulerFieldExclusionDatesRepository,
+  PrismaSchedulerMatchupRepository,
   PrismaSchedulerProblemSpecRepository,
   PrismaSchedulerSeasonConfigRepository,
   PrismaSchedulerSeasonLeagueSelectionsRepository,
@@ -205,6 +207,7 @@ export class RepositoryFactory {
   private static instagramIngestionRepository: IInstagramIngestionRepository;
   private static schedulerFieldAvailabilityRulesRepository: ISchedulerFieldAvailabilityRulesRepository;
   private static schedulerFieldExclusionDatesRepository: ISchedulerFieldExclusionDatesRepository;
+  private static schedulerMatchupRepository: ISchedulerMatchupRepository;
   private static schedulerProblemSpecRepository: ISchedulerProblemSpecRepository;
   private static schedulerSeasonConfigRepository: ISchedulerSeasonConfigRepository;
   private static schedulerSeasonLeagueSelectionsRepository: ISchedulerSeasonLeagueSelectionsRepository;
@@ -493,6 +496,13 @@ export class RepositoryFactory {
         new PrismaSchedulerFieldExclusionDatesRepository(prisma);
     }
     return this.schedulerFieldExclusionDatesRepository;
+  }
+
+  static getSchedulerMatchupRepository(): ISchedulerMatchupRepository {
+    if (!this.schedulerMatchupRepository) {
+      this.schedulerMatchupRepository = new PrismaSchedulerMatchupRepository(prisma);
+    }
+    return this.schedulerMatchupRepository;
   }
 
   static getSchedulerProblemSpecRepository(): ISchedulerProblemSpecRepository {

--- a/draco-nodejs/backend/src/routes/season-scheduler-field-availability.ts
+++ b/draco-nodejs/backend/src/routes/season-scheduler-field-availability.ts
@@ -12,6 +12,7 @@ import {
   SchedulerUmpireExclusionUpsertSchema,
   SchedulerSeasonSolveRequestSchema,
   SchedulerSeasonApplyRequestSchema,
+  SchedulerGenerateMatchupsRequestSchema,
 } from '@draco/shared-schemas';
 
 const router = Router({ mergeParams: true });
@@ -27,6 +28,7 @@ const schedulerUmpireExclusionsService = ServiceFactory.getSchedulerUmpireExclus
 const schedulerProblemSpecService = ServiceFactory.getSchedulerProblemSpecService();
 const schedulerEngineService = ServiceFactory.getSchedulerEngineService();
 const schedulerSeasonApplyService = ServiceFactory.getSchedulerSeasonApplyService();
+const schedulerMatchupGenerationService = ServiceFactory.getSchedulerMatchupGenerationService();
 
 router.get(
   '/season-window-config',
@@ -358,6 +360,23 @@ router.post(
       accountId,
       seasonId,
       request,
+    );
+    res.json(result);
+  }),
+);
+
+router.post(
+  '/generate-matchups',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('account.games.manage'),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId } = extractBigIntParams(req.params, 'accountId', 'seasonId');
+    const body = SchedulerGenerateMatchupsRequestSchema.parse(req.body);
+    const result = await schedulerMatchupGenerationService.generateForSeason(
+      accountId,
+      seasonId,
+      body,
     );
     res.json(result);
   }),

--- a/draco-nodejs/backend/src/services/__tests__/schedulerEngineService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerEngineService.test.ts
@@ -924,4 +924,218 @@ describe('SchedulerEngineService', () => {
       expect(unscheduled.reason).toBeTruthy();
     }
   });
+
+  it('treats team blackouts as a hard constraint and schedules once the blackout is lifted', () => {
+    const service = new SchedulerEngineService();
+
+    const blackedOutSpec: SchedulerProblemSpec = {
+      season: {
+        id: 'spring-2026',
+        name: 'Spring 2026',
+        startDate: '2026-04-01',
+        endDate: '2026-08-31',
+        gameDurations: { defaultMinutes: 60 },
+      },
+      teams: [
+        { id: 'team-1', teamSeasonId: 'teamSeason-1', league: { id: 'league-1', name: 'Open' } },
+        { id: 'team-2', teamSeasonId: 'teamSeason-2', league: { id: 'league-1', name: 'Open' } },
+      ],
+      fields: [{ id: 'field-1', name: 'Field 1' }],
+      umpires: [],
+      games: [
+        {
+          id: 'game-1',
+          leagueSeasonId: 'leagueSeason-1',
+          homeTeamSeasonId: 'teamSeason-1',
+          visitorTeamSeasonId: 'teamSeason-2',
+          earliestStart: '2026-04-05T09:00:00Z',
+          latestEnd: '2026-04-05T14:00:00Z',
+          requiredUmpires: 0,
+        },
+      ],
+      fieldSlots: [
+        {
+          id: 'slot-1',
+          fieldId: 'field-1',
+          startTime: '2026-04-05T09:00:00Z',
+          endTime: '2026-04-05T10:30:00Z',
+        },
+      ],
+      teamBlackouts: [
+        {
+          teamSeasonId: 'teamSeason-1',
+          startTime: '2026-04-05T08:00:00Z',
+          endTime: '2026-04-05T12:00:00Z',
+        },
+      ],
+      constraints: { hard: { respectFieldSlots: true, respectTeamBlackouts: true } },
+    };
+
+    const blocked = service.solve(blackedOutSpec);
+    expect(blocked.status).toBe('infeasible');
+    expect(blocked.unscheduled).toHaveLength(1);
+    expect(blocked.unscheduled[0]?.gameId).toBe('game-1');
+
+    const cleared = service.solve({ ...blackedOutSpec, teamBlackouts: [] });
+    expect(cleared.status).toBe('completed');
+    expect(cleared.assignments).toHaveLength(1);
+    expect(cleared.assignments[0]?.fieldId).toBe('field-1');
+  });
+
+  it('ignores team blackouts when respectTeamBlackouts is disabled', () => {
+    const service = new SchedulerEngineService();
+
+    const spec: SchedulerProblemSpec = {
+      season: {
+        id: 'spring-2026',
+        name: 'Spring 2026',
+        startDate: '2026-04-01',
+        endDate: '2026-08-31',
+        gameDurations: { defaultMinutes: 60 },
+      },
+      teams: [
+        { id: 'team-1', teamSeasonId: 'teamSeason-1', league: { id: 'league-1', name: 'Open' } },
+        { id: 'team-2', teamSeasonId: 'teamSeason-2', league: { id: 'league-1', name: 'Open' } },
+      ],
+      fields: [{ id: 'field-1', name: 'Field 1' }],
+      umpires: [],
+      games: [
+        {
+          id: 'game-1',
+          leagueSeasonId: 'leagueSeason-1',
+          homeTeamSeasonId: 'teamSeason-1',
+          visitorTeamSeasonId: 'teamSeason-2',
+          earliestStart: '2026-04-05T09:00:00Z',
+          latestEnd: '2026-04-05T14:00:00Z',
+          requiredUmpires: 0,
+        },
+      ],
+      fieldSlots: [
+        {
+          id: 'slot-1',
+          fieldId: 'field-1',
+          startTime: '2026-04-05T09:00:00Z',
+          endTime: '2026-04-05T10:30:00Z',
+        },
+      ],
+      teamBlackouts: [
+        {
+          teamSeasonId: 'teamSeason-1',
+          startTime: '2026-04-05T08:00:00Z',
+          endTime: '2026-04-05T12:00:00Z',
+        },
+      ],
+      constraints: { hard: { respectFieldSlots: true, respectTeamBlackouts: false } },
+    };
+
+    const result = service.solve(spec);
+    expect(result.status).toBe('completed');
+    expect(result.assignments).toHaveLength(1);
+  });
+
+  it('leaves a game unscheduled when no umpire is available during its window and schedules it once availability covers the slot', () => {
+    const service = new SchedulerEngineService();
+
+    const spec: SchedulerProblemSpec = {
+      season: {
+        id: 'spring-2026',
+        name: 'Spring 2026',
+        startDate: '2026-04-01',
+        endDate: '2026-08-31',
+        gameDurations: { defaultMinutes: 60 },
+      },
+      teams: [
+        { id: 'team-1', teamSeasonId: 'teamSeason-1', league: { id: 'league-1', name: 'Open' } },
+        { id: 'team-2', teamSeasonId: 'teamSeason-2', league: { id: 'league-1', name: 'Open' } },
+      ],
+      fields: [{ id: 'field-1', name: 'Field 1' }],
+      umpires: [{ id: 'ump-1', name: 'Alice' }],
+      games: [
+        {
+          id: 'game-1',
+          leagueSeasonId: 'leagueSeason-1',
+          homeTeamSeasonId: 'teamSeason-1',
+          visitorTeamSeasonId: 'teamSeason-2',
+          earliestStart: '2026-04-05T09:00:00Z',
+          latestEnd: '2026-04-05T14:00:00Z',
+          requiredUmpires: 1,
+        },
+      ],
+      fieldSlots: [
+        {
+          id: 'slot-1',
+          fieldId: 'field-1',
+          startTime: '2026-04-05T09:00:00Z',
+          endTime: '2026-04-05T10:30:00Z',
+        },
+      ],
+      umpireAvailability: [
+        { umpireId: 'ump-1', startTime: '2026-04-05T12:00:00Z', endTime: '2026-04-05T18:00:00Z' },
+      ],
+      constraints: { hard: { respectFieldSlots: true, respectUmpireAvailability: true } },
+    };
+
+    const unavailable = service.solve(spec);
+    expect(unavailable.status).toBe('infeasible');
+    expect(unavailable.unscheduled).toHaveLength(1);
+    expect(unavailable.unscheduled[0]?.gameId).toBe('game-1');
+
+    const covering = service.solve({
+      ...spec,
+      umpireAvailability: [
+        { umpireId: 'ump-1', startTime: '2026-04-05T08:00:00Z', endTime: '2026-04-05T18:00:00Z' },
+      ],
+    });
+    expect(covering.status).toBe('completed');
+    expect(covering.assignments).toHaveLength(1);
+    expect(covering.assignments[0]?.umpireIds).toEqual(['ump-1']);
+  });
+
+  it('assigns an umpire outside their availability window when respectUmpireAvailability is disabled', () => {
+    const service = new SchedulerEngineService();
+
+    const spec: SchedulerProblemSpec = {
+      season: {
+        id: 'spring-2026',
+        name: 'Spring 2026',
+        startDate: '2026-04-01',
+        endDate: '2026-08-31',
+        gameDurations: { defaultMinutes: 60 },
+      },
+      teams: [
+        { id: 'team-1', teamSeasonId: 'teamSeason-1', league: { id: 'league-1', name: 'Open' } },
+        { id: 'team-2', teamSeasonId: 'teamSeason-2', league: { id: 'league-1', name: 'Open' } },
+      ],
+      fields: [{ id: 'field-1', name: 'Field 1' }],
+      umpires: [{ id: 'ump-1', name: 'Alice' }],
+      games: [
+        {
+          id: 'game-1',
+          leagueSeasonId: 'leagueSeason-1',
+          homeTeamSeasonId: 'teamSeason-1',
+          visitorTeamSeasonId: 'teamSeason-2',
+          earliestStart: '2026-04-05T09:00:00Z',
+          latestEnd: '2026-04-05T14:00:00Z',
+          requiredUmpires: 1,
+        },
+      ],
+      fieldSlots: [
+        {
+          id: 'slot-1',
+          fieldId: 'field-1',
+          startTime: '2026-04-05T09:00:00Z',
+          endTime: '2026-04-05T10:30:00Z',
+        },
+      ],
+      umpireAvailability: [
+        { umpireId: 'ump-1', startTime: '2026-04-05T12:00:00Z', endTime: '2026-04-05T18:00:00Z' },
+      ],
+      constraints: { hard: { respectFieldSlots: true, respectUmpireAvailability: false } },
+    };
+
+    const result = service.solve(spec);
+    expect(result.status).toBe('completed');
+    expect(result.assignments).toHaveLength(1);
+    expect(result.assignments[0]?.umpireIds).toEqual(['ump-1']);
+  });
 });

--- a/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 import { SchedulerMatchupGenerationService } from '../schedulerMatchupGenerationService.js';
 import type { ISchedulerMatchupRepository } from '../../repositories/interfaces/ISchedulerMatchupRepository.js';
 import { NotFoundError, ValidationError } from '../../utils/customErrors.js';
@@ -7,6 +7,7 @@ import type {
   SchedulerGenerateMatchupsResult,
 } from '@draco/shared-schemas';
 import type { SchedulerMatchupGeneratorService } from '../schedulerMatchupGeneratorService.js';
+import { partialMock } from '../../test-utils/partialMock.js';
 
 class MatchupRepositoryStub implements ISchedulerMatchupRepository {
   listLeagueTeamsWithDivision = vi.fn<ISchedulerMatchupRepository['listLeagueTeamsWithDivision']>();
@@ -16,8 +17,8 @@ class MatchupRepositoryStub implements ISchedulerMatchupRepository {
 
 const makeGeneratorStub = (
   result: SchedulerGenerateMatchupsResult,
-): SchedulerMatchupGeneratorService =>
-  ({ generate: vi.fn().mockReturnValue(result) }) as unknown as SchedulerMatchupGeneratorService;
+): Mocked<SchedulerMatchupGeneratorService> =>
+  partialMock<SchedulerMatchupGeneratorService>({ generate: vi.fn().mockReturnValue(result) });
 
 const ACCOUNT_ID = BigInt(1);
 const SEASON_ID = BigInt(100);

--- a/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SchedulerMatchupGenerationService } from '../schedulerMatchupGenerationService.js';
+import type { ISchedulerMatchupRepository } from '../../repositories/interfaces/ISchedulerMatchupRepository.js';
+import { NotFoundError, ValidationError } from '../../utils/customErrors.js';
+import type {
+  SchedulerGenerateMatchupsRequest,
+  SchedulerGenerateMatchupsResult,
+} from '@draco/shared-schemas';
+import type { SchedulerMatchupGeneratorService } from '../schedulerMatchupGeneratorService.js';
+
+class MatchupRepositoryStub implements ISchedulerMatchupRepository {
+  listLeagueTeamsWithDivision = vi.fn<ISchedulerMatchupRepository['listLeagueTeamsWithDivision']>();
+  listLeagueSeasonIdsBySeasonAndAccount =
+    vi.fn<ISchedulerMatchupRepository['listLeagueSeasonIdsBySeasonAndAccount']>();
+}
+
+const makeGeneratorStub = (
+  result: SchedulerGenerateMatchupsResult,
+): SchedulerMatchupGeneratorService =>
+  ({ generate: vi.fn().mockReturnValue(result) }) as unknown as SchedulerMatchupGeneratorService;
+
+const ACCOUNT_ID = BigInt(1);
+const SEASON_ID = BigInt(100);
+const LEAGUE_SEASON_ID = '500';
+
+const makeRequest = (leagueSeasonId = LEAGUE_SEASON_ID): SchedulerGenerateMatchupsRequest => ({
+  leagueCounts: [
+    { leagueSeasonId: leagueSeasonId, inDivisionGameCount: 2, crossDivisionGameCount: 1 },
+  ],
+});
+
+const makeEmptyResult = (): SchedulerGenerateMatchupsResult => ({
+  matchups: [],
+  summary: [],
+});
+
+describe('SchedulerMatchupGenerationService', () => {
+  let repo: MatchupRepositoryStub;
+  let service: SchedulerMatchupGenerationService;
+
+  beforeEach(() => {
+    repo = new MatchupRepositoryStub();
+
+    repo.listLeagueSeasonIdsBySeasonAndAccount.mockResolvedValue([BigInt(LEAGUE_SEASON_ID)]);
+    repo.listLeagueTeamsWithDivision.mockResolvedValue([
+      { leagueseasonid: BigInt(LEAGUE_SEASON_ID), teamseasonid: BigInt(1), divisionseasonid: null },
+      { leagueseasonid: BigInt(LEAGUE_SEASON_ID), teamseasonid: BigInt(2), divisionseasonid: null },
+    ]);
+
+    service = new SchedulerMatchupGenerationService(repo, makeGeneratorStub(makeEmptyResult()));
+  });
+
+  it('returns the generator result on a valid request', async () => {
+    const result = await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+    expect(result).toEqual(makeEmptyResult());
+  });
+
+  it('calls listLeagueSeasonIdsBySeasonAndAccount with the correct seasonId and accountId', async () => {
+    await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+    expect(repo.listLeagueSeasonIdsBySeasonAndAccount).toHaveBeenCalledWith(SEASON_ID, ACCOUNT_ID);
+  });
+
+  it('calls listLeagueTeamsWithDivision with bigint ids from the request', async () => {
+    await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+    expect(repo.listLeagueTeamsWithDivision).toHaveBeenCalledWith([BigInt(LEAGUE_SEASON_ID)]);
+  });
+
+  it('passes correct GeneratorLeagueInput to the generator', async () => {
+    const generatorStub = makeGeneratorStub(makeEmptyResult());
+    service = new SchedulerMatchupGenerationService(repo, generatorStub);
+
+    await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+
+    expect(generatorStub.generate).toHaveBeenCalledWith([
+      {
+        leagueSeasonId: LEAGUE_SEASON_ID,
+        teams: [
+          { teamSeasonId: '1', divisionSeasonId: null },
+          { teamSeasonId: '2', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 2,
+        crossDivisionGameCount: 1,
+      },
+    ]);
+  });
+
+  it('throws NotFoundError when a requested leagueSeasonId does not belong to the account/season', async () => {
+    repo.listLeagueSeasonIdsBySeasonAndAccount.mockResolvedValue([BigInt(999)]);
+
+    await expect(
+      service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest(LEAGUE_SEASON_ID)),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('throws NotFoundError with the offending id in the message', async () => {
+    repo.listLeagueSeasonIdsBySeasonAndAccount.mockResolvedValue([]);
+
+    await expect(
+      service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest(LEAGUE_SEASON_ID)),
+    ).rejects.toThrow(LEAGUE_SEASON_ID);
+  });
+
+  it('throws ValidationError when a valid league has no teams', async () => {
+    repo.listLeagueTeamsWithDivision.mockResolvedValue([]);
+
+    await expect(service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest())).rejects.toThrow(
+      ValidationError,
+    );
+  });
+
+  it('converts divisionseasonid bigint to string in generator input', async () => {
+    repo.listLeagueTeamsWithDivision.mockResolvedValue([
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(10),
+        divisionseasonid: BigInt(77),
+      },
+    ]);
+    const generatorStub = makeGeneratorStub(makeEmptyResult());
+    service = new SchedulerMatchupGenerationService(repo, generatorStub);
+
+    await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+
+    expect(generatorStub.generate).toHaveBeenCalledWith([
+      expect.objectContaining({
+        teams: [{ teamSeasonId: '10', divisionSeasonId: '77' }],
+      }),
+    ]);
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGeneratorService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGeneratorService.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SchedulerMatchupGeneratorService,
+  type GeneratorLeagueInput,
+} from '../schedulerMatchupGeneratorService.js';
+
+const makeLeague = (overrides: Partial<GeneratorLeagueInput> = {}): GeneratorLeagueInput => ({
+  leagueSeasonId: 'ls-1',
+  teams: [],
+  inDivisionGameCount: 1,
+  crossDivisionGameCount: 1,
+  ...overrides,
+});
+
+describe('SchedulerMatchupGeneratorService', () => {
+  const service = new SchedulerMatchupGeneratorService();
+
+  describe('single division (all divisionSeasonId: null)', () => {
+    it('4 teams, inDivisionGameCount=2, cross=0 → 12 games with perfect home/away balance', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-1',
+        teams: [
+          { teamSeasonId: 'T1', divisionSeasonId: null },
+          { teamSeasonId: 'T2', divisionSeasonId: null },
+          { teamSeasonId: 'T3', divisionSeasonId: null },
+          { teamSeasonId: 'T4', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 2,
+        crossDivisionGameCount: 0,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.matchups).toHaveLength(12);
+      expect(result.summary).toHaveLength(1);
+      expect(result.summary[0].inDivisionGames).toBe(12);
+      expect(result.summary[0].crossDivisionGames).toBe(0);
+      expect(result.summary[0].totalGames).toBe(12);
+      expect(result.summary[0].teamCount).toBe(4);
+
+      const pairCounts = new Map<string, number>();
+      for (const m of result.matchups) {
+        const key = [m.homeTeamSeasonId, m.visitorTeamSeasonId].sort().join('|');
+        pairCounts.set(key, (pairCounts.get(key) ?? 0) + 1);
+      }
+
+      const expectedPairs = ['T1|T2', 'T1|T3', 'T1|T4', 'T2|T3', 'T2|T4', 'T3|T4'];
+      expect(pairCounts.size).toBe(6);
+      for (const pair of expectedPairs) {
+        expect(pairCounts.get(pair)).toBe(2);
+      }
+
+      const homeCount = new Map<string, number>();
+      const awayCount = new Map<string, number>();
+      for (const m of result.matchups) {
+        homeCount.set(m.homeTeamSeasonId, (homeCount.get(m.homeTeamSeasonId) ?? 0) + 1);
+        awayCount.set(m.visitorTeamSeasonId, (awayCount.get(m.visitorTeamSeasonId) ?? 0) + 1);
+      }
+
+      for (const teamId of ['T1', 'T2', 'T3', 'T4']) {
+        expect(homeCount.get(teamId)).toBe(awayCount.get(teamId));
+      }
+    });
+
+    it('C(n,2) games produced, crossDivisionGames === 0', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-nodiv',
+        teams: [
+          { teamSeasonId: 'A', divisionSeasonId: null },
+          { teamSeasonId: 'B', divisionSeasonId: null },
+          { teamSeasonId: 'C', divisionSeasonId: null },
+          { teamSeasonId: 'D', divisionSeasonId: null },
+          { teamSeasonId: 'E', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 1,
+        crossDivisionGameCount: 0,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.matchups).toHaveLength(10);
+      expect(result.summary[0].crossDivisionGames).toBe(0);
+      expect(result.summary[0].inDivisionGames).toBe(10);
+    });
+  });
+
+  describe('two divisions', () => {
+    it('2 divisions × 2 teams, inDivision=2, cross=1 → inDivision=4, cross=4, total=8', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-2div',
+        teams: [
+          { teamSeasonId: 'D1T1', divisionSeasonId: 'div-1' },
+          { teamSeasonId: 'D1T2', divisionSeasonId: 'div-1' },
+          { teamSeasonId: 'D2T1', divisionSeasonId: 'div-2' },
+          { teamSeasonId: 'D2T2', divisionSeasonId: 'div-2' },
+        ],
+        inDivisionGameCount: 2,
+        crossDivisionGameCount: 1,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.summary).toHaveLength(1);
+      const summary = result.summary[0];
+      expect(summary.inDivisionGames).toBe(4);
+      expect(summary.crossDivisionGames).toBe(4);
+      expect(summary.totalGames).toBe(8);
+      expect(summary.teamCount).toBe(4);
+      expect(result.matchups).toHaveLength(8);
+    });
+
+    it('inDivisionGameCount=0, cross=2 → only cross-division games produced', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-crossonly',
+        teams: [
+          { teamSeasonId: 'X1', divisionSeasonId: 'div-A' },
+          { teamSeasonId: 'X2', divisionSeasonId: 'div-A' },
+          { teamSeasonId: 'Y1', divisionSeasonId: 'div-B' },
+          { teamSeasonId: 'Y2', divisionSeasonId: 'div-B' },
+        ],
+        inDivisionGameCount: 0,
+        crossDivisionGameCount: 2,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.summary[0].inDivisionGames).toBe(0);
+      expect(result.summary[0].crossDivisionGames).toBe(8);
+      expect(result.summary[0].totalGames).toBe(8);
+
+      for (const m of result.matchups) {
+        const homeDivision = league.teams.find(
+          (t) => t.teamSeasonId === m.homeTeamSeasonId,
+        )!.divisionSeasonId;
+        const visitorDivision = league.teams.find(
+          (t) => t.teamSeasonId === m.visitorTeamSeasonId,
+        )!.divisionSeasonId;
+        expect(homeDivision).not.toBe(visitorDivision);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('league with 1 team → 0 games, totalGames === 0', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-one',
+        teams: [{ teamSeasonId: 'Solo', divisionSeasonId: null }],
+        inDivisionGameCount: 3,
+        crossDivisionGameCount: 2,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.matchups).toHaveLength(0);
+      expect(result.summary[0].totalGames).toBe(0);
+    });
+
+    it('league with 0 teams → 0 games, totalGames === 0', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-empty',
+        teams: [],
+        inDivisionGameCount: 2,
+        crossDivisionGameCount: 1,
+      });
+
+      const result = service.generate([league]);
+
+      expect(result.matchups).toHaveLength(0);
+      expect(result.summary[0].totalGames).toBe(0);
+      expect(result.summary[0].teamCount).toBe(0);
+    });
+
+    it('every matchup has homeTeamSeasonId !== visitorTeamSeasonId', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-noself',
+        teams: [
+          { teamSeasonId: 'P', divisionSeasonId: 'div-1' },
+          { teamSeasonId: 'Q', divisionSeasonId: 'div-1' },
+          { teamSeasonId: 'R', divisionSeasonId: 'div-2' },
+          { teamSeasonId: 'S', divisionSeasonId: 'div-2' },
+        ],
+        inDivisionGameCount: 3,
+        crossDivisionGameCount: 2,
+      });
+
+      const result = service.generate([league]);
+
+      for (const m of result.matchups) {
+        expect(m.homeTeamSeasonId).not.toBe(m.visitorTeamSeasonId);
+      }
+    });
+  });
+
+  describe('determinism', () => {
+    it('calling generate twice with identical input produces deep-equal results', () => {
+      const leagues: GeneratorLeagueInput[] = [
+        makeLeague({
+          leagueSeasonId: 'ls-det',
+          teams: [
+            { teamSeasonId: 'Z1', divisionSeasonId: 'div-1' },
+            { teamSeasonId: 'Z2', divisionSeasonId: 'div-1' },
+            { teamSeasonId: 'Z3', divisionSeasonId: 'div-2' },
+            { teamSeasonId: 'Z4', divisionSeasonId: 'div-2' },
+          ],
+          inDivisionGameCount: 2,
+          crossDivisionGameCount: 1,
+        }),
+      ];
+
+      const result1 = service.generate(leagues);
+      const result2 = service.generate(leagues);
+
+      expect(result1).toEqual(result2);
+
+      for (let i = 0; i < result1.matchups.length; i++) {
+        expect(result1.matchups[i].id).toBe(result2.matchups[i].id);
+        expect(result1.matchups[i].homeTeamSeasonId).toBe(result2.matchups[i].homeTeamSeasonId);
+        expect(result1.matchups[i].visitorTeamSeasonId).toBe(
+          result2.matchups[i].visitorTeamSeasonId,
+        );
+      }
+    });
+  });
+
+  describe('multiple leagues', () => {
+    it('matchups partitioned correctly by leagueSeasonId; summary has one entry per league', () => {
+      const leagueA = makeLeague({
+        leagueSeasonId: 'ls-A',
+        teams: [
+          { teamSeasonId: 'A1', divisionSeasonId: null },
+          { teamSeasonId: 'A2', divisionSeasonId: null },
+          { teamSeasonId: 'A3', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 1,
+        crossDivisionGameCount: 0,
+      });
+
+      const leagueB = makeLeague({
+        leagueSeasonId: 'ls-B',
+        teams: [
+          { teamSeasonId: 'B1', divisionSeasonId: null },
+          { teamSeasonId: 'B2', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 2,
+        crossDivisionGameCount: 0,
+      });
+
+      const result = service.generate([leagueA, leagueB]);
+
+      expect(result.summary).toHaveLength(2);
+      expect(result.summary[0].leagueSeasonId).toBe('ls-A');
+      expect(result.summary[1].leagueSeasonId).toBe('ls-B');
+
+      const leagueAMatchups = result.matchups.filter((m) => m.leagueSeasonId === 'ls-A');
+      const leagueBMatchups = result.matchups.filter((m) => m.leagueSeasonId === 'ls-B');
+
+      expect(leagueAMatchups).toHaveLength(3);
+      expect(leagueBMatchups).toHaveLength(2);
+
+      expect(result.summary[0].totalGames).toBe(3);
+      expect(result.summary[1].totalGames).toBe(2);
+
+      for (const m of leagueAMatchups) {
+        expect(['A1', 'A2', 'A3']).toContain(m.homeTeamSeasonId);
+        expect(['A1', 'A2', 'A3']).toContain(m.visitorTeamSeasonId);
+      }
+
+      for (const m of leagueBMatchups) {
+        expect(['B1', 'B2']).toContain(m.homeTeamSeasonId);
+        expect(['B1', 'B2']).toContain(m.visitorTeamSeasonId);
+      }
+    });
+  });
+});

--- a/draco-nodejs/backend/src/services/schedulerMatchupGenerationService.ts
+++ b/draco-nodejs/backend/src/services/schedulerMatchupGenerationService.ts
@@ -1,0 +1,83 @@
+import type {
+  SchedulerGenerateMatchupsRequest,
+  SchedulerGenerateMatchupsResult,
+} from '@draco/shared-schemas';
+import { RepositoryFactory } from '../repositories/repositoryFactory.js';
+import { ServiceFactory } from './serviceFactory.js';
+import type { ISchedulerMatchupRepository } from '../repositories/interfaces/ISchedulerMatchupRepository.js';
+import { NotFoundError, ValidationError } from '../utils/customErrors.js';
+import type {
+  GeneratorLeagueInput,
+  SchedulerMatchupGeneratorService,
+} from './schedulerMatchupGeneratorService.js';
+
+export class SchedulerMatchupGenerationService {
+  private readonly matchupRepository: ISchedulerMatchupRepository;
+  private readonly injectedGeneratorService: SchedulerMatchupGeneratorService | undefined;
+
+  constructor(
+    matchupRepository?: ISchedulerMatchupRepository,
+    generatorService?: SchedulerMatchupGeneratorService,
+  ) {
+    this.matchupRepository = matchupRepository ?? RepositoryFactory.getSchedulerMatchupRepository();
+    this.injectedGeneratorService = generatorService;
+  }
+
+  private get generatorService(): SchedulerMatchupGeneratorService {
+    return this.injectedGeneratorService ?? ServiceFactory.getSchedulerMatchupGeneratorService();
+  }
+
+  async generateForSeason(
+    accountId: bigint,
+    seasonId: bigint,
+    request: SchedulerGenerateMatchupsRequest,
+  ): Promise<SchedulerGenerateMatchupsResult> {
+    const validLeagueSeasonIds = await this.matchupRepository.listLeagueSeasonIdsBySeasonAndAccount(
+      seasonId,
+      accountId,
+    );
+    const validIdSet = new Set(validLeagueSeasonIds.map((id) => id.toString()));
+
+    const requestedIds = request.leagueCounts.map((lc) => lc.leagueSeasonId);
+    const unknownIds = requestedIds.filter((id) => !validIdSet.has(id));
+    if (unknownIds.length > 0) {
+      throw new NotFoundError(
+        `League season(s) not found for this account/season: ${unknownIds.join(', ')}`,
+      );
+    }
+
+    const requestedBigIntIds = requestedIds.map((id) => BigInt(id));
+    const teamRows = await this.matchupRepository.listLeagueTeamsWithDivision(requestedBigIntIds);
+
+    const teamsByLeague = new Map<
+      string,
+      Array<{ teamSeasonId: string; divisionSeasonId: string | null }>
+    >();
+    for (const row of teamRows) {
+      const key = row.leagueseasonid.toString();
+      const list = teamsByLeague.get(key) ?? [];
+      list.push({
+        teamSeasonId: row.teamseasonid.toString(),
+        divisionSeasonId: row.divisionseasonid?.toString() ?? null,
+      });
+      teamsByLeague.set(key, list);
+    }
+
+    const generatorInputs: GeneratorLeagueInput[] = request.leagueCounts.map((lc) => {
+      const teams = teamsByLeague.get(lc.leagueSeasonId) ?? [];
+      if (teams.length === 0) {
+        throw new ValidationError(
+          `League season ${lc.leagueSeasonId} has no teams enrolled for this season`,
+        );
+      }
+      return {
+        leagueSeasonId: lc.leagueSeasonId,
+        teams,
+        inDivisionGameCount: lc.inDivisionGameCount,
+        crossDivisionGameCount: lc.crossDivisionGameCount,
+      };
+    });
+
+    return this.generatorService.generate(generatorInputs);
+  }
+}

--- a/draco-nodejs/backend/src/services/schedulerMatchupGeneratorService.ts
+++ b/draco-nodejs/backend/src/services/schedulerMatchupGeneratorService.ts
@@ -1,0 +1,135 @@
+import type {
+  SchedulerGameRequest,
+  SchedulerGenerateMatchupsResult,
+  SchedulerMatchupGenerationSummary,
+} from '@draco/shared-schemas';
+
+export interface GeneratorTeamInput {
+  teamSeasonId: string;
+  divisionSeasonId: string | null;
+}
+
+export interface GeneratorLeagueInput {
+  leagueSeasonId: string;
+  teams: GeneratorTeamInput[];
+  inDivisionGameCount: number;
+  crossDivisionGameCount: number;
+}
+
+export class SchedulerMatchupGeneratorService {
+  generate(leagues: GeneratorLeagueInput[]): SchedulerGenerateMatchupsResult {
+    const allMatchups: SchedulerGameRequest[] = [];
+    const summaries: SchedulerMatchupGenerationSummary[] = [];
+
+    for (const league of leagues) {
+      const { matchups, summary } = this.generateLeagueMatchups(league);
+      allMatchups.push(...matchups);
+      summaries.push(summary);
+    }
+
+    return { matchups: allMatchups, summary: summaries };
+  }
+
+  private generateLeagueMatchups(league: GeneratorLeagueInput): {
+    matchups: SchedulerGameRequest[];
+    summary: SchedulerMatchupGenerationSummary;
+  } {
+    const { leagueSeasonId, teams, inDivisionGameCount, crossDivisionGameCount } = league;
+
+    const sortedTeams = [...teams].sort((a, b) => a.teamSeasonId.localeCompare(b.teamSeasonId));
+
+    const divisionGroups = new Map<string, GeneratorTeamInput[]>();
+    for (const team of sortedTeams) {
+      const key = team.divisionSeasonId ?? '__null__';
+      const existing = divisionGroups.get(key);
+      if (existing) {
+        existing.push(team);
+      } else {
+        divisionGroups.set(key, [team]);
+      }
+    }
+
+    const sortedKeys = [...divisionGroups.keys()].sort();
+
+    const matchups: SchedulerGameRequest[] = [];
+    const homeGameTally = new Map<string, number>();
+
+    for (const team of sortedTeams) {
+      homeGameTally.set(team.teamSeasonId, 0);
+    }
+
+    let inDivisionGames = 0;
+    let crossDivisionGames = 0;
+
+    const allTeamsSorted = sortedKeys.flatMap((key) => divisionGroups.get(key)!);
+
+    const maxGameCount = Math.max(inDivisionGameCount, crossDivisionGameCount);
+
+    for (let k = 0; k < maxGameCount; k++) {
+      for (let i = 0; i < allTeamsSorted.length; i++) {
+        for (let j = i + 1; j < allTeamsSorted.length; j++) {
+          const teamA = allTeamsSorted[i];
+          const teamB = allTeamsSorted[j];
+
+          const sameGroup =
+            (teamA.divisionSeasonId ?? '__null__') === (teamB.divisionSeasonId ?? '__null__');
+          const gameCount = sameGroup ? inDivisionGameCount : crossDivisionGameCount;
+
+          if (k >= gameCount) {
+            continue;
+          }
+
+          const minId =
+            teamA.teamSeasonId < teamB.teamSeasonId ? teamA.teamSeasonId : teamB.teamSeasonId;
+          const maxId =
+            teamA.teamSeasonId < teamB.teamSeasonId ? teamB.teamSeasonId : teamA.teamSeasonId;
+
+          const id = `gen-${leagueSeasonId}-${minId}-${maxId}-${k}`;
+
+          const tallyA = homeGameTally.get(teamA.teamSeasonId) ?? 0;
+          const tallyB = homeGameTally.get(teamB.teamSeasonId) ?? 0;
+
+          let homeTeamSeasonId: string;
+          let visitorTeamSeasonId: string;
+
+          if (tallyA < tallyB) {
+            homeTeamSeasonId = teamA.teamSeasonId;
+            visitorTeamSeasonId = teamB.teamSeasonId;
+          } else if (tallyB < tallyA) {
+            homeTeamSeasonId = teamB.teamSeasonId;
+            visitorTeamSeasonId = teamA.teamSeasonId;
+          } else {
+            if (teamA.teamSeasonId < teamB.teamSeasonId) {
+              homeTeamSeasonId = teamA.teamSeasonId;
+              visitorTeamSeasonId = teamB.teamSeasonId;
+            } else {
+              homeTeamSeasonId = teamB.teamSeasonId;
+              visitorTeamSeasonId = teamA.teamSeasonId;
+            }
+          }
+
+          homeGameTally.set(homeTeamSeasonId, (homeGameTally.get(homeTeamSeasonId) ?? 0) + 1);
+
+          matchups.push({ id, leagueSeasonId, homeTeamSeasonId, visitorTeamSeasonId });
+
+          if (sameGroup) {
+            inDivisionGames++;
+          } else {
+            crossDivisionGames++;
+          }
+        }
+      }
+    }
+
+    return {
+      matchups,
+      summary: {
+        leagueSeasonId,
+        teamCount: sortedTeams.length,
+        inDivisionGames,
+        crossDivisionGames,
+        totalGames: inDivisionGames + crossDivisionGames,
+      },
+    };
+  }
+}

--- a/draco-nodejs/backend/src/services/schedulerProblemSpecService.ts
+++ b/draco-nodejs/backend/src/services/schedulerProblemSpecService.ts
@@ -116,13 +116,17 @@ export class SchedulerProblemSpecService {
     request: SchedulerSeasonSolveRequest,
   ): Promise<{ problemSpec: SchedulerProblemSpec; timeZoneId: string }> {
     const base = await this.loadBaseSpecData(accountId, seasonId);
-    const filteredGames = request.gameIds?.length
-      ? base.games.filter((game) => request.gameIds?.includes(game.id))
-      : base.games;
+
+    const sourceGames: SchedulerGameRequest[] =
+      request.matchups && request.matchups.length > 0
+        ? request.matchups
+        : request.gameIds?.length
+          ? base.games.filter((game) => request.gameIds?.includes(game.id))
+          : base.games;
 
     const requiredUmpiresOverride =
       request.umpiresPerGame ?? base.seasonWindowConfig.umpiresPerGame ?? 2;
-    const normalizedGames = filteredGames.map((game) => ({
+    const normalizedGames = sourceGames.map((game) => ({
       ...game,
       requiredUmpires: requiredUmpiresOverride,
     }));

--- a/draco-nodejs/backend/src/services/serviceFactory.ts
+++ b/draco-nodejs/backend/src/services/serviceFactory.ts
@@ -48,6 +48,8 @@ import { SchedulerSeasonWindowConfigService } from './schedulerSeasonWindowConfi
 import { SchedulerSeasonExclusionsService } from './schedulerSeasonExclusionsService.js';
 import { SchedulerTeamSeasonExclusionsService } from './schedulerTeamSeasonExclusionsService.js';
 import { SchedulerUmpireExclusionsService } from './schedulerUmpireExclusionsService.js';
+import { SchedulerMatchupGenerationService } from './schedulerMatchupGenerationService.js';
+import { SchedulerMatchupGeneratorService } from './schedulerMatchupGeneratorService.js';
 import { LeagueService } from './LeagueService.js';
 import { LeagueFaqService } from './LeagueFaqService.js';
 import { MonitoringService } from './monitoringService.js';
@@ -162,6 +164,8 @@ export class ServiceFactory {
   private static schedulerSeasonExclusionsService: SchedulerSeasonExclusionsService;
   private static schedulerTeamSeasonExclusionsService: SchedulerTeamSeasonExclusionsService;
   private static schedulerUmpireExclusionsService: SchedulerUmpireExclusionsService;
+  private static schedulerMatchupGenerationService: SchedulerMatchupGenerationService;
+  private static schedulerMatchupGeneratorService: SchedulerMatchupGeneratorService;
   private static leagueService: LeagueService;
   private static leagueFaqService: LeagueFaqService;
   private static monitoringService: MonitoringService;
@@ -552,6 +556,22 @@ export class ServiceFactory {
     }
 
     return this.schedulerUmpireExclusionsService;
+  }
+
+  static getSchedulerMatchupGeneratorService(): SchedulerMatchupGeneratorService {
+    if (!this.schedulerMatchupGeneratorService) {
+      this.schedulerMatchupGeneratorService = new SchedulerMatchupGeneratorService();
+    }
+
+    return this.schedulerMatchupGeneratorService;
+  }
+
+  static getSchedulerMatchupGenerationService(): SchedulerMatchupGenerationService {
+    if (!this.schedulerMatchupGenerationService) {
+      this.schedulerMatchupGenerationService = new SchedulerMatchupGenerationService();
+    }
+
+    return this.schedulerMatchupGenerationService;
   }
 
   static getMonitoringService(): MonitoringService {

--- a/draco-nodejs/frontend-next/components/scheduler/SchedulerRoundRobinConfig.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SchedulerRoundRobinConfig.tsx
@@ -83,9 +83,7 @@ export const SchedulerRoundRobinConfig: React.FC<SchedulerRoundRobinConfigProps>
     };
     const next = new Map(counts);
     next.set(leagueSeasonId, { ...existing, [field]: value });
-    if (seasonId) {
-      saveRoundRobinCounts(accountId, seasonId, next);
-    }
+    saveRoundRobinCounts(accountId, seasonId, next);
     onCountsChange(next);
   };
 

--- a/draco-nodejs/frontend-next/components/scheduler/SchedulerRoundRobinConfig.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SchedulerRoundRobinConfig.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+import { Box, Divider, TextField, Typography } from '@mui/material';
+
+export interface LeagueRoundRobinCount {
+  leagueSeasonId: string;
+  inDivisionGameCount: number;
+  crossDivisionGameCount: number;
+}
+
+interface EntityOption {
+  id: string;
+  name: string;
+}
+
+interface SchedulerRoundRobinConfigProps {
+  accountId: string;
+  seasonId: string | null;
+  selectedLeagueSeasonIds: string[];
+  leagues: EntityOption[];
+  leagueNameById: Map<string, string>;
+  counts: Map<string, LeagueRoundRobinCount>;
+  onCountsChange: (counts: Map<string, LeagueRoundRobinCount>) => void;
+}
+
+const buildStorageKey = (accountId: string, seasonId: string) =>
+  `scheduler:rrCounts:${accountId}:${seasonId}`;
+
+export const loadRoundRobinCounts = (
+  accountId: string,
+  seasonId: string,
+): Map<string, LeagueRoundRobinCount> => {
+  if (typeof window === 'undefined') return new Map();
+  try {
+    const raw = window.localStorage.getItem(buildStorageKey(accountId, seasonId));
+    if (!raw) return new Map();
+    const parsed = JSON.parse(raw) as LeagueRoundRobinCount[];
+    return new Map(parsed.map((entry) => [entry.leagueSeasonId, entry]));
+  } catch {
+    return new Map();
+  }
+};
+
+const saveRoundRobinCounts = (
+  accountId: string,
+  seasonId: string,
+  counts: Map<string, LeagueRoundRobinCount>,
+): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      buildStorageKey(accountId, seasonId),
+      JSON.stringify(Array.from(counts.values())),
+    );
+  } catch {}
+};
+
+export const SchedulerRoundRobinConfig: React.FC<SchedulerRoundRobinConfigProps> = ({
+  accountId,
+  seasonId,
+  selectedLeagueSeasonIds,
+  leagues,
+  leagueNameById,
+  counts,
+  onCountsChange,
+}) => {
+  if (!seasonId || selectedLeagueSeasonIds.length === 0 || leagues.length === 0) {
+    return null;
+  }
+
+  const handleChange = (
+    leagueSeasonId: string,
+    field: 'inDivisionGameCount' | 'crossDivisionGameCount',
+    rawValue: string,
+  ) => {
+    const parsed = parseInt(rawValue, 10);
+    const value = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    const existing = counts.get(leagueSeasonId) ?? {
+      leagueSeasonId,
+      inDivisionGameCount: 0,
+      crossDivisionGameCount: 0,
+    };
+    const next = new Map(counts);
+    next.set(leagueSeasonId, { ...existing, [field]: value });
+    if (seasonId) {
+      saveRoundRobinCounts(accountId, seasonId, next);
+    }
+    onCountsChange(next);
+  };
+
+  return (
+    <>
+      <Divider sx={{ my: 2 }} />
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box>
+          <Typography variant="subtitle2">Round-Robin Game Counts</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Per-league game counts for generating matchups. In-division and cross-division counts
+            are applied per opponent pair.
+          </Typography>
+        </Box>
+
+        {selectedLeagueSeasonIds.map((id) => {
+          const leagueName = leagueNameById.get(id) ?? `League ${id}`;
+          const entry = counts.get(id) ?? {
+            leagueSeasonId: id,
+            inDivisionGameCount: 0,
+            crossDivisionGameCount: 0,
+          };
+
+          return (
+            <Box key={id} sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="body2" color="text.primary">
+                {leagueName}
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+                <TextField
+                  label="In-division games"
+                  type="number"
+                  size="small"
+                  value={entry.inDivisionGameCount}
+                  onChange={(event) => handleChange(id, 'inDivisionGameCount', event.target.value)}
+                  inputProps={{ min: 0, step: 1 }}
+                  sx={{ width: 180 }}
+                />
+                <TextField
+                  label="Cross-division games"
+                  type="number"
+                  size="small"
+                  value={entry.crossDivisionGameCount}
+                  onChange={(event) =>
+                    handleChange(id, 'crossDivisionGameCount', event.target.value)
+                  }
+                  inputProps={{ min: 0, step: 1 }}
+                  sx={{ width: 200 }}
+                />
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </>
+  );
+};

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerConfigPanel.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerConfigPanel.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import type { SchedulerSeasonWindowConfig } from '@draco/shared-schemas';
+import { SchedulerRoundRobinConfig, type LeagueRoundRobinCount } from './SchedulerRoundRobinConfig';
 
 type UmpiresPerGame = 1 | 2 | 3 | 4;
 
@@ -23,6 +24,7 @@ interface EntityOption {
 }
 
 interface SeasonSchedulerConfigPanelProps {
+  accountId: string;
   seasonId: string | null;
   seasonWindowConfig: SchedulerSeasonWindowConfig | null;
   seasonStartDate: string;
@@ -35,15 +37,18 @@ interface SeasonSchedulerConfigPanelProps {
   leagueSeasonIdFilter: string | undefined;
   leagueSeasonSelection: string[] | null;
   leagueNameById: Map<string, string>;
+  roundRobinCounts: Map<string, LeagueRoundRobinCount>;
   onSeasonStartDateChange: (value: string) => void;
   onSeasonEndDateChange: (value: string) => void;
   onUmpiresPerGameChange: (value: UmpiresPerGame) => void;
   onMaxGamesPerUmpirePerDayChange: (value: string) => void;
   onLeagueSelectionChange: (ids: string[]) => void;
+  onRoundRobinCountsChange: (counts: Map<string, LeagueRoundRobinCount>) => void;
   onSave: () => void;
 }
 
 export const SeasonSchedulerConfigPanel: React.FC<SeasonSchedulerConfigPanelProps> = ({
+  accountId,
   seasonId,
   seasonWindowConfig,
   seasonStartDate,
@@ -56,11 +61,13 @@ export const SeasonSchedulerConfigPanel: React.FC<SeasonSchedulerConfigPanelProp
   leagueSeasonIdFilter,
   leagueSeasonSelection,
   leagueNameById,
+  roundRobinCounts,
   onSeasonStartDateChange,
   onSeasonEndDateChange,
   onUmpiresPerGameChange,
   onMaxGamesPerUmpirePerDayChange,
   onLeagueSelectionChange,
+  onRoundRobinCountsChange,
   onSave,
 }) => {
   const allLeagueSeasonIds = leagues.map((league) => league.id);
@@ -237,6 +244,16 @@ export const SeasonSchedulerConfigPanel: React.FC<SeasonSchedulerConfigPanelProp
           />
         </Box>
       </Box>
+
+      <SchedulerRoundRobinConfig
+        accountId={accountId}
+        seasonId={seasonId}
+        selectedLeagueSeasonIds={selectedLeagueSeasonIds}
+        leagues={leagues}
+        leagueNameById={leagueNameById}
+        counts={roundRobinCounts}
+        onCountsChange={onRoundRobinCountsChange}
+      />
     </>
   );
 };

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerConstraintLists.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerConstraintLists.tsx
@@ -279,7 +279,7 @@ export const SeasonSchedulerConstraintLists: React.FC<SeasonSchedulerConstraintL
       {seasonId && (
         <>
           <SchedulerFieldAvailabilityRuleDialog
-            key={ruleDialog.dialogKey}
+            key={`field-availability-${ruleDialog.dialogKey}`}
             open={ruleDialog.open}
             mode={ruleDialog.mode}
             seasonId={seasonId}
@@ -290,7 +290,7 @@ export const SeasonSchedulerConstraintLists: React.FC<SeasonSchedulerConstraintL
             loading={loading}
           />
           <SchedulerFieldExclusionDateDialog
-            key={exclusionDialog.dialogKey}
+            key={`field-exclusion-${exclusionDialog.dialogKey}`}
             open={exclusionDialog.open}
             mode={exclusionDialog.mode}
             seasonId={seasonId}
@@ -301,7 +301,7 @@ export const SeasonSchedulerConstraintLists: React.FC<SeasonSchedulerConstraintL
             loading={loading}
           />
           <SchedulerSeasonExclusionDialog
-            key={seasonExclusionDialog.dialogKey}
+            key={`season-exclusion-${seasonExclusionDialog.dialogKey}`}
             open={seasonExclusionDialog.open}
             mode={seasonExclusionDialog.mode}
             seasonId={seasonId}
@@ -311,7 +311,7 @@ export const SeasonSchedulerConstraintLists: React.FC<SeasonSchedulerConstraintL
             loading={loading}
           />
           <SchedulerTeamExclusionDialog
-            key={teamExclusionDialog.dialogKey}
+            key={`team-exclusion-${teamExclusionDialog.dialogKey}`}
             open={teamExclusionDialog.open}
             mode={teamExclusionDialog.mode}
             seasonId={seasonId}
@@ -322,7 +322,7 @@ export const SeasonSchedulerConstraintLists: React.FC<SeasonSchedulerConstraintL
             loading={loading}
           />
           <SchedulerUmpireExclusionDialog
-            key={umpireExclusionDialog.dialogKey}
+            key={`umpire-exclusion-${umpireExclusionDialog.dialogKey}`}
             open={umpireExclusionDialog.open}
             mode={umpireExclusionDialog.mode}
             seasonId={seasonId}

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
@@ -27,6 +27,7 @@ interface SeasonSchedulerProposalReviewProps {
   teamNameById: Map<string, string>;
   umpireNameById: Map<string, string>;
   leagueNameById: Map<string, string>;
+  proposalFromGenerated: boolean;
   getGameSummaryLabel: (gameId: string) => string;
   onToggleSelection: (gameId: string) => void;
   onToggleAll: () => void;
@@ -87,6 +88,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   teamNameById,
   umpireNameById,
   leagueNameById,
+  proposalFromGenerated,
   getGameSummaryLabel,
   onToggleSelection,
   onToggleAll,
@@ -173,13 +175,27 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
                     }
                     label={`Select (${selectedGameIds.size}/${proposal.assignments.length})`}
                   />
-                  <Button
-                    variant="contained"
-                    onClick={onApply}
-                    disabled={selectedGameIds.size === 0}
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-end',
+                      gap: 0.5,
+                    }}
                   >
-                    Apply {selectedMode === 'all' ? 'All' : 'Selected'}
-                  </Button>
+                    <Button
+                      variant="contained"
+                      onClick={onApply}
+                      disabled={selectedGameIds.size === 0 || proposalFromGenerated}
+                    >
+                      Apply {selectedMode === 'all' ? 'All' : 'Selected'}
+                    </Button>
+                    {proposalFromGenerated && (
+                      <Typography variant="caption" color="text.secondary">
+                        Applying generated schedules is coming soon.
+                      </Typography>
+                    )}
+                  </Box>
                 </Box>
 
                 <Stack spacing={1}>

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
@@ -11,7 +11,11 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import type { SchedulerProblemSpecPreview, SchedulerSolveResult } from '@draco/shared-schemas';
+import type {
+  SchedulerGameRequest,
+  SchedulerProblemSpecPreview,
+  SchedulerSolveResult,
+} from '@draco/shared-schemas';
 import { formatDateInTimezone, getDateKeyInTimezone } from '../../utils/dateUtils';
 import { ProposalAssignmentRow } from './ProposalAssignmentRow';
 import { SchedulerSpecPreviewDialog } from './SchedulerSpecPreviewDialog';
@@ -28,6 +32,7 @@ interface SeasonSchedulerProposalReviewProps {
   umpireNameById: Map<string, string>;
   leagueNameById: Map<string, string>;
   proposalFromGenerated: boolean;
+  generatedMatchups: SchedulerGameRequest[] | null;
   getGameSummaryLabel: (gameId: string) => string;
   onToggleSelection: (gameId: string) => void;
   onToggleAll: () => void;
@@ -89,6 +94,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   umpireNameById,
   leagueNameById,
   proposalFromGenerated,
+  generatedMatchups,
   getGameSummaryLabel,
   onToggleSelection,
   onToggleAll,
@@ -115,7 +121,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   );
 
   const gameRequestById = new Map<string, SchedulerProblemSpecPreview['games'][number]>(
-    (specPreview?.games ?? []).map((game) => [game.id, game]),
+    [...(specPreview?.games ?? []), ...(generatedMatchups ?? [])].map((game) => [game.id, game]),
   );
 
   const selectedMode = !proposal || selectedGameIds.size === assignments.length ? 'all' : 'subset';

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -156,6 +156,11 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     };
   }, [canEdit, seasonId, setError]);
 
+  useEffect(() => {
+    if (!seasonId) return;
+    setRoundRobinCounts(loadRoundRobinCounts(accountId, seasonId));
+  }, [accountId, seasonId]);
+
   const handleSaveSeasonWindow = async () => {
     if (!seasonId) return;
 

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Alert, Box, Button, Divider, Typography } from '@mui/material';
 import WidgetShell from '../ui/WidgetShell';
 import type {
+  SchedulerGenerateMatchupsRequest,
   SchedulerProblemSpecPreview,
   SchedulerSeasonApplyRequest,
   SchedulerSeasonSolveRequest,
@@ -17,6 +18,7 @@ import { useEntityNameMaps } from '../../hooks/useEntityNameMaps';
 import { SeasonSchedulerConfigPanel } from './SeasonSchedulerConfigPanel';
 import { SeasonSchedulerConstraintLists } from './SeasonSchedulerConstraintLists';
 import { SeasonSchedulerProposalReview } from './SeasonSchedulerProposalReview';
+import { loadRoundRobinCounts, type LeagueRoundRobinCount } from './SchedulerRoundRobinConfig';
 
 type FieldOption = { id: string; name: string };
 type EntityOption = { id: string; name: string };
@@ -66,6 +68,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     getSeasonWindowConfig,
     upsertSeasonWindowConfig,
     getProblemSpecPreview,
+    generateMatchups,
     solveSeason,
     applySeason,
     loading,
@@ -90,11 +93,15 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   const [seasonEndDate, setSeasonEndDate] = useState('');
   const [leagueSeasonSelection, setLeagueSeasonSelection] = useState<string[] | null>(null);
   const [proposal, setProposal] = useState<SchedulerSolveResult | null>(null);
+  const [proposalFromGenerated, setProposalFromGenerated] = useState(false);
   const [selectedGameIds, setSelectedGameIds] = useState<Set<string>>(new Set());
   const [specPreview, setSpecPreview] = useState<SchedulerProblemSpecPreview | null>(null);
   const [specPreviewOpen, setSpecPreviewOpen] = useState(false);
   const [umpiresPerGame, setUmpiresPerGame] = useState<UmpiresPerGame>(2);
   const [maxGamesPerUmpirePerDayInput, setMaxGamesPerUmpirePerDayInput] = useState('');
+  const [roundRobinCounts, setRoundRobinCounts] = useState<Map<string, LeagueRoundRobinCount>>(
+    () => (seasonId ? loadRoundRobinCounts(accountId, seasonId) : new Map()),
+  );
 
   const { fieldNameById, teamNameById, umpireNameById } = useEntityNameMaps({
     fields,
@@ -220,6 +227,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       setError(null);
       clearError();
       setProposal(null);
+      setProposalFromGenerated(false);
       if (!seasonWindowConfig)
         throw new Error('Season dates are required before generating a proposal');
       if (leagues.length > 0 && selectedLeagueSeasonIds.length === 0)
@@ -266,6 +274,74 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       );
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate proposal');
+    }
+  };
+
+  const handleGenerateMatchups = async () => {
+    try {
+      setError(null);
+      clearError();
+      setProposal(null);
+      setProposalFromGenerated(false);
+
+      if (!seasonWindowConfig)
+        throw new Error('Season dates are required before generating matchups');
+      if (leagues.length > 0 && selectedLeagueSeasonIds.length === 0)
+        throw new Error('Select at least one league to schedule');
+
+      const leagueCounts = selectedLeagueSeasonIds
+        .map((id) => {
+          const entry = roundRobinCounts.get(id);
+          return {
+            leagueSeasonId: id,
+            inDivisionGameCount: entry?.inDivisionGameCount ?? 0,
+            crossDivisionGameCount: entry?.crossDivisionGameCount ?? 0,
+          };
+        })
+        .filter((entry) => entry.inDivisionGameCount > 0 || entry.crossDivisionGameCount > 0);
+
+      if (leagueCounts.length === 0) {
+        setError(
+          'Enter at least one game count (in-division or cross-division) for a selected league before generating matchups.',
+        );
+        return;
+      }
+
+      const generateRequest: SchedulerGenerateMatchupsRequest = { leagueCounts };
+      const { matchups } = await generateMatchups(generateRequest);
+
+      if (matchups.length === 0) {
+        setError('No matchups were generated. Check that your leagues have teams and divisions.');
+        return;
+      }
+
+      const trimmedMaxGames = maxGamesPerUmpirePerDayInput.trim();
+      const maxGamesPerUmpirePerDay =
+        trimmedMaxGames.length > 0 ? Number(trimmedMaxGames) : undefined;
+      if (maxGamesPerUmpirePerDay !== undefined) {
+        if (!Number.isFinite(maxGamesPerUmpirePerDay) || maxGamesPerUmpirePerDay <= 0)
+          throw new Error('Max games/day for umpires must be a positive number');
+      }
+
+      const solveRequest: SchedulerSeasonSolveRequest = {
+        matchups,
+        objectives: { primary: 'maximize_scheduled_games' },
+        umpiresPerGame,
+        constraints:
+          maxGamesPerUmpirePerDay !== undefined
+            ? { hard: { maxGamesPerUmpirePerDay: Math.floor(maxGamesPerUmpirePerDay) } }
+            : undefined,
+      };
+
+      const result = await solveSeason(solveRequest);
+      setProposal(result);
+      setProposalFromGenerated(true);
+      setSelectedGameIds(new Set(result.assignments.map((a) => a.gameId)));
+      setSuccess(
+        `Generated matchups placed (${result.metrics.scheduledGames}/${result.metrics.totalGames} scheduled)`,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate matchups');
     }
   };
 
@@ -352,6 +428,17 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
             Preview Problem Spec
           </Button>
           <Button
+            variant="outlined"
+            onClick={handleGenerateMatchups}
+            disabled={
+              !seasonId ||
+              !seasonWindowConfig ||
+              (leagues.length > 0 && selectedLeagueSeasonIds.length === 0)
+            }
+          >
+            Generate Matchups
+          </Button>
+          <Button
             variant="contained"
             onClick={handleSolve}
             disabled={
@@ -374,6 +461,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       <Divider sx={{ my: 2 }} />
 
       <SeasonSchedulerConfigPanel
+        accountId={accountId}
         seasonId={seasonId}
         seasonWindowConfig={seasonWindowConfig}
         seasonStartDate={seasonStartDate}
@@ -386,11 +474,13 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         leagueSeasonIdFilter={leagueSeasonIdFilter}
         leagueSeasonSelection={leagueSeasonSelection}
         leagueNameById={leagueNameById}
+        roundRobinCounts={roundRobinCounts}
         onSeasonStartDateChange={setSeasonStartDate}
         onSeasonEndDateChange={setSeasonEndDate}
         onUmpiresPerGameChange={setUmpiresPerGame}
         onMaxGamesPerUmpirePerDayChange={setMaxGamesPerUmpirePerDayInput}
         onLeagueSelectionChange={setLeagueSeasonSelection}
+        onRoundRobinCountsChange={setRoundRobinCounts}
         onSave={() => {
           handleSaveSeasonWindow()
             .then(() => setSuccess('Scheduler settings saved'))
@@ -447,6 +537,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         teamNameById={teamNameById}
         umpireNameById={umpireNameById}
         leagueNameById={leagueNameById}
+        proposalFromGenerated={proposalFromGenerated}
         getGameSummaryLabel={getGameSummaryLabel}
         onToggleSelection={handleToggleSelection}
         onToggleAll={handleToggleAll}

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Alert, Box, Button, Divider, Typography } from '@mui/material';
 import WidgetShell from '../ui/WidgetShell';
 import type {
+  SchedulerGameRequest,
   SchedulerGenerateMatchupsRequest,
   SchedulerProblemSpecPreview,
   SchedulerSeasonApplyRequest,
@@ -94,6 +95,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   const [leagueSeasonSelection, setLeagueSeasonSelection] = useState<string[] | null>(null);
   const [proposal, setProposal] = useState<SchedulerSolveResult | null>(null);
   const [proposalFromGenerated, setProposalFromGenerated] = useState(false);
+  const [generatedMatchups, setGeneratedMatchups] = useState<SchedulerGameRequest[] | null>(null);
   const [selectedGameIds, setSelectedGameIds] = useState<Set<string>>(new Set());
   const [specPreview, setSpecPreview] = useState<SchedulerProblemSpecPreview | null>(null);
   const [specPreviewOpen, setSpecPreviewOpen] = useState(false);
@@ -233,6 +235,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       clearError();
       setProposal(null);
       setProposalFromGenerated(false);
+      setGeneratedMatchups(null);
       if (!seasonWindowConfig)
         throw new Error('Season dates are required before generating a proposal');
       if (leagues.length > 0 && selectedLeagueSeasonIds.length === 0)
@@ -288,6 +291,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       clearError();
       setProposal(null);
       setProposalFromGenerated(false);
+      setGeneratedMatchups(null);
 
       if (!seasonWindowConfig)
         throw new Error('Season dates are required before generating matchups');
@@ -341,6 +345,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       const result = await solveSeason(solveRequest);
       setProposal(result);
       setProposalFromGenerated(true);
+      setGeneratedMatchups(matchups);
       setSelectedGameIds(new Set(result.assignments.map((a) => a.gameId)));
       setSuccess(
         `Generated matchups placed (${result.metrics.scheduledGames}/${result.metrics.totalGames} scheduled)`,
@@ -543,6 +548,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         umpireNameById={umpireNameById}
         leagueNameById={leagueNameById}
         proposalFromGenerated={proposalFromGenerated}
+        generatedMatchups={generatedMatchups}
         getGameSummaryLabel={getGameSummaryLabel}
         onToggleSelection={handleToggleSelection}
         onToggleAll={handleToggleAll}

--- a/draco-nodejs/frontend-next/constants/featureFlags.ts
+++ b/draco-nodejs/frontend-next/constants/featureFlags.ts
@@ -1,2 +1,2 @@
 export const SHOW_AI_INTEGRATIONS = true;
-export const SHOW_SEASON_SCHEDULER = false;
+export const SHOW_SEASON_SCHEDULER = process.env.SHOW_SEASON_SCHEDULER === 'true';

--- a/draco-nodejs/frontend-next/hooks/useSeasonSchedulerOperations.ts
+++ b/draco-nodejs/frontend-next/hooks/useSeasonSchedulerOperations.ts
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import type {
   SchedulerFieldAvailabilityRuleUpsert,
   SchedulerFieldExclusionDateUpsert,
+  SchedulerGenerateMatchupsRequest,
   SchedulerSeasonApplyRequest,
   SchedulerSeasonExclusionUpsert,
   SchedulerSeasonSolveRequest,
@@ -148,6 +149,9 @@ export const useSeasonSchedulerOperations = (accountId: string, seasonId: string
       ),
       deleteUmpireExclusion: mutate((s, a, i, exclusionId: string) =>
         s.deleteUmpireExclusion(a, i, exclusionId),
+      ),
+      generateMatchups: mutate((s, a, i, request: SchedulerGenerateMatchupsRequest) =>
+        s.generateSeasonMatchups(a, i, request),
       ),
       solveSeason: mutate(
         (s, a, i, request: SchedulerSeasonSolveRequest, options?: { idempotencyKey?: string }) =>

--- a/draco-nodejs/frontend-next/next.config.ts
+++ b/draco-nodejs/frontend-next/next.config.ts
@@ -22,6 +22,9 @@ const nextConfig: NextConfig = {
   experimental: {
     webpackMemoryOptimizations: true,
   },
+  env: {
+    SHOW_SEASON_SCHEDULER: process.env.SHOW_SEASON_SCHEDULER,
+  },
   allowedDevOrigins,
   /* config options here */
   async rewrites() {

--- a/draco-nodejs/frontend-next/services/schedulerService.ts
+++ b/draco-nodejs/frontend-next/services/schedulerService.ts
@@ -4,6 +4,8 @@ import type {
   SchedulerFieldAvailabilityRuleUpsert,
   SchedulerFieldExclusionDate,
   SchedulerFieldExclusionDateUpsert,
+  SchedulerGenerateMatchupsRequest,
+  SchedulerGenerateMatchupsResult,
   SchedulerProblemSpecPreview,
   SchedulerSeasonExclusion,
   SchedulerSeasonExclusionUpsert,
@@ -32,6 +34,7 @@ import {
   deleteSchedulerSeasonExclusion,
   deleteSchedulerTeamExclusion,
   deleteSchedulerUmpireExclusion,
+  generateSeasonMatchups,
   getSchedulerProblemSpecPreview,
   getSchedulerSeasonWindowConfig,
   listSchedulerFieldExclusionDates,
@@ -126,6 +129,21 @@ export class SchedulerService {
     });
 
     return unwrapApiResult(result, 'Failed to generate schedule proposal');
+  }
+
+  async generateSeasonMatchups(
+    accountId: string,
+    seasonId: string,
+    request: SchedulerGenerateMatchupsRequest,
+  ): Promise<SchedulerGenerateMatchupsResult> {
+    const result = await generateSeasonMatchups({
+      client: this.client,
+      path: { accountId, seasonId },
+      body: request,
+      throwOnError: false,
+    });
+
+    return unwrapApiResult(result, 'Failed to generate matchups');
   }
 
   async applySeason(

--- a/draco-nodejs/shared/shared-schemas/scheduler.ts
+++ b/draco-nodejs/shared/shared-schemas/scheduler.ts
@@ -533,6 +533,10 @@ export const SchedulerSeasonSolveRequestSchema = z
     constraints: SchedulerConstraintsOverrideSchema,
     objectives: SchedulerObjectivesSchema,
     gameIds: schedulerIdSchema.array().min(1).optional(),
+    matchups: SchedulerGameRequestSchema.array().min(1).optional().openapi({
+      description:
+        'Optional caller-provided matchups to place instead of DB-sourced games. When present, the backend skips loading existing games and schedules exactly these matchups (used by round-robin matchup generation). gameIds is ignored when matchups is provided.',
+    }),
     umpiresPerGame: z.number().int().min(1).max(4).optional().openapi({
       example: 2,
       description:
@@ -542,7 +546,53 @@ export const SchedulerSeasonSolveRequestSchema = z
   .openapi({
     title: 'SchedulerSeasonSolveRequest',
     description:
-      'DB-sourced solve request. The backend assembles teams/games/fields/umpires/fieldSlots from the database; the caller may provide optional constraint/objective overrides.',
+      'DB-sourced solve request. The backend assembles teams/games/fields/umpires/fieldSlots from the database; the caller may provide optional constraint/objective overrides, or supply explicit matchups to place.',
+  });
+
+export const SchedulerLeagueRoundRobinCountSchema = z
+  .object({
+    leagueSeasonId: schedulerIdSchema,
+    inDivisionGameCount: z.number().int().min(0).max(50).openapi({
+      example: 5,
+      description: 'How many times each team plays every other team in its own division.',
+    }),
+    crossDivisionGameCount: z.number().int().min(0).max(50).openapi({
+      example: 3,
+      description:
+        'How many times each team plays every other team in the same league but a different division.',
+    }),
+  })
+  .openapi({ title: 'SchedulerLeagueRoundRobinCount' });
+
+export const SchedulerGenerateMatchupsRequestSchema = z
+  .object({
+    leagueCounts: SchedulerLeagueRoundRobinCountSchema.array().min(1),
+  })
+  .openapi({
+    title: 'SchedulerGenerateMatchupsRequest',
+    description:
+      'Round-robin matchup generation request. For each selected league, specifies the per-opponent game counts for in-division and cross-division pairings. The backend reads the league teams and divisions from the database and returns deterministic, home/away-balanced matchups without persisting them.',
+  });
+
+export const SchedulerMatchupGenerationSummarySchema = z
+  .object({
+    leagueSeasonId: schedulerIdSchema,
+    teamCount: z.number().int().nonnegative(),
+    inDivisionGames: z.number().int().nonnegative(),
+    crossDivisionGames: z.number().int().nonnegative(),
+    totalGames: z.number().int().nonnegative(),
+  })
+  .openapi({ title: 'SchedulerMatchupGenerationSummary' });
+
+export const SchedulerGenerateMatchupsResultSchema = z
+  .object({
+    matchups: SchedulerGameRequestSchema.array(),
+    summary: SchedulerMatchupGenerationSummarySchema.array(),
+  })
+  .openapi({
+    title: 'SchedulerGenerateMatchupsResult',
+    description:
+      'Generated round-robin matchups (unplaced; no dates/fields/umpires) plus a per-league summary. Matchups are not persisted; feed them into the solve endpoint to place them.',
   });
 
 export const SchedulerAssignmentSchema = z
@@ -749,6 +799,14 @@ export type SchedulerApplyStatus = z.infer<typeof SchedulerApplyStatusSchema>;
 export type SchedulerApplyResult = z.infer<typeof SchedulerApplyResultSchema>;
 export type SchedulerSeasonSolveRequest = z.infer<typeof SchedulerSeasonSolveRequestSchema>;
 export type SchedulerSeasonApplyRequest = z.infer<typeof SchedulerSeasonApplyRequestSchema>;
+export type SchedulerLeagueRoundRobinCount = z.infer<typeof SchedulerLeagueRoundRobinCountSchema>;
+export type SchedulerGenerateMatchupsRequest = z.infer<
+  typeof SchedulerGenerateMatchupsRequestSchema
+>;
+export type SchedulerMatchupGenerationSummary = z.infer<
+  typeof SchedulerMatchupGenerationSummarySchema
+>;
+export type SchedulerGenerateMatchupsResult = z.infer<typeof SchedulerGenerateMatchupsResultSchema>;
 
 export const SchedulerProblemSpecPreviewSchema = z
   .object({


### PR DESCRIPTION
## Summary
Adds **Phase A** of the season scheduler completion roadmap: round-robin **matchup generation**. The scheduler was previously a *placer* (assigns field/time/umpire to games that already exist). This adds a *generator* in front of it: it produces deterministic, home/away-balanced matchups from per-league game counts, then feeds them into the existing solver to be placed.

Still gated behind `SHOW_SEASON_SCHEDULER` (now an env var — see below), so nothing is exposed in staging/production.

## What it does
- **Configure** per-league round-robin counts: how many times each team plays in-division vs. cross-division opponents. Counts live **client-side in localStorage** (no DB table — per the agreed "keep it simple" decision).
- **Generate Matchups** → backend builds the matchup set from league teams/divisions → existing solver places them → shows the placed proposal in the normal review UI.
- Generated matchups are **not persisted**; applying a generated proposal needs INSERT-vs-UPDATE logic on `leagueschedule` and is the **next increment** — so **Apply is disabled on generated proposals** with a "coming soon" note.

## Changes
- **shared-schemas**: `SchedulerGenerateMatchupsRequest/Result`, `SchedulerLeagueRoundRobinCount`, and an optional `matchups` field on `SchedulerSeasonSolveRequest`; new OpenAPI path `POST .../scheduler/generate-matchups`.
- **backend**: pure `SchedulerMatchupGeneratorService` (deterministic, balanced) + orchestrator service + teams/divisions repository + route; the solve path now accepts injected matchups instead of DB games.
- **frontend**: `SchedulerRoundRobinConfig` config UI + "Generate Matchups" action wired through the existing solve/review flow.
- **engine tests**: added team-blackout and umpire-availability constraint coverage (gaps from §2.6).
- **gate**: `SHOW_SEASON_SCHEDULER` now reads an env var — set `SHOW_SEASON_SCHEDULER=true` in `.env.local` to enable locally.
- **fixes** (first real render of the page surfaced these): unique constraint-dialog `key`s (was colliding on `"new"`); removed an infinite-render `useEffect` in the round-robin config.
- **docs**: wrote the completion roadmap (spec §3) and resolved-decisions table (§4).

## Testing
- Backend: type-check ✅, lint ✅, **1214 tests pass** (40 scheduler: 9 generator + 8 generation + 23 engine).
- Frontend: type-check ✅, lint ✅, **1584 tests pass**.
- Manually loaded the scheduler page locally with the flag on; resolved the console/runtime errors found.

## Not in scope (next increments)
- Applying a generated proposal (persist generated matchups to `leagueschedule`).
- Phase B (soft-constraint scoring) and Phase C (proposal persistence/edit/audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)