### PR TITLE
Fix forfeit games giving both teams a loss in standings

### DIFF
--- a/draco-nodejs/backend/src/services/statisticsService.ts
+++ b/draco-nodejs/backend/src/services/statisticsService.ts
@@ -355,25 +355,24 @@ export class StatisticsService {
         ds.id as "divisionId",
         dd.name as "divisionName",
         ds.priority as "divisionPriority",
-        COALESCE(SUM(CASE 
-          WHEN lg.gamestatus = 1 AND (
-            (lg.hteamid = ts.id AND lg.hscore > lg.vscore) OR 
+        COALESCE(SUM(CASE
+          WHEN lg.gamestatus IN (1, 4) AND (
+            (lg.hteamid = ts.id AND lg.hscore > lg.vscore) OR
             (lg.vteamid = ts.id AND lg.vscore > lg.hscore)
           ) THEN 1 ELSE 0 END), 0)::int as w,
-        COALESCE(SUM(CASE 
-          WHEN lg.gamestatus = 1 AND (
-            (lg.hteamid = ts.id AND lg.hscore < lg.vscore) OR 
+        COALESCE(SUM(CASE
+          WHEN lg.gamestatus IN (1, 4) AND (
+            (lg.hteamid = ts.id AND lg.hscore < lg.vscore) OR
             (lg.vteamid = ts.id AND lg.vscore < lg.hscore)
           ) THEN 1
           WHEN lg.gamestatus = 5 AND (lg.hteamid = ts.id OR lg.vteamid = ts.id) THEN 1
-          WHEN lg.gamestatus = 4 AND (lg.hteamid = ts.id OR lg.vteamid = ts.id) THEN 1
           ELSE 0 END), 0)::int as l,
         COALESCE(SUM(CASE 
           WHEN lg.gamestatus = 1 AND lg.hscore = lg.vscore AND (lg.hteamid = ts.id OR lg.vteamid = ts.id) 
           THEN 1 ELSE 0 END), 0)::int as t,
         -- Division Wins
         COALESCE(SUM(CASE
-          WHEN lg.gamestatus = 1
+          WHEN lg.gamestatus IN (1, 4)
             AND (
               (lg.hteamid = ts.id AND lg.hscore > lg.vscore)
               OR (lg.vteamid = ts.id AND lg.vscore > lg.hscore)
@@ -385,11 +384,11 @@ export class StatisticsService {
         -- Division Losses
         COALESCE(SUM(CASE
           WHEN (
-            (lg.gamestatus = 1 AND (
+            (lg.gamestatus IN (1, 4) AND (
               (lg.hteamid = ts.id AND lg.hscore < lg.vscore)
               OR (lg.vteamid = ts.id AND lg.vscore < lg.hscore)
             ))
-            OR (lg.gamestatus IN (4, 5) AND (lg.hteamid = ts.id OR lg.vteamid = ts.id))
+            OR (lg.gamestatus = 5 AND (lg.hteamid = ts.id OR lg.vteamid = ts.id))
           )
             AND hts.divisionseasonid = vts.divisionseasonid
             AND hts.divisionseasonid = ts.divisionseasonid


### PR DESCRIPTION
## Problem

When a game result is a **forfeit**, the standings page gives **both teams a loss** (and a win to neither). A forfeit produces `0 wins + 2 losses` instead of the correct `1 win + 1 loss`.

A forfeit always carries an entered score (e.g. `7-0`) where the forfeiting team is the loser and the other team is the winner — and the save-side validation (`UpdateGameResultsSchema`) already enforces that exactly one team has score `0` and the other `> 0`. So the winner is unambiguously determinable from the score, just like a Completed game.

## Root cause

In `getStandings` (`draco-nodejs/backend/src/services/statisticsService.ts`), the standings SQL treated **Forfeit (status `4`)** the same as **Did Not Report (status `5`)**:
- Wins only counted status `1`, so the forfeit winner got nothing.
- Losses awarded a loss to **both** teams of a forfeit.
- The division W/L clauses had the same flaw.

## Fix

Treat `Forfeit (4)` like `Completed (1)` — decide win/loss by score — for both overall and division records. `Did Not Report (5)` still correctly gives both teams a loss. Tie clauses remain scoped to status `1` (a forfeit can never be a tie). No schema or API-shape changes; this is the only place with this logic.

## Verification

- `pnpm backend:type-check` ✅
- `pnpm backend:lint` ✅
- Manual: load standings for a season with a forfeit game (`gamestatus = 4`, e.g. `7-0`) — the higher-score team now gets +1 win, the forfeiting team +1 loss (and division W/L if they share a division). Completed, tie, and Did-Not-Report games are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)