### PR TITLE
Fix First Year field snapping back to original value when cleared

### DIFF
--- a/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/roster/SignPlayerDialog.tsx
@@ -599,12 +599,12 @@ const SignPlayerDialog: React.FC<SignPlayerDialogProps> = ({
                   onChange={(event) => {
                     const { value } = event.target;
                     if (value === '') {
-                      field.onChange(undefined);
+                      field.onChange('');
                       return;
                     }
 
                     const parsed = Number.parseInt(value, 10);
-                    field.onChange(Number.isNaN(parsed) ? undefined : parsed);
+                    field.onChange(Number.isNaN(parsed) ? '' : parsed);
                   }}
                   inputProps={{ min: 1900, max: new Date().getFullYear() }}
                   fullWidth


### PR DESCRIPTION
## Summary
In the **Edit Roster Information** dialog, clearing the **First Year** field made it snap back to the original value (e.g. `2006`) the instant the input became empty — so a user couldn't delete `2006` to type `1980`; the field kept restoring `2006`.

## Root cause
The field is a React Hook Form `Controller`. Its `onChange` stored `undefined` for an empty input. In RHF v7, when a controlled field's stored value is `undefined`, the internal value lookup (`get(_formValues, name, defaultValue)`) falls back to the field's **default** — which was seeded by `reset(initialRosterData)` to the original year. So emptying the input → `undefined` → RHF substitutes the default → the input visibly jumps back. This is the well-known "never store `undefined` in a controlled RHF field" gotcha.

## Fix
Store an empty string instead of `undefined` when the input is cleared (both the empty case and the `NaN` guard). An empty string is a real value, so RHF does not fall back to the default and the field stays empty while editing. Validity is unchanged and still enforced **on submit** by the existing Zod rule (`firstYear: z.number().min(1900).max(currentYear)`) — matching the intent that the constraint applies at submit time, not while typing.

```diff
  if (value === '') {
-   field.onChange(undefined);
+   field.onChange('');
    return;
  }
  const parsed = Number.parseInt(value, 10);
- field.onChange(Number.isNaN(parsed) ? undefined : parsed);
+ field.onChange(Number.isNaN(parsed) ? '' : parsed);
```

No shared-schema or backend changes.

## Testing
- `pnpm frontend:type-check` — passes
- `pnpm frontend:lint` — passes
- Manual: edit a roster member, clear First Year, confirm it stays empty and accepts a new year; submitting empty surfaces the existing validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)