### PR TITLE
Fix broken player link in single-game team stats view

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -11017,7 +11017,7 @@
       "PlayerBattingStats": {
         "type": "object",
         "properties": {
-          "playerId": {
+          "contactId": {
             "type": "string",
             "pattern": "^\\d+$",
             "example": "12345"
@@ -11118,7 +11118,7 @@
           }
         },
         "required": [
-          "playerId",
+          "contactId",
           "playerName",
           "teamName",
           "ab",
@@ -11145,7 +11145,7 @@
       "PlayerBattingStatsBrief": {
         "type": "object",
         "properties": {
-          "playerId": {
+          "contactId": {
             "type": "string",
             "pattern": "^\\d+$",
             "example": "12345"
@@ -11209,7 +11209,7 @@
           }
         },
         "required": [
-          "playerId",
+          "contactId",
           "playerName",
           "ab",
           "h",
@@ -11229,7 +11229,7 @@
       "PlayerPitchingStats": {
         "type": "object",
         "properties": {
-          "playerId": {
+          "contactId": {
             "type": "string",
             "pattern": "^\\d+$",
             "example": "12345"
@@ -11338,7 +11338,7 @@
           }
         },
         "required": [
-          "playerId",
+          "contactId",
           "playerName",
           "teamName",
           "ip",
@@ -11367,7 +11367,7 @@
       "PlayerPitchingStatsBrief": {
         "type": "object",
         "properties": {
-          "playerId": {
+          "contactId": {
             "type": "string",
             "pattern": "^\\d+$",
             "example": "12345"
@@ -11423,7 +11423,7 @@
           }
         },
         "required": [
-          "playerId",
+          "contactId",
           "playerName",
           "w",
           "l",
@@ -11468,7 +11468,7 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "playerId": {
+                    "contactId": {
                       "type": "string",
                       "pattern": "^\\d+$",
                       "example": "12345"
@@ -11609,7 +11609,7 @@
                     }
                   },
                   "required": [
-                    "playerId",
+                    "contactId",
                     "playerName",
                     "teamName",
                     "ab",
@@ -11648,7 +11648,7 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "playerId": {
+                    "contactId": {
                       "type": "string",
                       "pattern": "^\\d+$",
                       "example": "12345"
@@ -11797,7 +11797,7 @@
                     }
                   },
                   "required": [
-                    "playerId",
+                    "contactId",
                     "playerName",
                     "teamName",
                     "ip",

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -8156,7 +8156,7 @@ components:
     PlayerBattingStats:
       type: object
       properties:
-        playerId:
+        contactId:
           type: string
           pattern: ^\d+$
           example: "12345"
@@ -8232,7 +8232,7 @@ components:
           type: number
           minimum: 0
       required:
-        - playerId
+        - contactId
         - playerName
         - teamName
         - ab
@@ -8257,7 +8257,7 @@ components:
     PlayerBattingStatsBrief:
       type: object
       properties:
-        playerId:
+        contactId:
           type: string
           pattern: ^\d+$
           example: "12345"
@@ -8305,7 +8305,7 @@ components:
           type: number
           minimum: 0
       required:
-        - playerId
+        - contactId
         - playerName
         - ab
         - h
@@ -8323,7 +8323,7 @@ components:
     PlayerPitchingStats:
       type: object
       properties:
-        playerId:
+        contactId:
           type: string
           pattern: ^\d+$
           example: "12345"
@@ -8405,7 +8405,7 @@ components:
           type: number
           minimum: 0
       required:
-        - playerId
+        - contactId
         - playerName
         - teamName
         - ip
@@ -8432,7 +8432,7 @@ components:
     PlayerPitchingStatsBrief:
       type: object
       properties:
-        playerId:
+        contactId:
           type: string
           pattern: ^\d+$
           example: "12345"
@@ -8474,7 +8474,7 @@ components:
           type: string
           description: Innings pitched, rounded to nearest whole inning
       required:
-        - playerId
+        - contactId
         - playerName
         - w
         - l
@@ -8513,7 +8513,7 @@ components:
               items:
                 type: object
                 properties:
-                  playerId:
+                  contactId:
                     type: string
                     pattern: ^\d+$
                     example: "12345"
@@ -8620,7 +8620,7 @@ components:
                   isTotals:
                     type: boolean
                 required:
-                  - playerId
+                  - contactId
                   - playerName
                   - teamName
                   - ab
@@ -8653,7 +8653,7 @@ components:
               items:
                 type: object
                 properties:
-                  playerId:
+                  contactId:
                     type: string
                     pattern: ^\d+$
                     example: "12345"
@@ -8766,7 +8766,7 @@ components:
                   isTotals:
                     type: boolean
                 required:
-                  - playerId
+                  - contactId
                   - playerName
                   - teamName
                   - ip

--- a/draco-nodejs/backend/src/responseFormatters/statsResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/statsResponseFormatter.ts
@@ -52,7 +52,7 @@ export class StatsResponseFormatter {
     return stats.map((stat) => {
       const teams = stat.teams?.length ? stat.teams : undefined;
       const formatted = {
-        playerId: stat.playerId.toString(),
+        contactId: stat.playerId.toString(),
         playerName: stat.playerName,
         teamName: StatsResponseFormatter.resolveTeamName(stat.teamName, teams),
         ab: stat.ab,
@@ -85,7 +85,7 @@ export class StatsResponseFormatter {
     return stats.map((stat) => {
       const teams = stat.teams?.length ? stat.teams : undefined;
       const formatted = {
-        playerId: stat.playerId.toString(),
+        contactId: stat.playerId.toString(),
         playerName: stat.playerName,
         teamName: StatsResponseFormatter.resolveTeamName(stat.teamName, teams),
         ip: stat.ip,
@@ -130,7 +130,7 @@ export class StatsResponseFormatter {
             : undefined;
 
       return {
-        playerId: stat.playerId.toString(),
+        contactId: stat.playerId.toString(),
         playerName: stat.playerName,
         teamName: StatsResponseFormatter.resolveTeamName(stat.teamName, teams),
         teams,
@@ -181,7 +181,7 @@ export class StatsResponseFormatter {
             : undefined;
 
       return {
-        playerId: stat.playerId.toString(),
+        contactId: stat.playerId.toString(),
         playerName: stat.playerName,
         teamName: StatsResponseFormatter.resolveTeamName(stat.teamName, teams),
         teams,
@@ -352,7 +352,7 @@ export class StatsResponseFormatter {
     battingStats: dbBattingStatisticsRow[],
   ): PlayerBattingStatsBriefType[] {
     return battingStats.map((stat) => ({
-      playerId: stat.playerId.toString(),
+      contactId: stat.playerId.toString(),
       playerName: stat.playerName,
       ab: stat.ab,
       h: stat.h,
@@ -374,7 +374,7 @@ export class StatsResponseFormatter {
     pitchingStats: dbPitchingStatisticsRow[],
   ): PlayerPitchingStatsBriefType[] {
     return pitchingStats.map((stat) => ({
-      playerId: stat.playerId.toString(),
+      contactId: stat.playerId.toString(),
       playerName: stat.playerName,
       ip: stat.ip.toString() + '.' + stat.ip2.toString(), // Use ip (string) for brief stats to preserve fractional innings
       w: stat.w,

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/BattingStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/BattingStatistics.tsx
@@ -191,7 +191,7 @@ export default function BattingStatistics({ accountId, filters }: BattingStatist
         data={loading && previousStats.length > 0 ? previousStats : stats}
         loading={loading && previousStats.length === 0}
         emptyMessage="No batting statistics available for the selected filters."
-        getRowKey={(player, index) => `${player.playerId}-${index}`}
+        getRowKey={(player, index) => `${player.contactId}-${index}`}
         sortField={String(sortField)}
         sortOrder={sortOrder}
         onSort={(field) => handleSort(field as SortField)}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PitchingStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PitchingStatistics.tsx
@@ -197,7 +197,7 @@ export default function PitchingStatistics({ accountId, filters }: PitchingStati
         data={loading && previousStats.length > 0 ? previousStats : stats}
         loading={loading && previousStats.length === 0}
         emptyMessage="No pitching statistics available for the selected filters."
-        getRowKey={(player, index) => `${player.playerId}-${index}`}
+        getRowKey={(player, index) => `${player.contactId}-${index}`}
         sortField={String(sortField)}
         sortOrder={sortOrder}
         onSort={(field) => handleSort(field as SortField)}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -575,7 +575,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
                   data={sortedBattingStats}
                   loading={loading.batting}
                   emptyMessage="No batting statistics available"
-                  getRowKey={(stat) => stat.playerId}
+                  getRowKey={(stat) => stat.contactId}
                   sortField={String(battingSortField)}
                   sortOrder={battingSortOrder}
                   onSort={(field) => handleBattingSort(field as keyof PlayerBattingStatsType)}
@@ -598,7 +598,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
                   data={sortedPitchingStats}
                   loading={loading.pitching}
                   emptyMessage="No pitching statistics available"
-                  getRowKey={(stat) => stat.playerId}
+                  getRowKey={(stat) => stat.contactId}
                   sortField={String(pitchingSortField)}
                   sortOrder={pitchingSortOrder}
                   onSort={(field) => handlePitchingSort(field as keyof PlayerPitchingStatsType)}

--- a/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
@@ -676,7 +676,7 @@ const StatisticsTable = <T extends StatsRowBase>({
           return null;
         }
 
-        const candidate = row.playerId ?? row.contactId;
+        const candidate = row.contactId;
         if (candidate === null || candidate === undefined) {
           return null;
         }

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/PlayerCareerStatisticsCard.test.tsx
@@ -16,7 +16,7 @@ const ACCOUNT_ID = '1';
 const buildBattingRow = (
   overrides: Partial<PlayerCareerBattingRowType>,
 ): PlayerCareerBattingRowType => ({
-  playerId: '100',
+  contactId: '100',
   playerName: 'Casey Jones',
   teamName: '',
   ab: 10,

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StatisticsTable, { type StatsRowBase } from '../StatisticsTable';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ accountId: '1' }),
+  usePathname: () => '/account/1/statistics',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+vi.stubGlobal('ResizeObserver', mockResizeObserver);
+
+type Row = StatsRowBase & { id: string };
+
+const renderTable = (data: Row[]) =>
+  render(
+    <StatisticsTable
+      variant="batting"
+      extendedStats={false}
+      data={data}
+      getRowKey={(row) => (row as Row).id}
+    />,
+  );
+
+describe('StatisticsTable player links', () => {
+  it('builds the player link from contactId even when a different playerId (roster id) is present', () => {
+    renderTable([{ id: 'r1', playerName: 'Game Player', contactId: '42', playerId: '999' }]);
+
+    const link = screen.getByRole('link', { name: 'Game Player' });
+    const href = link.getAttribute('href') ?? '';
+    expect(href).toContain('/account/1/players/42/statistics');
+    expect(href).not.toContain('/players/999/');
+  });
+
+  it('builds the player link from contactId for season-style rows that carry only contactId', () => {
+    renderTable([{ id: 'r2', playerName: 'Season Player', contactId: '7' }]);
+
+    const link = screen.getByRole('link', { name: 'Season Player' });
+    expect(link.getAttribute('href') ?? '').toContain('/account/1/players/7/statistics');
+  });
+
+  it('does not link a row that has a playerId but no contactId (no fallback)', () => {
+    renderTable([{ id: 'r3', playerName: 'No Contact', playerId: '999' }]);
+
+    expect(screen.getByText('No Contact')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'No Contact' })).not.toBeInTheDocument();
+  });
+
+  it('does not link a totals row', () => {
+    renderTable([{ id: 'totals', playerName: 'Totals', isTotals: true, contactId: '42' }]);
+
+    expect(screen.getByText('Totals')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Totals' })).not.toBeInTheDocument();
+  });
+});

--- a/draco-nodejs/frontend-next/components/team-stats-entry/SeasonBattingStatsSection.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/SeasonBattingStatsSection.tsx
@@ -149,16 +149,16 @@ const SeasonBattingStatsSection: React.FC<SeasonBattingStatsSectionProps> = ({ s
 
     const resolvedPlayerName = values.playerName;
     const id =
-      stat.playerId !== undefined && stat.playerId !== null && stat.playerId !== ''
-        ? String(stat.playerId)
-        : (stat.playerName ?? `player-${stat.playerId ?? 'unknown'}`);
+      stat.contactId !== undefined && stat.contactId !== null && stat.contactId !== ''
+        ? String(stat.contactId)
+        : (stat.playerName ?? `player-${stat.contactId ?? 'unknown'}`);
 
     return {
       ...(values as Record<string, StatValue>),
       id,
       playerName:
         typeof resolvedPlayerName === 'string' ? resolvedPlayerName : (stat.playerName ?? null),
-      playerId: stat.playerId ?? null,
+      contactId: stat.contactId ?? null,
     };
   });
 
@@ -184,7 +184,7 @@ const SeasonBattingStatsSection: React.FC<SeasonBattingStatsSectionProps> = ({ s
       id: 'totals',
       playerName: 'Totals',
       isTotals: true,
-      playerId: null,
+      contactId: null,
     };
 
     tableRows.push(totalsRow);

--- a/draco-nodejs/frontend-next/components/team-stats-entry/SeasonPitchingStatsSection.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/SeasonPitchingStatsSection.tsx
@@ -135,9 +135,9 @@ const SeasonPitchingStatsSection: React.FC<SeasonPitchingStatsSectionProps> = ({
 
     const resolvedPlayerName = values.playerName;
     const id =
-      stat.playerId !== undefined && stat.playerId !== null && stat.playerId !== ''
-        ? String(stat.playerId)
-        : (stat.playerName ?? `player-${stat.playerId ?? 'unknown'}`);
+      stat.contactId !== undefined && stat.contactId !== null && stat.contactId !== ''
+        ? String(stat.contactId)
+        : (stat.playerName ?? `player-${stat.contactId ?? 'unknown'}`);
 
     return {
       ...(values as Record<string, StatValue>),
@@ -146,7 +146,7 @@ const SeasonPitchingStatsSection: React.FC<SeasonPitchingStatsSectionProps> = ({
         typeof resolvedPlayerName === 'string' ? resolvedPlayerName : (stat.playerName ?? null),
       ip: stat.ip ?? null,
       ip2: stat.ip2 ?? null,
-      playerId: stat.playerId ?? null,
+      contactId: stat.contactId ?? null,
     };
   });
 
@@ -168,7 +168,7 @@ const SeasonPitchingStatsSection: React.FC<SeasonPitchingStatsSectionProps> = ({
       isTotals: true,
       ip: Number(totals.ip ?? 0),
       ip2: Number(totals.ip2 ?? 0),
-      playerId: null,
+      contactId: null,
     };
 
     tableRows.push(totalsRow);

--- a/draco-nodejs/shared/shared-schemas/statistics.ts
+++ b/draco-nodejs/shared/shared-schemas/statistics.ts
@@ -6,7 +6,7 @@ import { booleanQueryParam } from './queryParams.js';
 extendZodWithOpenApi(z);
 
 export const PlayerBattingStatsSchema = z.object({
-  playerId: bigintToStringSchema,
+  contactId: bigintToStringSchema,
   playerName: nameSchema,
   teams: nameSchema.array().optional(), // Array of team names player played for
   teamName: nameSchema, // Formatted string of teams for display
@@ -44,7 +44,7 @@ export const PlayerBattingStatsBriefSchema = PlayerBattingStatsSchema.omit({
 });
 
 export const PlayerPitchingStatsSchema = z.object({
-  playerId: bigintToStringSchema,
+  contactId: bigintToStringSchema,
   playerName: nameSchema,
   teams: nameSchema.array().optional(), // Array of team names player played for
   teamName: nameSchema, // Formatted string of teams for display


### PR DESCRIPTION
## Problem
On a team's statistics page, each player row links to that player's statistics page. The link worked under **Season Totals** but was **broken when a single game was selected** — clicking a player did nothing useful.

## Root cause
The link is built in one shared helper, `StatisticsTable.defaultBuildPlayerHref`, which used `row.playerId ?? row.contactId`. The destination page (`/account/[accountId]/players/[playerId]/statistics`) is keyed on **contactId** (`contacts.id`). The two stats responses populated their id fields inconsistently:

| View | response `playerId` field held | `contactId` field |
|------|-------------------------------|-------------------|
| Season Totals | **contactId** (`contacts.id`) — SQL literally `c.id as "playerId"` | *(absent)* |
| Single game | **playerId** (`roster.id`) | **contactId** (`contacts.id`) |

So `playerId ?? contactId` resolved to the contactId in season (worked by accident) but to `roster.id` in game view → a link to a `contacts.id`-keyed page using the wrong id → broken.

## Fix (at the source)
- Renamed the misnamed season field `playerId` → `contactId` in `PlayerBattingStatsSchema` / `PlayerPitchingStatsSchema` (cascades to the Brief + Career row schemas; the value was already `contacts.id`).
- Mapped it in the response formatter (`statsResponseFormatter.ts`) — the layer responsible for DB→API field mapping — leaving the internal SQL/db-row naming untouched.
- Updated the season-stats consumers (`getRowKey`, the two season-section row builders now carry `contactId`).
- The shared link builder now uses **`contactId` only — no fallback** to a non-contact id (a missing `contactId` yields no link rather than a broken one).
- Regenerated OpenAPI spec + API client.

## Tests
- New `components/statistics/__tests__/StatisticsTable.test.tsx` exercises the real href builder: game-style row (has both ids) links by `contactId`, season-style row links by `contactId`, a row with only `playerId` and no `contactId` produces **no link** (proves the no-fallback rule), and totals rows don't link.

## Verification
- `pnpm backend:type-check` ✅ · `pnpm frontend:type-check` ✅
- `pnpm backend:lint` ✅ · `pnpm frontend:lint` ✅
- Backend suite: 1248 ✅ · Frontend suite: 1645 ✅ · pre-push E2E: 252 ✅

**Manual check still recommended:** open a team's stats → select a single game → click a player in both Batting and Pitching tabs → lands on the player page; re-confirm Season Totals links still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)