### PR TITLE
Link teams in player career statistics

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -17621,6 +17621,15 @@
           "hasGameRecap": {
             "type": "boolean"
           },
+          "teamsWithStats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^\\d+$",
+              "example": "12345"
+            },
+            "description": "Team-season IDs (home and/or visitor) that have entered stats for this game"
+          },
           "umpire1": {
             "type": "object",
             "properties": {
@@ -17958,6 +17967,15 @@
                 "hasGameRecap": {
                   "type": "boolean"
                 },
+                "teamsWithStats": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "example": "12345"
+                  },
+                  "description": "Team-season IDs (home and/or visitor) that have entered stats for this game"
+                },
                 "umpire1": {
                   "type": "object",
                   "properties": {
@@ -18262,6 +18280,15 @@
                 },
                 "hasGameRecap": {
                   "type": "boolean"
+                },
+                "teamsWithStats": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "example": "12345"
+                  },
+                  "description": "Team-season IDs (home and/or visitor) that have entered stats for this game"
                 },
                 "umpire1": {
                   "type": "object",
@@ -18576,6 +18603,15 @@
                 },
                 "hasGameRecap": {
                   "type": "boolean"
+                },
+                "teamsWithStats": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "example": "12345"
+                  },
+                  "description": "Team-season IDs (home and/or visitor) that have entered stats for this game"
                 },
                 "umpire1": {
                   "type": "object",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -13178,6 +13178,14 @@ components:
           description: 0=Regular, 1=Playoff, 2=Exhibition
         hasGameRecap:
           type: boolean
+        teamsWithStats:
+          type: array
+          items:
+            type: string
+            pattern: ^\d+$
+            example: "12345"
+          description: Team-season IDs (home and/or visitor) that have entered stats for
+            this game
         umpire1:
           type: object
           properties:
@@ -13430,6 +13438,14 @@ components:
                 description: 0=Regular, 1=Playoff, 2=Exhibition
               hasGameRecap:
                 type: boolean
+              teamsWithStats:
+                type: array
+                items:
+                  type: string
+                  pattern: ^\d+$
+                  example: "12345"
+                description: Team-season IDs (home and/or visitor) that have entered stats for
+                  this game
               umpire1:
                 type: object
                 properties:
@@ -13655,6 +13671,14 @@ components:
                 description: 0=Regular, 1=Playoff, 2=Exhibition
               hasGameRecap:
                 type: boolean
+              teamsWithStats:
+                type: array
+                items:
+                  type: string
+                  pattern: ^\d+$
+                  example: "12345"
+                description: Team-season IDs (home and/or visitor) that have entered stats for
+                  this game
               umpire1:
                 type: object
                 properties:
@@ -13886,6 +13910,14 @@ components:
                 description: 0=Regular, 1=Playoff, 2=Exhibition
               hasGameRecap:
                 type: boolean
+              teamsWithStats:
+                type: array
+                items:
+                  type: string
+                  pattern: ^\d+$
+                  example: "12345"
+                description: Team-season IDs (home and/or visitor) that have entered stats for
+                  this game
               umpire1:
                 type: object
                 properties:

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaScheduleRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaScheduleRepository.ts
@@ -481,6 +481,28 @@ export class PrismaScheduleRepository implements IScheduleRepository {
     return BatchQueryHelper.batchTeamNames(this.prisma, teamIds);
   }
 
+  async getTeamsWithStatsByGameIds(gameIds: bigint[]): Promise<Map<string, Set<string>>> {
+    const result = new Map<string, Set<string>>();
+    if (gameIds.length === 0) {
+      return result;
+    }
+
+    const where = { gameid: { in: gameIds } };
+    const [battingGroups, pitchingGroups] = await Promise.all([
+      this.prisma.batstatsum.groupBy({ by: ['gameid', 'teamid'], where }),
+      this.prisma.pitchstatsum.groupBy({ by: ['gameid', 'teamid'], where }),
+    ]);
+
+    for (const group of [...battingGroups, ...pitchingGroups]) {
+      const gameKey = group.gameid.toString();
+      const teams = result.get(gameKey) ?? new Set<string>();
+      teams.add(group.teamid.toString());
+      result.set(gameKey, teams);
+    }
+
+    return result;
+  }
+
   async listUpcomingGamesForTeam(
     teamSeasonId: bigint,
     seasonId: bigint,

--- a/draco-nodejs/backend/src/repositories/interfaces/IScheduleRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IScheduleRepository.ts
@@ -89,6 +89,7 @@ export interface IScheduleRepository extends IBaseRepository<leagueschedule> {
   findRecap(gameId: bigint, teamSeasonId: bigint): Promise<dbGameRecap | null>;
   upsertRecap(gameId: bigint, teamSeasonId: bigint, recap: string): Promise<gamerecap>;
   getTeamNames(teamIds: bigint[]): Promise<Map<string, string>>;
+  getTeamsWithStatsByGameIds(gameIds: bigint[]): Promise<Map<string, Set<string>>>;
   listUpcomingGamesForTeam(
     teamSeasonId: bigint,
     seasonId: bigint,

--- a/draco-nodejs/backend/src/responseFormatters/__tests__/scheduleResponseFormatter.test.ts
+++ b/draco-nodejs/backend/src/responseFormatters/__tests__/scheduleResponseFormatter.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+
+import { ScheduleResponseFormatter } from '../scheduleResponseFormatter.js';
+import type { dbScheduleGameWithDetails } from '../../repositories/types/index.js';
+
+const makeGame = (overrides: Partial<dbScheduleGameWithDetails> = {}): dbScheduleGameWithDetails =>
+  ({
+    id: 1n,
+    leagueid: 10n,
+    hteamid: 100n,
+    vteamid: 200n,
+    gamedate: new Date('2025-06-15T19:00:00Z'),
+    fieldid: null,
+    gamestatus: 1,
+    gametype: 0,
+    hscore: 3,
+    vscore: 2,
+    comment: '',
+    umpire1: null,
+    umpire2: null,
+    umpire3: null,
+    umpire4: null,
+    availablefields: null,
+    leagueseason: {
+      id: 10n,
+      seasonid: 5n,
+      leagueid: 1n,
+      league: {
+        id: 1n,
+        name: 'Summer League',
+        accountid: 99n,
+        divisiondefs: [],
+        scheduler: false,
+        sport: 0,
+        teamsperleague: 0,
+        leaguetype: 0,
+        inactive: false,
+        teamlimit: 0,
+        divisionlimit: 0,
+      },
+      season: {
+        id: 5n,
+        name: '2025 Season',
+        accountid: 99n,
+        schedulevisible: true,
+      },
+    },
+    _count: { gamerecap: 0 },
+    ...overrides,
+  }) as dbScheduleGameWithDetails;
+
+const teamNames = new Map<string, string>([
+  ['100', 'Home Team'],
+  ['200', 'Visitor Team'],
+]);
+
+describe('ScheduleResponseFormatter.formatGamesList teamsWithStats', () => {
+  it('lists both home and visitor team ids when both have stats', () => {
+    const statsMap = new Map<string, Set<string>>([['1', new Set(['100', '200'])]]);
+
+    const [game] = ScheduleResponseFormatter.formatGamesList([makeGame()], teamNames, statsMap);
+
+    expect(game.teamsWithStats).toEqual(['100', '200']);
+  });
+
+  it('lists only the team that has stats', () => {
+    const statsMap = new Map<string, Set<string>>([['1', new Set(['200'])]]);
+
+    const [game] = ScheduleResponseFormatter.formatGamesList([makeGame()], teamNames, statsMap);
+
+    expect(game.teamsWithStats).toEqual(['200']);
+  });
+
+  it('ignores team ids in the map that are not part of the game', () => {
+    const statsMap = new Map<string, Set<string>>([['1', new Set(['100', '999'])]]);
+
+    const [game] = ScheduleResponseFormatter.formatGamesList([makeGame()], teamNames, statsMap);
+
+    expect(game.teamsWithStats).toEqual(['100']);
+  });
+
+  it('returns undefined when the game has no stats entry', () => {
+    const statsMap = new Map<string, Set<string>>([['2', new Set(['100'])]]);
+
+    const [game] = ScheduleResponseFormatter.formatGamesList([makeGame()], teamNames, statsMap);
+
+    expect(game.teamsWithStats).toBeUndefined();
+  });
+
+  it('returns undefined when no stats map is provided', () => {
+    const [game] = ScheduleResponseFormatter.formatGamesList([makeGame()], teamNames);
+
+    expect(game.teamsWithStats).toBeUndefined();
+  });
+});

--- a/draco-nodejs/backend/src/responseFormatters/scheduleResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/scheduleResponseFormatter.ts
@@ -16,6 +16,23 @@ interface FormatGameOptions {
   homeTeamName?: string;
   visitorTeamName?: string;
   hasRecap?: boolean;
+  teamsWithStats?: string[];
+}
+
+function teamsWithStatsForGame(
+  homeTeamId: string,
+  visitorTeamId: string,
+  statsMap?: Map<string, Set<string>>,
+  gameId?: string,
+): string[] | undefined {
+  if (!statsMap || gameId === undefined) {
+    return undefined;
+  }
+  const teams = statsMap.get(gameId);
+  if (!teams || teams.size === 0) {
+    return undefined;
+  }
+  return [homeTeamId, visitorTeamId].filter((id) => teams.has(id));
 }
 
 export class ScheduleResponseFormatter {
@@ -59,6 +76,7 @@ export class ScheduleResponseFormatter {
       gameStatusShortText: getGameStatusShortText(game.gamestatus) as GameStatusShortEnumType,
       gameType: game.gametype,
       hasGameRecap: Boolean(options.hasRecap),
+      teamsWithStats: options.teamsWithStats,
       umpire1: game.umpire1 ? { id: game.umpire1.toString() } : undefined,
       umpire2: game.umpire2 ? { id: game.umpire2.toString() } : undefined,
       umpire3: game.umpire3 ? { id: game.umpire3.toString() } : undefined,
@@ -71,6 +89,7 @@ export class ScheduleResponseFormatter {
   static formatGameWithRecaps(
     game: dbScheduleGameWithRecaps,
     teamNames: Map<string, string>,
+    teamsWithStatsMap?: Map<string, Set<string>>,
   ): ScheduleGameWithRecapsType {
     const homeTeamId = game.hteamid.toString();
     const visitorTeamId = game.vteamid.toString();
@@ -79,6 +98,12 @@ export class ScheduleResponseFormatter {
       homeTeamName: teamNames.get(homeTeamId),
       visitorTeamName: teamNames.get(visitorTeamId),
       hasRecap: Boolean(game.gamerecap?.length),
+      teamsWithStats: teamsWithStatsForGame(
+        homeTeamId,
+        visitorTeamId,
+        teamsWithStatsMap,
+        game.id.toString(),
+      ),
     }) as ScheduleGameWithRecapsType;
 
     if (game.gamerecap?.length) {
@@ -96,16 +121,25 @@ export class ScheduleResponseFormatter {
   static formatGamesList(
     games: dbScheduleGameWithDetails[],
     teamNames: Map<string, string>,
+    teamsWithStatsMap?: Map<string, Set<string>>,
   ): GameType[] {
     return games.map((game) => {
       const recapCount = Number(
         (game as { _count?: { gamerecap?: number } })._count?.gamerecap ?? 0,
       );
+      const homeTeamId = game.hteamid.toString();
+      const visitorTeamId = game.vteamid.toString();
 
       return this.formatGame(game, {
-        homeTeamName: teamNames.get(game.hteamid.toString()),
-        visitorTeamName: teamNames.get(game.vteamid.toString()),
+        homeTeamName: teamNames.get(homeTeamId),
+        visitorTeamName: teamNames.get(visitorTeamId),
         hasRecap: recapCount > 0,
+        teamsWithStats: teamsWithStatsForGame(
+          homeTeamId,
+          visitorTeamId,
+          teamsWithStatsMap,
+          game.id.toString(),
+        ),
       });
     });
   }

--- a/draco-nodejs/backend/src/responseFormatters/statsResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/statsResponseFormatter.ts
@@ -256,7 +256,7 @@ export class StatsResponseFormatter {
     });
   }
 
-  static formatGameInfoResponse(game: dbGameInfo): GameTypeShared {
+  static formatGameInfoResponse(game: dbGameInfo, teamsWithStats?: string[]): GameTypeShared {
     const field = game.fieldid
       ? formatFieldFromAvailableField(
           game.availablefields ?? {
@@ -287,12 +287,13 @@ export class StatsResponseFormatter {
       gameStatus: game.gamestatus,
       field,
       hasGameRecap: Boolean(game._count?.gamerecap),
+      teamsWithStats: teamsWithStats && teamsWithStats.length > 0 ? teamsWithStats : undefined,
       gameType: game.gametype,
     };
   }
 
   /*
-      gameStatusText: 
+      gameStatusText:
       gameStatusShortText: g,
       
   */

--- a/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
@@ -52,6 +52,9 @@ class ScheduleRepositoryStub implements IScheduleRepository {
   findRecap = vi.fn<IScheduleRepository['findRecap']>();
   upsertRecap = vi.fn<IScheduleRepository['upsertRecap']>();
   getTeamNames = vi.fn<IScheduleRepository['getTeamNames']>();
+  getTeamsWithStatsByGameIds = vi.fn<IScheduleRepository['getTeamsWithStatsByGameIds']>(
+    async () => new Map(),
+  );
   listUpcomingGamesForTeam = vi.fn<IScheduleRepository['listUpcomingGamesForTeam']>();
   listRecentGamesForTeam = vi.fn<IScheduleRepository['listRecentGamesForTeam']>();
   listAllGamesForTeam = vi.fn<IScheduleRepository['listAllGamesForTeam']>();

--- a/draco-nodejs/backend/src/services/scheduleService.ts
+++ b/draco-nodejs/backend/src/services/scheduleService.ts
@@ -638,7 +638,10 @@ export class ScheduleService {
       teamIds.add(game.vteamid);
     }
 
-    const teamNames = await this.scheduleRepository.getTeamNames(Array.from(teamIds));
+    const [teamNames, teamsWithStatsMap] = await Promise.all([
+      this.scheduleRepository.getTeamNames(Array.from(teamIds)),
+      this.scheduleRepository.getTeamsWithStatsByGameIds(gamesArray.map((game) => game.id)),
+    ]);
 
     let formattedGames: GamesWithRecapsType['games'];
 
@@ -648,10 +651,14 @@ export class ScheduleService {
       );
 
       formattedGames = gamesWithRecaps.map((game) =>
-        ScheduleResponseFormatter.formatGameWithRecaps(game, teamNames),
+        ScheduleResponseFormatter.formatGameWithRecaps(game, teamNames, teamsWithStatsMap),
       );
     } else {
-      formattedGames = ScheduleResponseFormatter.formatGamesList(gamesArray, teamNames);
+      formattedGames = ScheduleResponseFormatter.formatGamesList(
+        gamesArray,
+        teamNames,
+        teamsWithStatsMap,
+      );
     }
 
     return {

--- a/draco-nodejs/backend/src/services/teamStatsService.ts
+++ b/draco-nodejs/backend/src/services/teamStatsService.ts
@@ -78,6 +78,18 @@ export class TeamStatsService {
       recentGamesPromise,
     ]);
 
+    const teamsWithStatsMap = await this.scheduleRepository.getTeamsWithStatsByGameIds(
+      recentGames.map((game) => game.id),
+    );
+
+    const teamsWithStatsForGame = (game: dbGameInfo): string[] | undefined => {
+      const teams = teamsWithStatsMap.get(game.id.toString());
+      if (!teams || teams.size === 0) {
+        return undefined;
+      }
+      return [game.hteamid.toString(), game.vteamid.toString()].filter((id) => teams.has(id));
+    };
+
     // Map games with team names (async)
     const result: RecentGamesType = {
       upcoming: [],
@@ -92,7 +104,7 @@ export class TeamStatsService {
 
     if (includeRecent) {
       result.recent = recentGames.map((game) =>
-        StatsResponseFormatter.formatGameInfoResponse(game),
+        StatsResponseFormatter.formatGameInfoResponse(game, teamsWithStatsForGame(game)),
       );
     }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/statistics/PlayerStatisticsClientWrapper.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/players/[playerId]/statistics/PlayerStatisticsClientWrapper.tsx
@@ -57,6 +57,7 @@ export default function PlayerStatisticsClientWrapper() {
         ) : null}
 
         <PlayerCareerStatisticsCard
+          accountId={accountId}
           stats={playerStats}
           loading={playerLoading}
           error={playerError}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule-management/ScheduleManagement.tsx
@@ -14,6 +14,7 @@ import { GameCardData } from '../../../../components/GameCard';
 import { getGameSummary } from '../../../../lib/utils';
 import { convertGameToGameCardData } from '../../../../utils/gameTransformers';
 import { useGameRecapFlow } from '../../../../hooks/useGameRecapFlow';
+import { useGameStatisticsFlow } from '../../../../hooks/useGameStatisticsFlow';
 import {
   useScheduleData,
   useScheduleFilters,
@@ -309,6 +310,12 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
     onRecapSaved: handleRecapSaved,
   });
 
+  const { openViewStatistics, dialogs: statsDialogs } = useGameStatisticsFlow<Game>({
+    accountId,
+    resolveSeasonId: (game) => game.season?.id ?? null,
+    getTeamName: (_game, teamId) => getTeamName(teamId),
+  });
+
   const { triggerPrint } = usePrintAction();
 
   const printTitle = currentSeasonName ? `Schedule — ${currentSeasonName}` : 'Schedule';
@@ -381,6 +388,7 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       timeZone={timeZone}
       convertGameToGameCardData={convertGameToGameCardDataWithTeams}
       onViewRecap={openViewRecap}
+      onViewStatistics={openViewStatistics}
       canEditSchedule={true}
       onEditGame={handleEditGame}
       onGameResults={handleGameResults}
@@ -507,6 +515,7 @@ const ScheduleManagement: React.FC<ScheduleManagementProps> = ({ accountId }) =>
       />
 
       {recapDialogs}
+      {statsDialogs}
 
       <SchedulePrintView games={filteredGames} title={printTitle} timeZone={timeZone} />
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -8,6 +8,7 @@ import { GameCardData } from '../../../../components/GameCard';
 import { getGameSummary } from '../../../../lib/utils';
 import { convertGameToGameCardData } from '../../../../utils/gameTransformers';
 import { useGameRecapFlow } from '../../../../hooks/useGameRecapFlow';
+import { useGameStatisticsFlow } from '../../../../hooks/useGameStatisticsFlow';
 import {
   useScheduleData,
   useScheduleFilters,
@@ -161,6 +162,12 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
     getTeamName: (_game, teamId) => getTeamName(teamId),
   });
 
+  const { openViewStatistics, dialogs: statsDialogs } = useGameStatisticsFlow<Game>({
+    accountId,
+    resolveSeasonId: (game) => game.season?.id ?? null,
+    getTeamName: (_game, teamId) => getTeamName(teamId),
+  });
+
   const { triggerPrint } = usePrintAction();
 
   const printTitle = currentSeasonName ? `${currentSeasonName} Schedule` : 'Schedule';
@@ -270,6 +277,7 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
       timeZone={timeZone}
       convertGameToGameCardData={convertGameToGameCardDataWithTeams}
       onViewRecap={openViewRecap}
+      onViewStatistics={openViewStatistics}
       onGameClick={handleGameClick}
       feedback={feedback}
       onFeedbackClose={handleFeedbackClose}
@@ -304,6 +312,7 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
       )}
 
       {recapDialogs}
+      {statsDialogs}
 
       <SchedulePrintView games={filteredGames} title={printTitle} timeZone={timeZone} />
     </ScheduleLayout>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -577,6 +577,17 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     </Button>
   );
 
+  const teamStatisticsButton = (
+    <Button
+      component={NextLink}
+      href={`/account/${accountId}/seasons/${seasonId}/teams/${teamSeasonId}/stat-entry`}
+      variant="outlined"
+      size="small"
+    >
+      Team Statistics
+    </Button>
+  );
+
   return (
     <main className="min-h-screen bg-background">
       {/* Account Header with Team Information */}
@@ -584,7 +595,15 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Box sx={{ flex: 1, textAlign: 'center' }}>
             <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexWrap: 'wrap',
+                  gap: 2,
+                }}
+              >
                 <TeamAvatar
                   name={teamData?.teamName || ''}
                   logoUrl={teamData?.logoUrl || undefined}
@@ -607,6 +626,11 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                     {teamData.teamName}
                   </Typography>
                 )}
+                {teamData?.leagueId ? (
+                  <Box sx={{ display: { xs: 'none', sm: 'inline-flex' } }}>
+                    {teamStatisticsButton}
+                  </Box>
+                ) : null}
               </Box>
               {teamData?.record && (
                 <Typography variant="h6" sx={{ color: 'text.secondary', fontWeight: 'medium' }}>
@@ -619,6 +643,11 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                   {teamData.seasonName} Season
                 </Typography>
               )}
+              {teamData?.leagueId ? (
+                <Box sx={{ display: { xs: 'flex', sm: 'none' }, justifyContent: 'center', mt: 1 }}>
+                  {teamStatisticsButton}
+                </Box>
+              ) : null}
             </Box>
           </Box>
         </Box>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -41,6 +41,7 @@ import { usePendingPhotoSubmissions } from '../../../../../../../hooks/usePendin
 import { usePhotoGallery } from '../../../../../../../hooks/usePhotoGallery';
 import PhotoGallerySection from '@/components/photo-gallery/PhotoGallerySection';
 import { useGameRecapFlow } from '../../../../../../../hooks/useGameRecapFlow';
+import { useGameStatisticsFlow } from '../../../../../../../hooks/useGameStatisticsFlow';
 import LeadersWidget from '../../../../../../../components/statistics/LeadersWidget';
 import SurveySpotlightWidget from '@/components/surveys/SurveySpotlightWidget';
 import SpecialAnnouncementsWidget from '@/components/announcements/SpecialAnnouncementsWidget';
@@ -386,6 +387,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
         : null,
       hasGameRecap: game.hasGameRecap ?? false,
       gameRecaps: [],
+      teamsWithStats: game.teamsWithStats ?? undefined,
       gameType: game.gameType ? Number(game.gameType) : undefined,
     });
 
@@ -467,6 +469,11 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     seasonId,
     fetchRecap: fetchRecapForTeam,
     onRecapSaved: handleRecapSaved,
+  });
+
+  const { openViewStatistics, dialogs: statsDialogs } = useGameStatisticsFlow<Game>({
+    accountId,
+    seasonId,
   });
 
   const handleOpenEditRecap = (game: Game) => {
@@ -922,6 +929,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                       canEditRecap={canEditRecap}
                       onEditRecap={handleOpenEditRecap}
                       onViewRecap={handleOpenViewRecap}
+                      onViewStatistics={openViewStatistics}
                       timeZone={timeZone}
                       accountId={accountId}
                       currentTeamSeasonId={teamSeasonId}
@@ -984,6 +992,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
       )}
 
       {recapDialogs}
+      {statsDialogs}
 
       <CreatePlayersWantedDialog
         accountId={accountId}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -17,6 +17,7 @@ import { GameCardData } from '../../../../../../../../components/GameCard';
 import { getGameSummary } from '../../../../../../../../lib/utils';
 import { convertGameToGameCardData } from '../../../../../../../../utils/gameTransformers';
 import { useGameRecapFlow } from '../../../../../../../../hooks/useGameRecapFlow';
+import { useGameStatisticsFlow } from '../../../../../../../../hooks/useGameStatisticsFlow';
 import { useSchedulePermissions } from '../../../../../../../../hooks/useSchedulePermissions';
 import {
   ScheduleLayout,
@@ -235,6 +236,11 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     fetchRecap: fetchRecapForTeam,
   });
 
+  const { openViewStatistics, dialogs: statsDialogs } = useGameStatisticsFlow<Game>({
+    accountId,
+    seasonId,
+  });
+
   const { triggerPrint } = usePrintAction();
 
   const printTitle = [teamName ?? 'Team', seasonName ?? ''].filter(Boolean).join(' — ');
@@ -381,6 +387,7 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
       canEditRecap={canEditRecap}
       onEditRecap={openEditRecap}
       onViewRecap={openViewRecap}
+      onViewStatistics={openViewStatistics}
       onGameClick={handleGameClick}
       feedback={feedback}
       onFeedbackClose={handleFeedbackClose}
@@ -414,6 +421,7 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
       />
 
       {recapDialogs}
+      {statsDialogs}
 
       <SchedulePrintView
         games={summaryGames}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PlayerCareerSearchTab.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PlayerCareerSearchTab.tsx
@@ -75,6 +75,7 @@ const PlayerCareerSearchTab: React.FC<PlayerCareerSearchTabProps> = ({ accountId
       ) : null}
 
       <PlayerCareerStatisticsCard
+        accountId={accountId}
         stats={playerStats}
         loading={playerLoading}
         error={playerError}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   Box,
+  Button,
   Card,
   CardContent,
   Typography,
@@ -17,6 +18,10 @@ import {
   Alert,
 } from '@mui/material';
 import StatisticsTable from '../../../../components/statistics/StatisticsTable';
+import GameListCard, { type SortOrder } from '@/components/team-stats-entry/GameListCard';
+import BattingStatsViewTable from '@/components/team-stats-entry/BattingStatsViewTable';
+import PitchingStatsViewTable from '@/components/team-stats-entry/PitchingStatsViewTable';
+import { TeamStatsEntryService } from '@/services/teamStatsEntryService';
 import { Team } from '@/types/schedule';
 import { useApiClient } from '@/hooks/useApiClient';
 import { unwrapApiResult } from '@/utils/apiResult';
@@ -30,8 +35,11 @@ import {
 } from '@draco/shared-api-client';
 import type {
   AllTimeTeamSummaryType,
+  GameBattingStatsType,
+  GamePitchingStatsType,
   PlayerBattingStatsType,
   PlayerPitchingStatsType,
+  TeamCompletedGameType,
 } from '@draco/shared-schemas';
 
 interface TabPanelProps {
@@ -77,6 +85,17 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
   const [battingSortOrder, setBattingSortOrder] = useState<'asc' | 'desc'>('desc');
   const [pitchingSortField, setPitchingSortField] = useState<keyof PlayerPitchingStatsType>('era');
   const [pitchingSortOrder, setPitchingSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [games, setGames] = useState<TeamCompletedGameType[]>([]);
+  const [gamesLoading, setGamesLoading] = useState(false);
+  const [gamesError, setGamesError] = useState<string | null>(null);
+  const [gameSortOrder, setGameSortOrder] = useState<SortOrder>('desc');
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+  const [displayedGame, setDisplayedGame] = useState<{
+    gameId: string;
+    batting: GameBattingStatsType;
+    pitching: GamePitchingStatsType;
+  } | null>(null);
+  const [gameStatsError, setGameStatsError] = useState<string | null>(null);
   const apiClient = useApiClient();
 
   const isAllTime = seasonId === '0';
@@ -259,6 +278,91 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
     };
   }, [accountId, seasonId, isAllTime, selectedTeamId, apiClient]);
 
+  useEffect(() => {
+    setGames([]);
+    setSelectedGameId(null);
+    setGamesError(null);
+
+    if (isAllTime || !selectedTeamId || !seasonId) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setGamesLoading(true);
+
+    const loadGames = async () => {
+      try {
+        const service = new TeamStatsEntryService(null, apiClient);
+        const data = await service.listCompletedGames(
+          accountId,
+          seasonId,
+          selectedTeamId,
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+        setGames(data);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setGamesError(err instanceof Error ? err.message : 'Failed to load completed games');
+        setGames([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setGamesLoading(false);
+        }
+      }
+    };
+
+    void loadGames();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, seasonId, isAllTime, selectedTeamId, apiClient]);
+
+  useEffect(() => {
+    if (!selectedGameId || !seasonId || !selectedTeamId) {
+      setDisplayedGame(null);
+      setGameStatsError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setGameStatsError(null);
+
+    const loadGameStats = async () => {
+      try {
+        const service = new TeamStatsEntryService(null, apiClient);
+        const [batting, pitching] = await Promise.all([
+          service.getGameBattingStats(
+            accountId,
+            seasonId,
+            selectedTeamId,
+            selectedGameId,
+            controller.signal,
+          ),
+          service.getGamePitchingStats(
+            accountId,
+            seasonId,
+            selectedTeamId,
+            selectedGameId,
+            controller.signal,
+          ),
+        ]);
+        if (controller.signal.aborted) return;
+        setDisplayedGame({ gameId: selectedGameId, batting, pitching });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setGameStatsError(err instanceof Error ? err.message : 'Failed to load game statistics');
+      }
+    };
+
+    void loadGameStats();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, seasonId, selectedTeamId, selectedGameId, apiClient]);
+
   const handleTeamChange = (event: SelectChangeEvent) => {
     const teamId = event.target.value;
     setSelectedTeamId(teamId);
@@ -344,6 +448,14 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
     return pitchingSortOrder === 'asc' ? aStr.localeCompare(bStr) : bStr.localeCompare(aStr);
   });
 
+  const sortedGames = [...games].sort((a, b) => {
+    const dateA = new Date(a.gameDate).getTime();
+    const dateB = new Date(b.gameDate).getTime();
+    return gameSortOrder === 'desc' ? dateB - dateA : dateA - dateB;
+  });
+
+  const showGameList = !isAllTime;
+
   if (error) {
     return (
       <Box p={3}>
@@ -397,45 +509,102 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
 
       {selectedTeamId && (
         <>
+          {showGameList && (
+            <Box sx={{ mb: 3 }}>
+              <GameListCard
+                games={sortedGames}
+                selectedGameId={selectedGameId}
+                onSelectGame={setSelectedGameId}
+                sortOrder={gameSortOrder}
+                onSortOrderChange={setGameSortOrder}
+                loading={gamesLoading}
+                error={gamesError}
+                canManageStats={false}
+              />
+            </Box>
+          )}
+
           {/* Tabs */}
           <Paper sx={{ width: '100%' }}>
-            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                borderBottom: 1,
+                borderColor: 'divider',
+                pr: 2,
+              }}
+            >
               <Tabs value={tabValue} onChange={handleTabChange} aria-label="team statistics tabs">
                 <Tab label="Batting" id="team-stats-tab-0" />
                 <Tab label="Pitching" id="team-stats-tab-1" />
               </Tabs>
+              {selectedGameId && (
+                <Button
+                  variant="text"
+                  size="small"
+                  onClick={() => {
+                    setSelectedGameId(null);
+                    setDisplayedGame(null);
+                  }}
+                  sx={{ textTransform: 'none' }}
+                >
+                  View season totals
+                </Button>
+              )}
             </Box>
 
+            {gameStatsError && (
+              <Alert severity="error" sx={{ m: 2 }}>
+                {gameStatsError}
+              </Alert>
+            )}
+
             <TabPanel value={tabValue} index={0}>
-              <StatisticsTable
-                variant="batting"
-                extendedStats={false}
-                data={sortedBattingStats}
-                loading={loading.batting}
-                emptyMessage="No batting statistics available"
-                getRowKey={(stat) => stat.playerId}
-                sortField={String(battingSortField)}
-                sortOrder={battingSortOrder}
-                onSort={(field) => handleBattingSort(field as keyof PlayerBattingStatsType)}
-                playerLinkLabel="Team Batting Stats"
-                omitFields={['teamName']}
-              />
+              {displayedGame ? (
+                <BattingStatsViewTable
+                  stats={displayedGame.batting}
+                  totals={displayedGame.batting.totals}
+                />
+              ) : (
+                <StatisticsTable
+                  variant="batting"
+                  extendedStats={false}
+                  data={sortedBattingStats}
+                  loading={loading.batting}
+                  emptyMessage="No batting statistics available"
+                  getRowKey={(stat) => stat.playerId}
+                  sortField={String(battingSortField)}
+                  sortOrder={battingSortOrder}
+                  onSort={(field) => handleBattingSort(field as keyof PlayerBattingStatsType)}
+                  playerLinkLabel="Team Batting Stats"
+                  omitFields={['teamName']}
+                />
+              )}
             </TabPanel>
 
             <TabPanel value={tabValue} index={1}>
-              <StatisticsTable
-                variant="pitching"
-                extendedStats={false}
-                data={sortedPitchingStats}
-                loading={loading.pitching}
-                emptyMessage="No pitching statistics available"
-                getRowKey={(stat) => stat.playerId}
-                sortField={String(pitchingSortField)}
-                sortOrder={pitchingSortOrder}
-                onSort={(field) => handlePitchingSort(field as keyof PlayerPitchingStatsType)}
-                playerLinkLabel="Team Pitching Stats"
-                omitFields={['teamName']}
-              />
+              {displayedGame ? (
+                <PitchingStatsViewTable
+                  stats={displayedGame.pitching}
+                  totals={displayedGame.pitching.totals}
+                />
+              ) : (
+                <StatisticsTable
+                  variant="pitching"
+                  extendedStats={false}
+                  data={sortedPitchingStats}
+                  loading={loading.pitching}
+                  emptyMessage="No pitching statistics available"
+                  getRowKey={(stat) => stat.playerId}
+                  sortField={String(pitchingSortField)}
+                  sortOrder={pitchingSortOrder}
+                  onSort={(field) => handlePitchingSort(field as keyof PlayerPitchingStatsType)}
+                  playerLinkLabel="Team Pitching Stats"
+                  omitFields={['teamName']}
+                />
+              )}
             </TabPanel>
           </Paper>
         </>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -284,6 +284,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
     setGamesError(null);
 
     if (isAllTime || !selectedTeamId || !seasonId) {
+      setGamesLoading(false);
       return;
     }
 

--- a/draco-nodejs/frontend-next/components/GameCard.tsx
+++ b/draco-nodejs/frontend-next/components/GameCard.tsx
@@ -26,6 +26,7 @@ import { getGameStatusShortText } from '../utils/gameUtils';
 import { formatDateInTimezone, formatGameTime } from '../utils/dateUtils';
 import { DEFAULT_TIMEZONE } from '../utils/timezones';
 import RecapButton from './RecapButton';
+import StatisticsButton from './StatisticsButton';
 import { GameStatus, GameType } from '../types/schedule';
 import FieldDetailsCard, { FieldDetails } from './fields/FieldDetailsCard';
 import AccountOptional from './account/AccountOptional';
@@ -70,6 +71,7 @@ export interface GameCardData {
   fieldDetails?: FieldDetails | null;
   hasGameRecap: boolean;
   gameRecaps: Array<{ teamId: string; recap: string }>;
+  teamsWithStats?: string[];
   comment?: string;
   gameType?: number;
   // Sport-specific extensions
@@ -85,6 +87,7 @@ export interface GameCardProps {
   canEditRecap?: (game: GameCardData) => boolean;
   onEditRecap?: (game: GameCardData) => void;
   onViewRecap?: (game: GameCardData) => void;
+  onViewStatistics?: (game: GameCardData) => void;
   onClick?: (game: GameCardData) => void;
   showActions?: boolean;
   compact?: boolean;
@@ -113,6 +116,7 @@ const GameCard: React.FC<GameCardProps> = ({
   canEditRecap,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   onClick,
   showActions = true,
   compact = false,
@@ -237,6 +241,13 @@ const GameCard: React.FC<GameCardProps> = ({
 
     if (onViewRecap) {
       onViewRecap(game);
+    }
+  };
+
+  const handleStatsClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onViewStatistics) {
+      onViewStatistics(game);
     }
   };
 
@@ -588,6 +599,9 @@ const GameCard: React.FC<GameCardProps> = ({
                     </Tooltip>
                   )}
                   <RecapButton game={game} onRecapClick={handleRecapClick} {...recapButtonProps} />
+                  {onViewStatistics && (
+                    <StatisticsButton game={game} onStatsClick={handleStatsClick} />
+                  )}
                 </Box>
               )}
             </Box>
@@ -826,6 +840,9 @@ const GameCard: React.FC<GameCardProps> = ({
                   )}
                 {showActions && (
                   <RecapButton game={game} onRecapClick={handleRecapClick} {...recapButtonProps} />
+                )}
+                {showActions && onViewStatistics && (
+                  <StatisticsButton game={game} onStatsClick={handleStatsClick} />
                 )}
               </Box>
             </Box>

--- a/draco-nodejs/frontend-next/components/GameListDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/GameListDisplay.tsx
@@ -30,6 +30,7 @@ export interface GameListDisplayProps {
   canEditRecap?: (game: Game) => boolean;
   onEditRecap?: (game: Game) => void;
   onViewRecap?: (game: Game) => void;
+  onViewStatistics?: (game: Game) => void;
   layout?: 'vertical' | 'horizontal';
   timeZone?: string;
   accent?: WidgetAccent | 'none';
@@ -50,6 +51,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
   canEditRecap,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   layout = 'vertical',
   timeZone = DEFAULT_TIMEZONE,
   accent = 'warning',
@@ -230,6 +232,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
                           canEditRecap={canEditRecap}
                           onEditRecap={onEditRecap}
                           onViewRecap={onViewRecap}
+                          onViewStatistics={onViewStatistics}
                           fitContent={true}
                           timeZone={timeZone}
                           hasLiveSession={liveSessionGameIds?.has(game.id)}
@@ -250,6 +253,7 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
                             canEditRecap={canEditRecap}
                             onEditRecap={onEditRecap}
                             onViewRecap={onViewRecap}
+                            onViewStatistics={onViewStatistics}
                             timeZone={timeZone}
                             hasLiveSession={liveSessionGameIds?.has(game.id)}
                             canStartLiveScoring={canStartLiveScoring?.(game)}

--- a/draco-nodejs/frontend-next/components/GameStatisticsDialog.tsx
+++ b/draco-nodejs/frontend-next/components/GameStatisticsDialog.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import type { GameBattingStatsType, GamePitchingStatsType } from '@draco/shared-schemas';
+
+import { useApiClient } from '@/hooks/useApiClient';
+import { TeamStatsEntryService } from '../services/teamStatsEntryService';
+import BattingStatsViewTable from './team-stats-entry/BattingStatsViewTable';
+import PitchingStatsViewTable from './team-stats-entry/PitchingStatsViewTable';
+
+interface GameStatisticsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  accountId: string;
+  seasonId: string;
+  gameId: string;
+  teamSeasonId: string;
+  teamName?: string;
+  gameDate?: string;
+  homeScore?: number;
+  visitorScore?: number;
+  homeTeamName?: string;
+  visitorTeamName?: string;
+}
+
+const GameStatisticsDialog: React.FC<GameStatisticsDialogProps> = ({
+  open,
+  onClose,
+  accountId,
+  seasonId,
+  gameId,
+  teamSeasonId,
+  teamName,
+  gameDate,
+  homeScore,
+  visitorScore,
+  homeTeamName,
+  visitorTeamName,
+}) => {
+  const theme = useTheme();
+  const apiClient = useApiClient();
+
+  const [battingStats, setBattingStats] = useState<GameBattingStatsType | null>(null);
+  const [pitchingStats, setPitchingStats] = useState<GamePitchingStatsType | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const service = new TeamStatsEntryService(null, apiClient);
+
+    const loadStats = async () => {
+      setLoading(true);
+      setError(null);
+      setBattingStats(null);
+      setPitchingStats(null);
+
+      try {
+        const [batting, pitching] = await Promise.all([
+          service.getGameBattingStats(accountId, seasonId, teamSeasonId, gameId, controller.signal),
+          service.getGamePitchingStats(
+            accountId,
+            seasonId,
+            teamSeasonId,
+            gameId,
+            controller.signal,
+          ),
+        ]);
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setBattingStats(batting);
+        setPitchingStats(pitching);
+      } catch (err: unknown) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'Failed to load game statistics');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadStats();
+
+    return () => {
+      controller.abort();
+    };
+  }, [open, accountId, seasonId, teamSeasonId, gameId, apiClient]);
+
+  const formattedGameDate = gameDate
+    ? Number.isNaN(new Date(gameDate).getTime())
+      ? gameDate
+      : new Date(gameDate).toLocaleDateString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+        })
+    : null;
+
+  const scoreboardLine =
+    homeScore !== undefined && visitorScore !== undefined && homeTeamName && visitorTeamName
+      ? `${visitorTeamName} ${visitorScore} at ${homeTeamName} ${homeScore}`
+      : null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      PaperProps={{
+        sx: {
+          bgcolor: theme.palette.widget.surface,
+          color: theme.palette.text.primary,
+          borderRadius: 2,
+          boxShadow: theme.shadows[theme.palette.mode === 'dark' ? 12 : 4],
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          fontWeight: 700,
+          color: theme.palette.widget.headerText,
+        }}
+      >
+        Game Statistics{teamName ? ` for ${teamName}` : ''}
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        {formattedGameDate && (
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            {formattedGameDate}
+          </Typography>
+        )}
+        {scoreboardLine && (
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            {scoreboardLine}
+          </Typography>
+        )}
+
+        {loading ? (
+          <Box
+            sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 260 }}
+          >
+            <CircularProgress size={32} />
+          </Box>
+        ) : error ? (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 1 }}>
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+                Batting
+              </Typography>
+              <BattingStatsViewTable stats={battingStats} totals={battingStats?.totals ?? null} />
+            </Box>
+            <Box>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+                Pitching
+              </Typography>
+              <PitchingStatsViewTable
+                stats={pitchingStats}
+                totals={pitchingStats?.totals ?? null}
+              />
+            </Box>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="secondary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default GameStatisticsDialog;

--- a/draco-nodejs/frontend-next/components/ScoreboardBase.tsx
+++ b/draco-nodejs/frontend-next/components/ScoreboardBase.tsx
@@ -13,6 +13,7 @@ import { GameStatus } from '../types/schedule';
 import { useAuth } from '../context/AuthContext';
 import { getGameSummary } from '../lib/utils';
 import { useGameRecapFlow } from '../hooks/useGameRecapFlow';
+import { useGameStatisticsFlow } from '../hooks/useGameStatisticsFlow';
 
 interface ScoreboardBaseProps {
   accountId: string;
@@ -148,6 +149,18 @@ const ScoreboardBase: React.FC<ScoreboardBaseProps> = ({
     getTeamName: (game, teamSeasonId) =>
       teamSeasonId === game.homeTeamId ? game.homeTeamName : game.visitorTeamName,
     onRecapSaved: handleRecapSaved,
+  });
+
+  const {
+    openViewStatistics,
+    dialogs: statsDialogs,
+    error: statsError,
+    clearError: clearStatsError,
+  } = useGameStatisticsFlow<Game>({
+    accountId,
+    seasonId: currentSeasonId,
+    getTeamName: (game, teamSeasonId) =>
+      teamSeasonId === game.homeTeamId ? game.homeTeamName : game.visitorTeamName,
   });
 
   const handleOpenEditRecap = (game: Game) => {
@@ -308,6 +321,11 @@ const ScoreboardBase: React.FC<ScoreboardBaseProps> = ({
           {recapError}
         </Alert>
       )}
+      {statsError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={clearStatsError}>
+          {statsError}
+        </Alert>
+      )}
       <GameListDisplay
         sections={sections}
         canEditGames={canEditGames}
@@ -315,6 +333,7 @@ const ScoreboardBase: React.FC<ScoreboardBaseProps> = ({
         canEditRecap={canEditRecap}
         onEditRecap={handleOpenEditRecap}
         onViewRecap={handleOpenViewRecap}
+        onViewStatistics={openViewStatistics}
         layout={layout}
         timeZone={timeZone}
         liveSessionGameIds={liveSessionGameIds}
@@ -333,6 +352,7 @@ const ScoreboardBase: React.FC<ScoreboardBaseProps> = ({
         />
       )}
       {recapDialogs}
+      {statsDialogs}
     </>
   );
 

--- a/draco-nodejs/frontend-next/components/StatisticsButton.tsx
+++ b/draco-nodejs/frontend-next/components/StatisticsButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import { GameCardData } from './GameCard';
+import { GameStatus } from '../types/schedule';
+
+interface StatisticsButtonProps {
+  game: GameCardData;
+  onStatsClick: (e: React.MouseEvent) => void;
+  sx?: object;
+}
+
+const StatisticsButton: React.FC<StatisticsButtonProps> = ({ game, onStatsClick, sx = {} }) => {
+  if (game.gameStatus !== GameStatus.Completed) {
+    return null;
+  }
+
+  if ((game.teamsWithStats?.length ?? 0) === 0) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="View Game Statistics">
+      <IconButton
+        size="small"
+        onClick={onStatsClick}
+        sx={{
+          color: 'primary.main',
+          p: 0.5,
+          '&:hover': {
+            color: 'primary.dark',
+            bgcolor: 'action.hover',
+          },
+          ...sx,
+        }}
+      >
+        <BarChartIcon sx={{ fontSize: 18 }} />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default StatisticsButton;

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -58,6 +58,7 @@ export interface ScheduleLayoutProps {
   timeZone: string;
   convertGameToGameCardData: (game: Game) => GameCardData;
   onViewRecap?: (game: Game) => void;
+  onViewStatistics?: (game: Game) => void;
   canEditSchedule?: boolean;
   onGameClick?: (game: Game) => void;
   onEditGame?: (game: Game) => void;
@@ -105,6 +106,7 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
   timeZone,
   convertGameToGameCardData,
   onViewRecap,
+  onViewStatistics,
   canEditSchedule = false,
   onGameClick,
   onEditGame,
@@ -273,6 +275,7 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
             onGameResults={onGameResults ?? (() => {})}
             onEditRecap={onEditRecap}
             onViewRecap={onViewRecap}
+            onViewStatistics={onViewStatistics}
             convertGameToGameCardData={convertGameToGameCardData}
             canEditRecap={canEditRecap}
             filterDate={filterDate}

--- a/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
@@ -35,6 +35,7 @@ export interface CalendarGridProps {
   onZoomClick?: (weekStartDate: Date) => void;
   onEditRecap?: (game: Game) => void;
   onViewRecap?: (game: Game) => void;
+  onViewStatistics?: (game: Game) => void;
 
   // Game card conversion
   convertGameToGameCardData: (game: Game) => GameCardData;
@@ -76,6 +77,7 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
   onZoomClick,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   convertGameToGameCardData,
   canEditSchedule,
   canEditRecap,
@@ -335,9 +337,11 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                           {getGamesForDay(day).length > 0 ? (
                             getGamesForDay(day).map((game) => {
                               const gameCardData = convertGameToGameCardData(game);
+                              const hasStats = (gameCardData.teamsWithStats?.length ?? 0) > 0;
                               const showActions =
                                 canEditSchedule ||
                                 (onViewRecap && gameCardData.hasGameRecap) ||
+                                (onViewStatistics && hasStats) ||
                                 (canEditRecap?.(gameCardData) ?? false);
 
                               return (
@@ -376,6 +380,11 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                                     onViewRecap={
                                       onViewRecap && gameCardData.hasGameRecap
                                         ? () => onViewRecap(game)
+                                        : undefined
+                                    }
+                                    onViewStatistics={
+                                      onViewStatistics && hasStats
+                                        ? () => onViewStatistics(game)
                                         : undefined
                                     }
                                     showActions={showActions}
@@ -477,9 +486,11 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                     {getGamesForDay(day).length > 0 ? (
                       getGamesForDay(day).map((game) => {
                         const gameCardData = convertGameToGameCardData(game);
+                        const hasStats = (gameCardData.teamsWithStats?.length ?? 0) > 0;
                         const showActions =
                           canEditSchedule ||
                           (onViewRecap && gameCardData.hasGameRecap) ||
+                          (onViewStatistics && hasStats) ||
                           (canEditRecap?.(gameCardData) ?? false);
 
                         return (
@@ -515,6 +526,11 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                               onViewRecap={
                                 onViewRecap && gameCardData.hasGameRecap
                                   ? () => onViewRecap(game)
+                                  : undefined
+                              }
+                              onViewStatistics={
+                                onViewStatistics && hasStats
+                                  ? () => onViewStatistics(game)
                                   : undefined
                               }
                               showActions={showActions}

--- a/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
@@ -25,6 +25,7 @@ const DayListView: React.FC<DayListViewProps> = ({
   onGameResults,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   convertGameToGameCardData,
   timeZone,
   filterType,
@@ -133,9 +134,11 @@ const DayListView: React.FC<DayListViewProps> = ({
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {dayGames.map((game) => {
           const gameCardData = convertGameToGameCardData(game);
+          const hasStats = (gameCardData.teamsWithStats?.length ?? 0) > 0;
           const showActions =
             canEditSchedule ||
             (onViewRecap && gameCardData.hasGameRecap) ||
+            (onViewStatistics && hasStats) ||
             (canEditRecap?.(gameCardData) ?? false);
 
           return (
@@ -153,6 +156,9 @@ const DayListView: React.FC<DayListViewProps> = ({
               onEditRecap={canEditRecap && onEditRecap ? () => onEditRecap(game) : undefined}
               onViewRecap={
                 onViewRecap && gameCardData.hasGameRecap ? () => onViewRecap(game) : undefined
+              }
+              onViewStatistics={
+                onViewStatistics && hasStats ? () => onViewStatistics(game) : undefined
               }
               showActions={showActions}
               timeZone={timeZone}
@@ -236,9 +242,11 @@ const DayListView: React.FC<DayListViewProps> = ({
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {games.map((game) => {
                   const gameCardData = convertGameToGameCardData(game);
+                  const hasStats = (gameCardData.teamsWithStats?.length ?? 0) > 0;
                   const showActions =
                     canEditSchedule ||
                     (onViewRecap && gameCardData.hasGameRecap) ||
+                    (onViewStatistics && hasStats) ||
                     (canEditRecap?.(gameCardData) ?? false);
 
                   return (
@@ -260,6 +268,9 @@ const DayListView: React.FC<DayListViewProps> = ({
                         onViewRecap && gameCardData.hasGameRecap
                           ? () => onViewRecap(game)
                           : undefined
+                      }
+                      onViewStatistics={
+                        onViewStatistics && hasStats ? () => onViewStatistics(game) : undefined
                       }
                       showActions={showActions}
                       timeZone={timeZone}

--- a/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
@@ -22,6 +22,7 @@ const MonthView: React.FC<ViewComponentProps> = ({
   onGameResults,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   convertGameToGameCardData,
   timeZone,
   filterType,
@@ -103,6 +104,7 @@ const MonthView: React.FC<ViewComponentProps> = ({
         onGameResults={onGameResults}
         onEditRecap={onEditRecap}
         onViewRecap={onViewRecap}
+        onViewStatistics={onViewStatistics}
         onZoomClick={(weekStartDate) => {
           setFilterType('week');
           setFilterDate(weekStartDate);

--- a/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
@@ -14,6 +14,7 @@ const WeekView: React.FC<ViewComponentProps> = ({
   onGameResults,
   onEditRecap,
   onViewRecap,
+  onViewStatistics,
   convertGameToGameCardData,
   timeZone,
   filterType,
@@ -94,6 +95,7 @@ const WeekView: React.FC<ViewComponentProps> = ({
         onGameResults={onGameResults}
         onEditRecap={onEditRecap}
         onViewRecap={onViewRecap}
+        onViewStatistics={onViewStatistics}
         convertGameToGameCardData={convertGameToGameCardData}
         canEditSchedule={canEditSchedule}
         canEditRecap={canEditRecap}

--- a/draco-nodejs/frontend-next/components/statistics/PlayerCareerStatisticsCard.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/PlayerCareerStatisticsCard.tsx
@@ -100,7 +100,9 @@ const buildCareerPrependColumns = <
             },
           }}
         >
-          <Link href={`/account/${accountId}/seasons/${seasonId}/teams/${teamId}`}>{label}</Link>
+          <Link href={`/account/${accountId}/seasons/${seasonId}/teams/${teamId}`} prefetch={false}>
+            {label}
+          </Link>
         </Box>
       );
     },

--- a/draco-nodejs/frontend-next/components/statistics/PlayerCareerStatisticsCard.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/PlayerCareerStatisticsCard.tsx
@@ -10,6 +10,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
+import Link from 'next/link';
 import StatisticsTable, { type ColumnConfig, type StatsRowBase } from './StatisticsTable';
 import type {
   PlayerCareerBattingRowType,
@@ -20,6 +21,7 @@ import type {
 type CareerTab = 'batting' | 'pitching';
 
 interface PlayerCareerStatisticsCardProps {
+  accountId: string;
   stats: PlayerCareerStatisticsType | null;
   loading?: boolean;
   error?: string | null;
@@ -32,8 +34,12 @@ const buildCareerPrependColumns = <
     seasonName?: string | null;
     leagueName?: string | null;
     teamName?: string | null;
+    teamId?: string | null;
+    seasonId?: string | null;
   },
->(): ColumnConfig<T>[] => {
+>(
+  accountId: string,
+): ColumnConfig<T>[] => {
   const seasonColumn: ColumnConfig<T> = {
     field: 'seasonName' as keyof T & string,
     label: 'Season',
@@ -72,11 +78,31 @@ const buildCareerPrependColumns = <
         return '—';
       }
 
-      if (league && team) {
-        return `${league} ${team}`;
+      const label = league && team ? `${league} ${team}` : (team ?? league ?? '—');
+      const teamId = row.teamId ?? undefined;
+      const seasonId = row.seasonId ?? undefined;
+
+      if (!team || !teamId || !seasonId) {
+        return label;
       }
 
-      return league ?? team ?? '—';
+      return (
+        <Box
+          component="span"
+          sx={{
+            '& a': {
+              color: 'primary.main',
+              textDecoration: 'none',
+              fontWeight: 600,
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            },
+          }}
+        >
+          <Link href={`/account/${accountId}/seasons/${seasonId}/teams/${teamId}`}>{label}</Link>
+        </Box>
+      );
     },
   };
 
@@ -97,6 +123,7 @@ const getRowKey = (
 };
 
 const PlayerCareerStatisticsCard: React.FC<PlayerCareerStatisticsCardProps> = ({
+  accountId,
   stats,
   loading = false,
   error = null,
@@ -112,9 +139,9 @@ const PlayerCareerStatisticsCard: React.FC<PlayerCareerStatisticsCardProps> = ({
 
   const pitchingRows: PlayerCareerPitchingRowType[] = stats?.pitching.rows ?? [];
 
-  const battingPrependColumns = buildCareerPrependColumns<PlayerCareerBattingRowType>();
+  const battingPrependColumns = buildCareerPrependColumns<PlayerCareerBattingRowType>(accountId);
 
-  const pitchingPrependColumns = buildCareerPrependColumns<PlayerCareerPitchingRowType>();
+  const pitchingPrependColumns = buildCareerPrependColumns<PlayerCareerPitchingRowType>(accountId);
 
   if (loading) {
     return (

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
@@ -106,8 +106,9 @@ describe('PlayerCareerStatisticsCard team links', () => {
 
     render(<PlayerCareerStatisticsCard accountId={ACCOUNT_ID} stats={stats} />);
 
-    expect(screen.getByText(/Multiple Teams/)).toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    const multipleTeams = screen.getByText(/Multiple Teams/);
+    expect(multipleTeams).toBeInTheDocument();
+    expect(multipleTeams.closest('a')).toBeNull();
   });
 
   it('renders distinct links per historical team-season', () => {

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { PlayerCareerBattingRowType, PlayerCareerStatisticsType } from '@draco/shared-schemas';
+import PlayerCareerStatisticsCard from '../PlayerCareerStatisticsCard';
+
+const mockResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+vi.stubGlobal('ResizeObserver', mockResizeObserver);
+
+const ACCOUNT_ID = '1';
+
+const buildBattingRow = (
+  overrides: Partial<PlayerCareerBattingRowType>,
+): PlayerCareerBattingRowType => ({
+  playerId: '100',
+  playerName: 'Casey Jones',
+  teamName: '',
+  ab: 10,
+  h: 4,
+  r: 2,
+  d: 1,
+  t: 0,
+  hr: 1,
+  rbi: 3,
+  bb: 2,
+  so: 1,
+  hbp: 0,
+  sb: 0,
+  sf: 0,
+  sh: 0,
+  avg: 0.4,
+  obp: 0.5,
+  slg: 0.8,
+  ops: 1.3,
+  tb: 8,
+  pa: 12,
+  level: 'team',
+  ...overrides,
+});
+
+const buildStats = (rows: PlayerCareerBattingRowType[]): PlayerCareerStatisticsType => ({
+  playerId: '100',
+  playerName: 'Casey Jones',
+  playerNumber: '7',
+  photoUrl: null,
+  batting: { rows },
+  pitching: { rows: [] },
+});
+
+describe('PlayerCareerStatisticsCard team links', () => {
+  it('renders a team-level row team name as a link to the team-season page', () => {
+    const stats = buildStats([
+      buildBattingRow({
+        level: 'team',
+        seasonId: '2024',
+        seasonName: '2024',
+        leagueId: '50',
+        leagueName: 'Premier',
+        teamId: '900',
+        teamName: 'Sharks',
+      }),
+    ]);
+
+    render(<PlayerCareerStatisticsCard accountId={ACCOUNT_ID} stats={stats} />);
+
+    const link = screen.getByRole('link', { name: 'Premier Sharks' });
+    expect(link).toHaveAttribute('href', `/account/${ACCOUNT_ID}/seasons/2024/teams/900`);
+  });
+
+  it('does not link the career-totals row', () => {
+    const stats = buildStats([
+      buildBattingRow({
+        level: 'career',
+        seasonId: null,
+        seasonName: null,
+        leagueId: null,
+        leagueName: null,
+        teamId: null,
+        teamName: 'All Teams',
+        isTotals: true,
+      }),
+    ]);
+
+    render(<PlayerCareerStatisticsCard accountId={ACCOUNT_ID} stats={stats} />);
+
+    expect(screen.getByText('All Teams')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'All Teams' })).not.toBeInTheDocument();
+  });
+
+  it('does not link a season-aggregate row that has no teamId', () => {
+    const stats = buildStats([
+      buildBattingRow({
+        level: 'season',
+        seasonId: '2024',
+        seasonName: '2024',
+        leagueId: '50',
+        leagueName: 'Premier',
+        teamId: null,
+        teamName: 'Multiple Teams',
+      }),
+    ]);
+
+    render(<PlayerCareerStatisticsCard accountId={ACCOUNT_ID} stats={stats} />);
+
+    expect(screen.getByText(/Multiple Teams/)).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders distinct links per historical team-season', () => {
+    const stats = buildStats([
+      buildBattingRow({
+        level: 'team',
+        seasonId: '2023',
+        seasonName: '2023',
+        leagueId: '50',
+        leagueName: 'Premier',
+        teamId: '800',
+        teamName: 'Sharks',
+      }),
+      buildBattingRow({
+        level: 'team',
+        seasonId: '2024',
+        seasonName: '2024',
+        leagueId: '50',
+        leagueName: 'Premier',
+        teamId: '900',
+        teamName: 'Sharks',
+      }),
+    ]);
+
+    render(<PlayerCareerStatisticsCard accountId={ACCOUNT_ID} stats={stats} />);
+
+    const links = screen.getAllByRole('link', { name: 'Premier Sharks' });
+    const hrefs = links.map((link) => link.getAttribute('href'));
+    expect(hrefs).toContain(`/account/${ACCOUNT_ID}/seasons/2023/teams/800`);
+    expect(hrefs).toContain(`/account/${ACCOUNT_ID}/seasons/2024/teams/900`);
+  });
+});

--- a/draco-nodejs/frontend-next/hooks/__tests__/useGameStatisticsFlow.test.tsx
+++ b/draco-nodejs/frontend-next/hooks/__tests__/useGameStatisticsFlow.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { dracoTheme } from '../../theme';
+import type { Game } from '../../components/GameListDisplay';
+import { GameStatus } from '../../types/schedule';
+import {
+  type UseGameStatisticsFlowParams,
+  type UseGameStatisticsFlowResult,
+  useGameStatisticsFlow,
+} from '../useGameStatisticsFlow';
+
+vi.mock('../../components/GameStatisticsDialog', () => ({
+  default: ({ open, teamName }: { open: boolean; teamName?: string }) =>
+    open ? <div data-testid="stats-dialog">StatsDialog:{teamName}</div> : null,
+}));
+
+const baseGame: Game = {
+  id: 'game-1',
+  date: '2024-01-20T18:00:00Z',
+  homeTeamId: 'home-team',
+  visitorTeamId: 'visitor-team',
+  homeTeamName: 'Home Team',
+  visitorTeamName: 'Visitor Team',
+  homeScore: 3,
+  visitorScore: 2,
+  gameStatus: GameStatus.Completed,
+  gameStatusText: 'Final',
+  leagueName: 'League',
+  fieldId: null,
+  fieldName: null,
+  fieldShortName: null,
+  hasGameRecap: false,
+  gameRecaps: [],
+};
+
+interface HookHarnessProps {
+  params: UseGameStatisticsFlowParams<Game>;
+}
+
+const HookHarness = React.forwardRef<UseGameStatisticsFlowResult<Game>, HookHarnessProps>(
+  ({ params }, ref) => {
+    const result = useGameStatisticsFlow<Game>(params);
+    React.useImperativeHandle(ref, () => result, [result]);
+
+    return <ThemeProvider theme={dracoTheme}>{result.dialogs}</ThemeProvider>;
+  },
+);
+HookHarness.displayName = 'HookHarness';
+
+const baseParams: UseGameStatisticsFlowParams<Game> = {
+  accountId: 'account-1',
+  seasonId: 'season-1',
+  getTeamName: (game, teamId) =>
+    teamId === game.homeTeamId ? game.homeTeamName : game.visitorTeamName,
+};
+
+describe('useGameStatisticsFlow', () => {
+  it('reports an error and shows neither dialog nor picker when no team has stats', async () => {
+    const hookRef = React.createRef<UseGameStatisticsFlowResult<Game>>();
+    render(<HookHarness ref={hookRef} params={baseParams} />);
+
+    await act(async () => {
+      hookRef.current?.openViewStatistics({ ...baseGame, teamsWithStats: [] });
+    });
+
+    expect(hookRef.current?.error).toBe('No statistics available for this game.');
+    expect(screen.queryByTestId('stats-dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select Team Statistics to View')).not.toBeInTheDocument();
+  });
+
+  it('opens the stats dialog directly when only one team has stats', async () => {
+    const hookRef = React.createRef<UseGameStatisticsFlowResult<Game>>();
+    render(<HookHarness ref={hookRef} params={baseParams} />);
+
+    await act(async () => {
+      hookRef.current?.openViewStatistics({
+        ...baseGame,
+        teamsWithStats: [baseGame.visitorTeamId],
+      });
+    });
+
+    expect(screen.getByTestId('stats-dialog')).toHaveTextContent('StatsDialog:Visitor Team');
+    expect(screen.queryByText('Select Team Statistics to View')).not.toBeInTheDocument();
+  });
+
+  it('prompts for team selection when both teams have stats, then opens the chosen team', async () => {
+    const hookRef = React.createRef<UseGameStatisticsFlowResult<Game>>();
+    render(<HookHarness ref={hookRef} params={baseParams} />);
+
+    await act(async () => {
+      hookRef.current?.openViewStatistics({
+        ...baseGame,
+        teamsWithStats: [baseGame.homeTeamId, baseGame.visitorTeamId],
+      });
+    });
+
+    expect(screen.getByText('Select Team Statistics to View')).toBeInTheDocument();
+    expect(screen.getByText('Home Team')).toBeInTheDocument();
+    expect(screen.getByText('Visitor Team')).toBeInTheDocument();
+    expect(screen.queryByTestId('stats-dialog')).not.toBeInTheDocument();
+
+    await act(async () => {
+      screen.getByText('Home Team').click();
+    });
+
+    expect(screen.getByTestId('stats-dialog')).toHaveTextContent('StatsDialog:Home Team');
+  });
+});

--- a/draco-nodejs/frontend-next/hooks/useGameStatisticsFlow.tsx
+++ b/draco-nodejs/frontend-next/hooks/useGameStatisticsFlow.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import MuiButton from '@mui/material/Button';
+import GameStatisticsDialog from '../components/GameStatisticsDialog';
+import { GameStatus } from '@/types/schedule';
+
+export interface StatisticsGameBase {
+  id: string;
+  homeTeamId: string;
+  homeTeamName?: string;
+  visitorTeamId: string;
+  visitorTeamName?: string;
+  teamsWithStats?: string[];
+  gameStatus?: number;
+  date?: string;
+  gameDate?: string;
+  homeScore?: number;
+  visitorScore?: number;
+  seasonId?: string;
+  season?: {
+    id?: string | null;
+  } | null;
+}
+
+interface StatisticsSelectionOption {
+  id: string;
+  name: string;
+}
+
+interface StatisticsSelectionState<GameType extends StatisticsGameBase> {
+  game: GameType;
+  options: StatisticsSelectionOption[];
+}
+
+interface StatisticsDialogState<GameType extends StatisticsGameBase> {
+  game: GameType;
+  teamSeasonId: string;
+  teamName: string;
+  seasonId: string;
+  gameDate?: string;
+  homeScore?: number;
+  visitorScore?: number;
+  homeTeamName?: string;
+  visitorTeamName?: string;
+}
+
+export interface UseGameStatisticsFlowParams<GameType extends StatisticsGameBase> {
+  accountId: string;
+  seasonId?: string;
+  resolveSeasonId?: (game: GameType) => string | null | undefined;
+  getTeamName?: (game: GameType, teamSeasonId: string) => string;
+}
+
+export interface UseGameStatisticsFlowResult<GameType extends StatisticsGameBase> {
+  openViewStatistics: (game: GameType) => void;
+  dialogs: React.ReactNode;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function useGameStatisticsFlow<GameType extends StatisticsGameBase>(
+  params: UseGameStatisticsFlowParams<GameType>,
+): UseGameStatisticsFlowResult<GameType> {
+  const { accountId, seasonId, resolveSeasonId, getTeamName } = params;
+
+  const [dialogState, setDialogState] = useState<StatisticsDialogState<GameType> | null>(null);
+  const [selectionState, setSelectionState] = useState<StatisticsSelectionState<GameType> | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const deriveSeasonId = (game: GameType): string | null => {
+    if (resolveSeasonId) {
+      const resolved = resolveSeasonId(game);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    if (seasonId) {
+      return seasonId;
+    }
+    if (game.seasonId) {
+      return game.seasonId;
+    }
+    if (game.season && game.season.id) {
+      return game.season.id || null;
+    }
+    return null;
+  };
+
+  const resolveTeamName = (game: GameType, teamSeasonId: string): string => {
+    if (getTeamName) {
+      return getTeamName(game, teamSeasonId);
+    }
+    if (teamSeasonId === game.homeTeamId) {
+      return game.homeTeamName ?? 'Home Team';
+    }
+    if (teamSeasonId === game.visitorTeamId) {
+      return game.visitorTeamName ?? 'Visitor Team';
+    }
+    return 'Team';
+  };
+
+  const resolveGameDate = (game: GameType): string | undefined => game.gameDate ?? game.date;
+
+  const openDialog = (game: GameType, teamSeasonId: string) => {
+    const seasonIdentifier = deriveSeasonId(game);
+    if (!seasonIdentifier) {
+      setError('Missing season information for the selected game.');
+      return;
+    }
+
+    setSelectionState(null);
+    setError(null);
+    setDialogState({
+      game,
+      teamSeasonId,
+      teamName: resolveTeamName(game, teamSeasonId),
+      seasonId: seasonIdentifier,
+      gameDate: resolveGameDate(game),
+      homeScore: typeof game.homeScore === 'number' ? game.homeScore : undefined,
+      visitorScore: typeof game.visitorScore === 'number' ? game.visitorScore : undefined,
+      homeTeamName: game.homeTeamName ?? resolveTeamName(game, game.homeTeamId),
+      visitorTeamName: game.visitorTeamName ?? resolveTeamName(game, game.visitorTeamId),
+    });
+  };
+
+  const openViewStatistics = (game: GameType) => {
+    if (
+      game.gameStatus !== undefined &&
+      game.gameStatus !== null &&
+      game.gameStatus !== GameStatus.Completed
+    ) {
+      setError('Statistics are only available for completed games.');
+      return;
+    }
+
+    const orderedTeamIds = [game.homeTeamId, game.visitorTeamId];
+    const teamsWithStats = new Set(game.teamsWithStats ?? []);
+    const eligibleTeamIds = orderedTeamIds.filter((teamId) => teamsWithStats.has(teamId));
+
+    if (eligibleTeamIds.length === 0) {
+      setError('No statistics available for this game.');
+      return;
+    }
+
+    if (eligibleTeamIds.length === 1) {
+      openDialog(game, eligibleTeamIds[0]);
+      return;
+    }
+
+    setSelectionState({
+      game,
+      options: eligibleTeamIds.map((teamId) => ({
+        id: teamId,
+        name: resolveTeamName(game, teamId),
+      })),
+    });
+  };
+
+  const handleSelection = (teamSeasonId: string) => {
+    if (!selectionState) {
+      return;
+    }
+    openDialog(selectionState.game, teamSeasonId);
+  };
+
+  const clearError = () => setError(null);
+
+  const dialogs = (
+    <>
+      {dialogState && (
+        <GameStatisticsDialog
+          open={Boolean(dialogState)}
+          onClose={() => setDialogState(null)}
+          accountId={accountId}
+          seasonId={dialogState.seasonId}
+          gameId={dialogState.game.id}
+          teamSeasonId={dialogState.teamSeasonId}
+          teamName={dialogState.teamName}
+          gameDate={dialogState.gameDate}
+          homeScore={dialogState.homeScore}
+          visitorScore={dialogState.visitorScore}
+          homeTeamName={dialogState.homeTeamName}
+          visitorTeamName={dialogState.visitorTeamName}
+        />
+      )}
+      {selectionState && (
+        <Dialog open onClose={() => setSelectionState(null)} fullWidth maxWidth="xs">
+          <DialogTitle
+            sx={{
+              fontWeight: 700,
+              color: (theme) => theme.palette.widget.headerText,
+            }}
+          >
+            Select Team Statistics to View
+          </DialogTitle>
+          <DialogContent dividers>
+            <List>
+              {selectionState.options.map((option) => (
+                <ListItemButton key={option.id} onClick={() => handleSelection(option.id)}>
+                  <ListItemText primary={option.name} secondary="View statistics" />
+                </ListItemButton>
+              ))}
+            </List>
+          </DialogContent>
+          <DialogActions>
+            <MuiButton onClick={() => setSelectionState(null)}>Cancel</MuiButton>
+          </DialogActions>
+        </Dialog>
+      )}
+    </>
+  );
+
+  return {
+    openViewStatistics,
+    dialogs,
+    error,
+    clearError,
+  };
+}

--- a/draco-nodejs/frontend-next/services/teamStatsEntryService.ts
+++ b/draco-nodejs/frontend-next/services/teamStatsEntryService.ts
@@ -95,10 +95,12 @@ export class TeamStatsEntryService {
     seasonId: string,
     teamSeasonId: string,
     gameId: string,
+    signal?: AbortSignal,
   ): Promise<GameBattingStatsType> {
     const result = await apiGetGameBattingStats({
       client: this.client,
       path: { accountId, seasonId, teamSeasonId, gameId },
+      signal,
       throwOnError: false,
     });
 
@@ -161,10 +163,12 @@ export class TeamStatsEntryService {
     seasonId: string,
     teamSeasonId: string,
     gameId: string,
+    signal?: AbortSignal,
   ): Promise<GamePitchingStatsType> {
     const result = await apiGetGamePitchingStats({
       client: this.client,
       path: { accountId, seasonId, teamSeasonId, gameId },
+      signal,
       throwOnError: false,
     });
 

--- a/draco-nodejs/frontend-next/types/schedule.ts
+++ b/draco-nodejs/frontend-next/types/schedule.ts
@@ -31,6 +31,7 @@ export interface Game {
   gameStatusShortText: string;
   gameType: number;
   hasGameRecap?: boolean;
+  teamsWithStats?: string[];
   league: {
     id: string;
     name: string;
@@ -169,6 +170,7 @@ export interface ViewComponentProps {
   onGameResults: (game: Game) => void;
   onEditRecap?: (game: Game) => void;
   onViewRecap?: (game: Game) => void;
+  onViewStatistics?: (game: Game) => void;
   convertGameToGameCardData: (game: Game) => GameCardData;
   timeZone: string;
   filterType: FilterType;

--- a/draco-nodejs/frontend-next/utils/gameTransformers.ts
+++ b/draco-nodejs/frontend-next/utils/gameTransformers.ts
@@ -171,6 +171,7 @@ const mapApiGameToGameCard = (game: ApiGame): Game => {
     fieldDetails,
     hasGameRecap: recaps.length > 0 || Boolean((game as { hasGameRecap?: boolean }).hasGameRecap),
     gameRecaps: recaps,
+    teamsWithStats: (game as { teamsWithStats?: string[] }).teamsWithStats ?? undefined,
     comment: game.comment ?? '',
     gameType: parsedGameType ?? undefined,
     baseballExtras: {
@@ -201,6 +202,7 @@ export const mapGameResponseToScheduleGame = (game: ApiGame): ScheduleGame => {
     visitorScore: Number(game.visitorScore ?? 0),
     comment: game.comment ?? '',
     hasGameRecap: game.hasGameRecap,
+    teamsWithStats: (game as { teamsWithStats?: string[] }).teamsWithStats ?? undefined,
     fieldId: toOptionalString(game.field?.id),
     field: mapScheduleFieldDetails(game),
     gameStatus,
@@ -371,6 +373,7 @@ export function convertGameToGameCardData(
     fieldDetails: mergeFieldDetails(null, fieldFromCollection, fallbackField, targetFieldId),
     hasGameRecap: Boolean(game.hasGameRecap),
     gameRecaps: [],
+    teamsWithStats: game.teamsWithStats ?? undefined,
     comment: game.comment,
     gameType: game.gameType,
     ...(hasGolfData && { golfExtras: game.golfExtras }),

--- a/draco-nodejs/shared/shared-schemas/game.ts
+++ b/draco-nodejs/shared/shared-schemas/game.ts
@@ -51,6 +51,10 @@ export const GameSchema = z.object({
   gameStatusShortText: GameStatusShortEnumSchema.optional(),
   gameType: z.number().describe('0=Regular, 1=Playoff, 2=Exhibition'),
   hasGameRecap: z.boolean().optional(),
+  teamsWithStats: bigintToStringSchema
+    .array()
+    .optional()
+    .describe('Team-season IDs (home and/or visitor) that have entered stats for this game'),
   umpire1: ContactIdSchema.optional(),
   umpire2: ContactIdSchema.optional(),
   umpire3: ContactIdSchema.optional(),


### PR DESCRIPTION
## Intent
On the statistics page, the **Standings** tab links each team to its team-season page, but the **Players** tab (player career stats) rendered team affiliations as plain text. This makes the Players tab consistent by linking the team affiliation, matching how Standings does it — including linking historical team-seasons correctly.

## Changes
- `PlayerCareerStatisticsCard.tsx` — the "Team" column now renders the full `"League Team"` affiliation as a Next.js `<Link>` to `/account/{accountId}/seasons/{seasonId}/teams/{teamId}`, reusing the Standings URL pattern and link styling (`primary.main`, hover underline). Added an `accountId` prop to support link construction.
- `PlayerCareerSearchTab.tsx` and `PlayerStatisticsClientWrapper.tsx` — pass `accountId` through to the card.

## Why historical teams link correctly
The career row's `teamId` is the **team-season id** (`teamsseason.id`) and `seasonId` is the season id — exactly the two ids the team page route expects (verified against the backend career-stats query). So each historical team-season row links to that specific season's team page.

Rows without a single linkable team stay as plain text:
- **Career-totals** rows (`level: 'career'`, "All Teams", null ids)
- **Season-aggregate** rows (`level: 'season'`, no `teamId`)

## Tests
Added `components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx` (renders through the real `StatisticsTable`, no logic mocking):
1. Team-level row renders an anchor with the correct team-season href.
2. Career-totals row is not linked.
3. Season-aggregate row (no `teamId`) is not linked.
4. Same franchise across two seasons produces two distinct per-season links (the "historical teams" case).

## Verification
- `pnpm frontend:type-check` — clean
- `pnpm frontend:lint` — clean
- New tests pass (4/4); full frontend suite green

## Additional scope on this branch
This branch also carries follow-on statistics work that builds on the team-linking above:
- **Completed Games widget** on the Statistics → Teams tab.
- **Game statistics popup from `GameCard`** — a stats icon (next to the recap icon) on completed games that opens a team's batting/pitching popup (reusing the existing `BattingStatsViewTable`/`PitchingStatsViewTable` widgets), with a team picker when both teams have entered stats. Wired into all `GameCard` surfaces (account scoreboard/schedule, schedule-management, team page, team schedule).

### Backend `teamsWithStats` contract + shared-schema approval
The game-statistics feature adds an optional `teamsWithStats?: string[]` field to `GameSchema` (in the restricted `shared/shared-schemas` directory), populated via a `batstatsum`/`pitchstatsum` `groupBy` in the season-games and team recent-games paths. The view-only per-game stats endpoints are already `optionalAuth`, so **no new permissions** were introduced.

Per `shared/AGENTS.md`, changes under `shared/shared-schemas` require explicit maintainer approval. **This addition was explicitly approved by the maintainer before implementation** (an optional, non-breaking field); `pnpm sync:api` regenerated the client/types accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
