### PR TITLE
Season scheduler: edit assignments before apply (Phase C / C2)

### DIFF
--- a/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
@@ -1,13 +1,32 @@
 'use client';
 
 import React from 'react';
-import { Box, Checkbox, Collapse, IconButton, Typography } from '@mui/material';
+import {
+  Box,
+  Checkbox,
+  Collapse,
+  FormControl,
+  IconButton,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import type { SchedulerProblemSpecPreview, SchedulerSolveResult } from '@draco/shared-schemas';
-import { formatLocalTimeRange } from '../../utils/schedulerTimeFormat';
+import {
+  formatLocalTimeRange,
+  utcIsoToZonedInputValue,
+  zonedInputValueToUtcIso,
+} from '../../utils/schedulerTimeFormat';
 
 type Assignment = SchedulerSolveResult['assignments'][number];
 type GameRequest = SchedulerProblemSpecPreview['games'][number];
+type Option = { id: string; name: string };
 
 interface ProposalAssignmentRowProps {
   assignment: Assignment;
@@ -15,6 +34,9 @@ interface ProposalAssignmentRowProps {
   timeZone: string;
   selected: boolean;
   expanded: boolean;
+  fields: Option[];
+  umpires: Option[];
+  maxUmpires: number;
   fieldNameById: Map<string, string>;
   teamNameById: Map<string, string>;
   umpireNameById: Map<string, string>;
@@ -22,6 +44,7 @@ interface ProposalAssignmentRowProps {
   leagueNameById: Map<string, string>;
   onToggleSelection: () => void;
   onToggleExpanded: () => void;
+  onAssignmentChange: (assignment: Assignment) => void;
 }
 
 export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
@@ -30,6 +53,9 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
   timeZone,
   selected,
   expanded,
+  fields,
+  umpires,
+  maxUmpires,
   fieldNameById,
   teamNameById,
   umpireNameById,
@@ -37,6 +63,7 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
   leagueNameById,
   onToggleSelection,
   onToggleExpanded,
+  onAssignmentChange,
 }) => {
   const home =
     (game?.homeTeamSeasonId ? teamNameById.get(game.homeTeamSeasonId) : null) ?? 'Unknown Home';
@@ -66,6 +93,33 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
 
   const detailsId = `proposal-assignment-details-${assignment.gameId}`;
 
+  const handleFieldChange = (event: SelectChangeEvent) => {
+    onAssignmentChange({ ...assignment, fieldId: event.target.value });
+  };
+
+  const handleUmpiresChange = (event: SelectChangeEvent<string[]>) => {
+    const value = event.target.value;
+    const ids = (typeof value === 'string' ? value.split(',') : value).filter(
+      (id) => id.length > 0,
+    );
+    onAssignmentChange({ ...assignment, umpireIds: ids.slice(0, maxUmpires) });
+  };
+
+  const handleStartChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextStartIso = zonedInputValueToUtcIso(event.target.value, timeZone);
+    if (!nextStartIso) return;
+    const previousStart = new Date(assignment.startTime).getTime();
+    const previousEnd = new Date(assignment.endTime).getTime();
+    const durationMs =
+      Number.isFinite(previousStart) && Number.isFinite(previousEnd) && previousEnd > previousStart
+        ? previousEnd - previousStart
+        : 0;
+    const nextEndIso = new Date(new Date(nextStartIso).getTime() + durationMs).toISOString();
+    onAssignmentChange({ ...assignment, startTime: nextStartIso, endTime: nextEndIso });
+  };
+
+  const startInputValue = utcIsoToZonedInputValue(assignment.startTime, timeZone);
+
   return (
     <Box sx={{ borderRadius: 1, border: '1px solid', borderColor: 'divider' }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1 }}>
@@ -84,7 +138,7 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
         </Box>
         <IconButton
           size="small"
-          aria-label={expanded ? `Collapse details for ${title}` : `Expand details for ${title}`}
+          aria-label={expanded ? `Edit ${title}` : `Edit ${title}`}
           aria-expanded={expanded}
           aria-controls={detailsId}
           onClick={onToggleExpanded}
@@ -94,23 +148,76 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
       </Box>
 
       <Collapse in={expanded} timeout="auto" unmountOnExit id={detailsId}>
-        <Box sx={{ px: 2, pb: 1 }}>
-          <Typography variant="caption" color="text.secondary" display="block">
-            Game ID: {assignment.gameId}
-          </Typography>
-          {game && (
+        <Box sx={{ px: 2, pb: 2, pt: 1 }}>
+          <Stack spacing={2}>
+            <FormControl size="small" fullWidth>
+              <InputLabel id={`${detailsId}-field-label`}>Field</InputLabel>
+              <Select
+                labelId={`${detailsId}-field-label`}
+                label="Field"
+                value={assignment.fieldId}
+                onChange={handleFieldChange}
+              >
+                {fields.map((field) => (
+                  <MenuItem key={field.id} value={field.id}>
+                    {field.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" fullWidth>
+              <InputLabel id={`${detailsId}-umpires-label`}>Umpires</InputLabel>
+              <Select
+                labelId={`${detailsId}-umpires-label`}
+                label="Umpires"
+                multiple
+                value={assignment.umpireIds}
+                onChange={handleUmpiresChange}
+                renderValue={(selectedIds) =>
+                  selectedIds.length === 0
+                    ? 'Unassigned'
+                    : selectedIds
+                        .map(
+                          (id) =>
+                            schedulerUmpireNameById.get(id) ??
+                            umpireNameById.get(id) ??
+                            `Umpire ${id}`,
+                        )
+                        .join(', ')
+                }
+              >
+                {umpires.map((umpire) => (
+                  <MenuItem
+                    key={umpire.id}
+                    value={umpire.id}
+                    disabled={
+                      assignment.umpireIds.length >= maxUmpires &&
+                      !assignment.umpireIds.includes(umpire.id)
+                    }
+                  >
+                    <Checkbox checked={assignment.umpireIds.includes(umpire.id)} />
+                    <ListItemText primary={umpire.name} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="Start"
+              type="datetime-local"
+              size="small"
+              fullWidth
+              value={startInputValue}
+              onChange={handleStartChange}
+              InputLabelProps={{ shrink: true }}
+              helperText="Times are shown in the league time zone. End time shifts with the same game length."
+            />
+
             <Typography variant="caption" color="text.secondary" display="block">
-              Home Team Season ID: {game.homeTeamSeasonId} • Visitor Team Season ID:{' '}
-              {game.visitorTeamSeasonId}
+              Game ID: {assignment.gameId}
             </Typography>
-          )}
-          <Typography variant="caption" color="text.secondary" display="block">
-            Start (UTC): {assignment.startTime} • End (UTC): {assignment.endTime}
-          </Typography>
-          <Typography variant="caption" color="text.secondary" display="block">
-            Field ID: {assignment.fieldId} • Umpire IDs:{' '}
-            {assignment.umpireIds.length ? assignment.umpireIds.join(', ') : 'None'}
-          </Typography>
+          </Stack>
         </Box>
       </Collapse>
     </Box>

--- a/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
@@ -138,7 +138,9 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
         </Box>
         <IconButton
           size="small"
-          aria-label={expanded ? `Edit ${title}` : `Edit ${title}`}
+          aria-label={
+            expanded ? `Collapse edit controls for ${title}` : `Expand edit controls for ${title}`
+          }
           aria-expanded={expanded}
           aria-controls={detailsId}
           onClick={onToggleExpanded}

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
@@ -17,8 +17,12 @@ import type {
   SchedulerSolveResult,
 } from '@draco/shared-schemas';
 import { formatDateInTimezone, getDateKeyInTimezone } from '../../utils/dateUtils';
+import { findSelectedFieldClashes } from '../../utils/schedulerAssignmentChecks';
 import { ProposalAssignmentRow } from './ProposalAssignmentRow';
 import { SchedulerSpecPreviewDialog } from './SchedulerSpecPreviewDialog';
+
+type Option = { id: string; name: string };
+type EditableAssignment = SchedulerSolveResult['assignments'][number];
 
 interface SeasonSchedulerProposalReviewProps {
   proposal: SchedulerSolveResult | null;
@@ -27,6 +31,9 @@ interface SeasonSchedulerProposalReviewProps {
   loading: boolean;
   timeZone: string;
   selectedGameIds: Set<string>;
+  fields: Option[];
+  umpires: Option[];
+  maxUmpires: number;
   fieldNameById: Map<string, string>;
   teamNameById: Map<string, string>;
   umpireNameById: Map<string, string>;
@@ -36,6 +43,7 @@ interface SeasonSchedulerProposalReviewProps {
   onToggleSelection: (gameId: string) => void;
   onToggleAll: () => void;
   onApply: () => void;
+  onAssignmentChange: (assignment: EditableAssignment) => void;
   onCloseSpecPreview: () => void;
 }
 
@@ -88,6 +96,9 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   loading,
   timeZone,
   selectedGameIds,
+  fields,
+  umpires,
+  maxUmpires,
   fieldNameById,
   teamNameById,
   umpireNameById,
@@ -97,6 +108,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   onToggleSelection,
   onToggleAll,
   onApply,
+  onAssignmentChange,
   onCloseSpecPreview,
 }) => {
   const [expandedGameIds, setExpandedGameIds] = useState<Set<string>>(new Set());
@@ -134,6 +146,9 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
   };
 
   const groupedAssignments = groupAssignmentsByDate(proposal, timeZone);
+  const fieldClashes = proposal
+    ? findSelectedFieldClashes(proposal.assignments, selectedGameIds)
+    : [];
 
   return (
     <>
@@ -188,6 +203,17 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
                   </Button>
                 </Box>
 
+                {fieldClashes.length > 0 && (
+                  <Alert severity="warning" sx={{ mb: 1 }}>
+                    {fieldClashes.length} selected field/time clash
+                    {fieldClashes.length === 1 ? '' : 'es'} detected (
+                    {fieldClashes
+                      .map((clash) => fieldNameById.get(clash.fieldId) ?? `Field ${clash.fieldId}`)
+                      .join(', ')}
+                    ). You can still apply — the server skips any true conflicts and reports them.
+                  </Alert>
+                )}
+
                 <Stack spacing={1}>
                   {groupedAssignments.map((group) => (
                     <Box
@@ -205,6 +231,9 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
                           timeZone={timeZone}
                           selected={selectedGameIds.has(assignment.gameId)}
                           expanded={expandedGameIds.has(assignment.gameId)}
+                          fields={fields}
+                          umpires={umpires}
+                          maxUmpires={maxUmpires}
                           fieldNameById={fieldNameById}
                           teamNameById={teamNameById}
                           umpireNameById={umpireNameById}
@@ -212,6 +241,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
                           leagueNameById={leagueNameById}
                           onToggleSelection={() => onToggleSelection(assignment.gameId)}
                           onToggleExpanded={() => toggleExpanded(assignment.gameId)}
+                          onAssignmentChange={onAssignmentChange}
                         />
                       ))}
                     </Box>

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -446,6 +446,19 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     setSelectedGameIds(new Set(assignments.map((a) => a.gameId)));
   };
 
+  const handleAssignmentChange = (updated: SchedulerSolveResult['assignments'][number]) => {
+    setProposal((prev) =>
+      prev
+        ? {
+            ...prev,
+            assignments: prev.assignments.map((assignment) =>
+              assignment.gameId === updated.gameId ? updated : assignment,
+            ),
+          }
+        : prev,
+    );
+  };
+
   if (!canEdit) {
     return null;
   }
@@ -591,6 +604,9 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         loading={loading}
         timeZone={timeZone}
         selectedGameIds={selectedGameIds}
+        fields={fields}
+        umpires={umpires}
+        maxUmpires={umpiresPerGame}
         fieldNameById={fieldNameById}
         teamNameById={teamNameById}
         umpireNameById={umpireNameById}
@@ -600,6 +616,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         onToggleSelection={handleToggleSelection}
         onToggleAll={handleToggleAll}
         onApply={handleApply}
+        onAssignmentChange={handleAssignmentChange}
         onCloseSpecPreview={() => setSpecPreviewOpen(false)}
       />
     </WidgetShell>

--- a/draco-nodejs/frontend-next/utils/__tests__/schedulerAssignmentChecks.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/schedulerAssignmentChecks.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { SchedulerSolveResult } from '@draco/shared-schemas';
+import { findSelectedFieldClashes } from '../schedulerAssignmentChecks';
+
+type Assignment = SchedulerSolveResult['assignments'][number];
+
+const assignment = (
+  gameId: string,
+  fieldId: string,
+  startTime: string,
+  endTime: string,
+): Assignment => ({ gameId, fieldId, startTime, endTime, umpireIds: [] });
+
+describe('findSelectedFieldClashes', () => {
+  it('flags two selected assignments on the same field with overlapping times', () => {
+    const assignments = [
+      assignment('g1', '44', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+      assignment('g2', '44', '2026-04-05T14:00:00Z', '2026-04-05T15:15:00Z'),
+    ];
+    const clashes = findSelectedFieldClashes(assignments, new Set(['g1', 'g2']));
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].fieldId).toBe('44');
+    expect(clashes[0].gameIds.sort()).toEqual(['g1', 'g2']);
+  });
+
+  it('does not flag overlaps on different fields', () => {
+    const assignments = [
+      assignment('g1', '44', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+      assignment('g2', '45', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+    ];
+    expect(findSelectedFieldClashes(assignments, new Set(['g1', 'g2']))).toHaveLength(0);
+  });
+
+  it('does not flag same-field assignments that do not overlap in time', () => {
+    const assignments = [
+      assignment('g1', '44', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+      assignment('g2', '44', '2026-04-05T14:15:00Z', '2026-04-05T15:30:00Z'),
+    ];
+    expect(findSelectedFieldClashes(assignments, new Set(['g1', 'g2']))).toHaveLength(0);
+  });
+
+  it('ignores assignments that are not selected', () => {
+    const assignments = [
+      assignment('g1', '44', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+      assignment('g2', '44', '2026-04-05T14:00:00Z', '2026-04-05T15:15:00Z'),
+    ];
+    expect(findSelectedFieldClashes(assignments, new Set(['g1']))).toHaveLength(0);
+  });
+
+  it('groups three overlapping games on one field into a single clash entry', () => {
+    const assignments = [
+      assignment('g1', '44', '2026-04-05T13:00:00Z', '2026-04-05T14:15:00Z'),
+      assignment('g2', '44', '2026-04-05T13:30:00Z', '2026-04-05T14:45:00Z'),
+      assignment('g3', '44', '2026-04-05T14:00:00Z', '2026-04-05T15:15:00Z'),
+    ];
+    const clashes = findSelectedFieldClashes(assignments, new Set(['g1', 'g2', 'g3']));
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].gameIds.sort()).toEqual(['g1', 'g2', 'g3']);
+  });
+});

--- a/draco-nodejs/frontend-next/utils/__tests__/schedulerTimeFormat.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/schedulerTimeFormat.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { utcIsoToZonedInputValue, zonedInputValueToUtcIso } from '../schedulerTimeFormat';
+
+describe('scheduler datetime-local <-> UTC conversion', () => {
+  it('renders a UTC instant as the wall clock in the target time zone', () => {
+    // 13:00Z is 09:00 EDT on 2026-04-05 (America/New_York, UTC-4 in April).
+    expect(utcIsoToZonedInputValue('2026-04-05T13:00:00Z', 'America/New_York')).toBe(
+      '2026-04-05T09:00',
+    );
+    // UTC zone shows the same wall clock.
+    expect(utcIsoToZonedInputValue('2026-04-05T13:00:00Z', 'UTC')).toBe('2026-04-05T13:00');
+  });
+
+  it('converts a zoned wall clock back to the correct UTC instant', () => {
+    expect(zonedInputValueToUtcIso('2026-04-05T09:00', 'America/New_York')).toBe(
+      '2026-04-05T13:00:00.000Z',
+    );
+    expect(zonedInputValueToUtcIso('2026-04-05T13:00', 'UTC')).toBe('2026-04-05T13:00:00.000Z');
+  });
+
+  it('round-trips a UTC instant through the zoned input value', () => {
+    const zones = ['America/New_York', 'America/Los_Angeles', 'UTC', 'America/Chicago'];
+    const iso = '2026-07-04T23:30:00.000Z';
+    for (const zone of zones) {
+      const input = utcIsoToZonedInputValue(iso, zone);
+      expect(zonedInputValueToUtcIso(input, zone)).toBe(iso);
+    }
+  });
+
+  it('returns empty/null for invalid input', () => {
+    expect(utcIsoToZonedInputValue('not-a-date', 'UTC')).toBe('');
+    expect(zonedInputValueToUtcIso('garbage', 'UTC')).toBeNull();
+  });
+});

--- a/draco-nodejs/frontend-next/utils/schedulerAssignmentChecks.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerAssignmentChecks.ts
@@ -1,0 +1,54 @@
+import type { SchedulerSolveResult } from '@draco/shared-schemas';
+
+type Assignment = SchedulerSolveResult['assignments'][number];
+
+export interface FieldClash {
+  fieldId: string;
+  gameIds: string[];
+}
+
+/**
+ * Cheap client-side heads-up: among the SELECTED assignments, find groups that share a field
+ * with overlapping time ranges. This is a warning only — the backend apply remains the source of
+ * truth (it reports true conflicts, including field capacity, via its skipped[] result).
+ */
+export const findSelectedFieldClashes = (
+  assignments: Assignment[],
+  selectedGameIds: Set<string>,
+): FieldClash[] => {
+  const selected = assignments.filter((assignment) => selectedGameIds.has(assignment.gameId));
+  const clashesByField = new Map<string, Set<string>>();
+
+  for (let i = 0; i < selected.length; i += 1) {
+    for (let j = i + 1; j < selected.length; j += 1) {
+      const a = selected[i];
+      const b = selected[j];
+      if (a.fieldId !== b.fieldId) continue;
+
+      const aStart = new Date(a.startTime).getTime();
+      const aEnd = new Date(a.endTime).getTime();
+      const bStart = new Date(b.startTime).getTime();
+      const bEnd = new Date(b.endTime).getTime();
+      if (
+        Number.isNaN(aStart) ||
+        Number.isNaN(aEnd) ||
+        Number.isNaN(bStart) ||
+        Number.isNaN(bEnd)
+      ) {
+        continue;
+      }
+
+      if (aStart < bEnd && bStart < aEnd) {
+        const set = clashesByField.get(a.fieldId) ?? new Set<string>();
+        set.add(a.gameId);
+        set.add(b.gameId);
+        clashesByField.set(a.fieldId, set);
+      }
+    }
+  }
+
+  return Array.from(clashesByField.entries()).map(([fieldId, ids]) => ({
+    fieldId,
+    gameIds: Array.from(ids),
+  }));
+};

--- a/draco-nodejs/frontend-next/utils/schedulerTimeFormat.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerTimeFormat.ts
@@ -8,6 +8,78 @@ export const formatLocalHhmmTo12Hour = (value: string): string => {
   return `${hours12}:${match[2] ?? '00'} ${suffix}`;
 };
 
+const pad2 = (value: number): string => String(value).padStart(2, '0');
+
+interface ZonedParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+const getZonedParts = (date: Date, timeZone: string): ZonedParts => {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts: Record<string, number> = {};
+  for (const part of formatter.formatToParts(date)) {
+    if (part.type !== 'literal') {
+      parts[part.type] = Number(part.value);
+    }
+  }
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour === 24 ? 0 : parts.hour,
+    minute: parts.minute,
+  };
+};
+
+/**
+ * UTC ISO instant -> "YYYY-MM-DDTHH:mm" wall-clock value (in timeZone) for a datetime-local input.
+ */
+export const utcIsoToZonedInputValue = (iso: string, timeZone: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  try {
+    const p = getZonedParts(date, timeZone);
+    return `${p.year}-${pad2(p.month)}-${pad2(p.day)}T${pad2(p.hour)}:${pad2(p.minute)}`;
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * "YYYY-MM-DDTHH:mm" wall-clock value (interpreted in timeZone) -> UTC ISO instant.
+ * Uses one-step offset inversion; correct except exactly at a DST transition instant.
+ */
+export const zonedInputValueToUtcIso = (value: string, timeZone: string): string | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  try {
+    const guess = Date.UTC(year, month - 1, day, hour, minute);
+    const p = getZonedParts(new Date(guess), timeZone);
+    const zonedAsUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute);
+    const offset = zonedAsUtc - guess;
+    return new Date(guess - offset).toISOString();
+  } catch {
+    return null;
+  }
+};
+
 interface ZoneFormatters {
   dateLabel: Intl.DateTimeFormat;
   time: Intl.DateTimeFormat;


### PR DESCRIPTION
## Summary
Second Phase C increment. Admins can now **manually override** an individual proposal assignment before applying — change its **field**, **umpires**, or **start time** — directly in the review UI. Frontend only; the apply API already accepts an `assignments[]` array, so there is **no backend change**.

## What changed
- **`ProposalAssignmentRow`** — the expand panel is now an editor: a field `Select`, an umpires multi-`Select` (capped at `umpiresPerGame`), and a `datetime-local` Start input. Changing the start shifts the end by the same game length.
- **Timezone-correct time editing** — the datetime input shows/edits the **account (league) time zone** wall clock (matching how the scheduler displays times), via new `utcIsoToZonedInputValue` / `zonedInputValueToUtcIso` helpers (one-step DST-aware offset inversion).
- **Edits flow to the in-memory proposal** (`handleAssignmentChange` → `proposal.assignments`), which C1 persists to localStorage automatically; apply sends the edited assignments.
- **Minimal validation (warn-but-allow)** — `findSelectedFieldClashes` flags selected assignments that share a field with overlapping times; a warning Alert shows but **Apply stays enabled**. The backend remains the source of truth and reports true conflicts (including field capacity) via its existing `skipped[]`.

## Decision recap
Per the locked C2 scope: minimal client validation (one cheap field/time clash check) rather than re-implementing engine availability rules on the client.

## Testing
- New `schedulerTimeFormat.test.ts` — UTC↔zoned round-trips across America/New_York, Los_Angeles, Chicago, UTC; invalid-input handling.
- New `schedulerAssignmentChecks.test.ts` — clash detection: overlap, different field, non-overlap, unselected excluded, 3-way grouping.
- Frontend: type-check ✅, lint ✅, **1600 tests pass**.

## Not in scope
- C3: write-only apply audit log (needs a new DB table + approval) — the last Phase C item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)