### PR TITLE
Season scheduler: persist proposal to localStorage (Phase C / C1)

### DIFF
--- a/docs/season-scheduler-spec.md
+++ b/docs/season-scheduler-spec.md
@@ -232,11 +232,13 @@ The soft constraints are **placement** concerns — they affect *when/where* a g
 
 **Activation:** the problem-spec assembly auto-enables these three soft constraints with the default weights above (no UI yet), so season solves get better spacing immediately. A caller-supplied `constraints.soft` overrides the defaults. Determinism is preserved: scoring is deterministic and ties keep the first slot in the existing stable order, so with no active soft constraint the engine output is identical to before. No solve time budget / cancellation (D.12) — the greedy approach is fast.
 
-### Phase C — Persistence, edit, audit
+### Phase C — Persistence, edit, audit *(scoped 2026-05-30)*
 
-- **C1. Proposal persistence (B.8).** Serialize the in-memory proposal to **localStorage as JSON**, keyed by (account, season), so re-opening the widget restores the last solve. **No backend proposal table.**
-- **C2. Edit before apply (C.9).** Allow manual override of an individual assignment (field/time/umpire) in the review UI before apply. Edits update the stored proposal and are re-validated against hard constraints; a hard-constraint violation is **warned but allowed** (manual override is an intentional admin decision).
-- **C3. Apply audit log (G.19).** Record who applied which assignments and when. This is the one place a small **durable DB table is justified** despite B.8 (audit must survive; localStorage won't do): account, season, applying user, timestamp, and the applied assignments / affected game count. **Requires schema approval before building.**
+Three independent increments. Suggested order: C1 → C2 → C3.
+
+- **C1. Proposal persistence (B.8).** *Frontend only, no schema change.* Serialize the widget's proposal state (`proposal`, `proposalFromGenerated`, `generatedMatchups`, `selectedGameIds`) to **localStorage** keyed `scheduler:proposal:{accountId}:{seasonId}`; hydrate on mount; clear storage on apply success. Mirrors the existing `loadRoundRobinCounts`/`saveRoundRobinCounts` pattern. Restores as-is on reopen; the apply path re-validates and reports stale/invalid assignments via its existing `skipped[]`.
+- **C2. Edit before apply (C.9).** *Frontend only — the apply API already takes an `assignments[]` array.* Make each `ProposalAssignmentRow` editable (field, umpires, start date/time; end derived from the existing duration), updating the in-memory/persisted proposal. **Validation = minimal + cheap clash check:** allow free edits, do one client-side check for two selected assignments sharing the same field + time, and otherwise rely on the backend apply response's existing `skipped[]` reasons (field busy, team double-booked, exclusions). This realizes "warn-but-allow" without re-implementing engine rules on the client.
+- **C3. Apply audit log (G.19).** *Backend; needs a new Prisma table — schema approval required before building.* **Write-only** table (e.g. `schedulerapplyauditlog`): `accountid`, `seasonid`, `runid`, `mode`, `appliedbyuserid` + `appliedbyusername` (from `req.user`), applied/skipped counts, `createdat`. Raw-SQL migration + repository; the acting user is threaded from the apply route into `SchedulerSeasonApplyService`, which writes one row after each apply. No read endpoint or UI in this increment (queryable in the DB).
 - **C4. No rollback (C.10).** No "undo apply" path on `games`.
 
 ### Scale (E.14)

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerAdapter.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerAdapter.tsx
@@ -97,6 +97,7 @@ export const SeasonSchedulerAdapter: React.FC<SeasonSchedulerAdapterProps> = ({
 
   return (
     <SeasonSchedulerWidget
+      key={`${accountId}:${seasonId ?? 'none'}`}
       accountId={accountId}
       seasonId={seasonId}
       canEdit={canEdit}

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -20,6 +20,11 @@ import { SeasonSchedulerConfigPanel } from './SeasonSchedulerConfigPanel';
 import { SeasonSchedulerConstraintLists } from './SeasonSchedulerConstraintLists';
 import { SeasonSchedulerProposalReview } from './SeasonSchedulerProposalReview';
 import { loadRoundRobinCounts, type LeagueRoundRobinCount } from './SchedulerRoundRobinConfig';
+import {
+  clearPersistedProposal,
+  loadPersistedProposal,
+  savePersistedProposal,
+} from '../../utils/schedulerProposalStorage';
 
 type FieldOption = { id: string; name: string };
 type EntityOption = { id: string; name: string };
@@ -93,10 +98,21 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   const [seasonStartDate, setSeasonStartDate] = useState('');
   const [seasonEndDate, setSeasonEndDate] = useState('');
   const [leagueSeasonSelection, setLeagueSeasonSelection] = useState<string[] | null>(null);
-  const [proposal, setProposal] = useState<SchedulerSolveResult | null>(null);
-  const [proposalFromGenerated, setProposalFromGenerated] = useState(false);
-  const [generatedMatchups, setGeneratedMatchups] = useState<SchedulerGameRequest[] | null>(null);
-  const [selectedGameIds, setSelectedGameIds] = useState<Set<string>>(new Set());
+  const [persistedProposal] = useState(() =>
+    seasonId ? loadPersistedProposal(accountId, seasonId) : null,
+  );
+  const [proposal, setProposal] = useState<SchedulerSolveResult | null>(
+    persistedProposal?.proposal ?? null,
+  );
+  const [proposalFromGenerated, setProposalFromGenerated] = useState(
+    persistedProposal?.proposalFromGenerated ?? false,
+  );
+  const [generatedMatchups, setGeneratedMatchups] = useState<SchedulerGameRequest[] | null>(
+    persistedProposal?.generatedMatchups ?? null,
+  );
+  const [selectedGameIds, setSelectedGameIds] = useState<Set<string>>(
+    new Set(persistedProposal?.selectedGameIds ?? []),
+  );
   const [specPreview, setSpecPreview] = useState<SchedulerProblemSpecPreview | null>(null);
   const [specPreviewOpen, setSpecPreviewOpen] = useState(false);
   const [umpiresPerGame, setUmpiresPerGame] = useState<UmpiresPerGame>(2);
@@ -104,6 +120,20 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   const [roundRobinCounts, setRoundRobinCounts] = useState<Map<string, LeagueRoundRobinCount>>(
     () => (seasonId ? loadRoundRobinCounts(accountId, seasonId) : new Map()),
   );
+
+  useEffect(() => {
+    if (!seasonId) return;
+    if (proposal) {
+      savePersistedProposal(accountId, seasonId, {
+        proposal,
+        proposalFromGenerated,
+        generatedMatchups,
+        selectedGameIds: Array.from(selectedGameIds),
+      });
+    } else {
+      clearPersistedProposal(accountId, seasonId);
+    }
+  }, [accountId, seasonId, proposal, proposalFromGenerated, generatedMatchups, selectedGameIds]);
 
   const { fieldNameById, teamNameById, umpireNameById } = useEntityNameMaps({
     fields,

--- a/draco-nodejs/frontend-next/utils/__tests__/schedulerProposalStorage.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/schedulerProposalStorage.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { SchedulerSolveResult } from '@draco/shared-schemas';
+import {
+  clearPersistedProposal,
+  loadPersistedProposal,
+  savePersistedProposal,
+  type PersistedSchedulerProposal,
+} from '../schedulerProposalStorage';
+
+const buildResult = (): SchedulerSolveResult => ({
+  runId: 'sched_account_1_abcdef',
+  status: 'completed',
+  metrics: { totalGames: 2, scheduledGames: 2, unscheduledGames: 0, objectiveValue: 2 },
+  assignments: [
+    {
+      gameId: 'gen-1-10-11-0',
+      fieldId: '44',
+      startTime: '2026-04-05T09:00:00.000Z',
+      endTime: '2026-04-05T10:15:00.000Z',
+      umpireIds: ['7'],
+    },
+    {
+      gameId: 'gen-1-10-12-0',
+      fieldId: '44',
+      startTime: '2026-04-06T09:00:00.000Z',
+      endTime: '2026-04-06T10:15:00.000Z',
+      umpireIds: [],
+    },
+  ],
+  unscheduled: [],
+});
+
+const buildPayload = (): PersistedSchedulerProposal => ({
+  proposal: buildResult(),
+  proposalFromGenerated: true,
+  generatedMatchups: [
+    {
+      id: 'gen-1-10-11-0',
+      leagueSeasonId: '5',
+      homeTeamSeasonId: '10',
+      visitorTeamSeasonId: '11',
+    },
+  ],
+  selectedGameIds: ['gen-1-10-11-0'],
+});
+
+describe('schedulerProposalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips a saved proposal for the same account and season', () => {
+    const payload = buildPayload();
+    savePersistedProposal('1', '2026', payload);
+
+    const loaded = loadPersistedProposal('1', '2026');
+    expect(loaded).toEqual(payload);
+    expect(loaded?.selectedGameIds).toEqual(['gen-1-10-11-0']);
+    expect(loaded?.generatedMatchups?.[0]?.homeTeamSeasonId).toBe('10');
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(loadPersistedProposal('1', '2026')).toBeNull();
+  });
+
+  it('isolates proposals by account and season key', () => {
+    savePersistedProposal('1', '2026', buildPayload());
+
+    expect(loadPersistedProposal('1', '2025')).toBeNull();
+    expect(loadPersistedProposal('2', '2026')).toBeNull();
+    expect(loadPersistedProposal('1', '2026')).not.toBeNull();
+  });
+
+  it('clears a stored proposal', () => {
+    savePersistedProposal('1', '2026', buildPayload());
+    expect(loadPersistedProposal('1', '2026')).not.toBeNull();
+
+    clearPersistedProposal('1', '2026');
+    expect(loadPersistedProposal('1', '2026')).toBeNull();
+  });
+
+  it('returns null for corrupt JSON', () => {
+    window.localStorage.setItem('scheduler:proposal:1:2026', '{not valid json');
+    expect(loadPersistedProposal('1', '2026')).toBeNull();
+  });
+
+  it('rejects a blob missing a valid proposal shape', () => {
+    window.localStorage.setItem(
+      'scheduler:proposal:1:2026',
+      JSON.stringify({ proposalFromGenerated: false, selectedGameIds: [] }),
+    );
+    expect(loadPersistedProposal('1', '2026')).toBeNull();
+  });
+
+  it('normalizes missing optional fields on load', () => {
+    window.localStorage.setItem(
+      'scheduler:proposal:1:2026',
+      JSON.stringify({ proposal: buildResult() }),
+    );
+
+    const loaded = loadPersistedProposal('1', '2026');
+    expect(loaded?.proposalFromGenerated).toBe(false);
+    expect(loaded?.generatedMatchups).toBeNull();
+    expect(loaded?.selectedGameIds).toEqual([]);
+  });
+});

--- a/draco-nodejs/frontend-next/utils/schedulerProposalStorage.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerProposalStorage.ts
@@ -1,0 +1,52 @@
+import type { SchedulerGameRequest, SchedulerSolveResult } from '@draco/shared-schemas';
+
+export interface PersistedSchedulerProposal {
+  proposal: SchedulerSolveResult;
+  proposalFromGenerated: boolean;
+  generatedMatchups: SchedulerGameRequest[] | null;
+  selectedGameIds: string[];
+}
+
+const buildProposalStorageKey = (accountId: string, seasonId: string): string =>
+  `scheduler:proposal:${accountId}:${seasonId}`;
+
+export const loadPersistedProposal = (
+  accountId: string,
+  seasonId: string,
+): PersistedSchedulerProposal | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(buildProposalStorageKey(accountId, seasonId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedSchedulerProposal;
+    if (!parsed || !parsed.proposal || !Array.isArray(parsed.proposal.assignments)) {
+      return null;
+    }
+    return {
+      proposal: parsed.proposal,
+      proposalFromGenerated: parsed.proposalFromGenerated === true,
+      generatedMatchups: Array.isArray(parsed.generatedMatchups) ? parsed.generatedMatchups : null,
+      selectedGameIds: Array.isArray(parsed.selectedGameIds) ? parsed.selectedGameIds : [],
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const savePersistedProposal = (
+  accountId: string,
+  seasonId: string,
+  data: PersistedSchedulerProposal,
+): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(buildProposalStorageKey(accountId, seasonId), JSON.stringify(data));
+  } catch {}
+};
+
+export const clearPersistedProposal = (accountId: string, seasonId: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(buildProposalStorageKey(accountId, seasonId));
+  } catch {}
+};


### PR DESCRIPTION
## Summary
First increment of Phase C. Re-opening the scheduler widget previously **lost the last solve** (a §1.7 rough edge). The proposal now survives close/reopen by persisting to `localStorage`.

## What changed (frontend only, no schema change)
- New `utils/schedulerProposalStorage.ts` — `load`/`save`/`clear` for the proposal bundle (`proposal`, `proposalFromGenerated`, `generatedMatchups`, `selectedGameIds`), keyed `scheduler:proposal:{accountId}:{seasonId}`. SSR-guarded, corrupt-data tolerant, normalizes missing optional fields.
- `SeasonSchedulerWidget` hydrates these four states from a once-loaded blob via lazy `useState` initializers (mirrors the existing round-robin pattern), and a **write-only** persistence effect saves when a proposal is present / clears when it is null. The effect calls no `setState`, so it cannot loop (the bug class the project's CLAUDE.md warns about); apply already nulls the proposal, so clear-on-apply is automatic.

## Staleness
Restored as-is on reopen; the apply path already re-validates and reports any stale/invalid assignments via its existing `skipped[]`. Generating or solving again overwrites the stored proposal.

## Testing
- New `utils/__tests__/schedulerProposalStorage.test.ts` (7 tests): round-trip, account/season key isolation, clear, corrupt-JSON → null, invalid-shape → null, optional-field normalization.
- Frontend: type-check ✅, lint ✅, **1591 tests pass**.

## Scope note
Includes the full **Phase C scope** in spec §3 (C1 persistence, C2 edit-before-apply, C3 write-only apply audit log — the last needs a DB table + approval). This PR is C1 only. Branched off `main`; Phase B (#854) is still open and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)