### PR TITLE
Fix MCP build after rename + add mcp-server to CI build

### DIFF
--- a/draco-nodejs/mcp-server/src/__tests__/tools/listTeamSeasonStats.test.ts
+++ b/draco-nodejs/mcp-server/src/__tests__/tools/listTeamSeasonStats.test.ts
@@ -45,7 +45,7 @@ function withCtx<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 const battingRow = {
-  playerId: '500',
+  contactId: '500',
   playerName: 'Jane Slugger',
   teamName: 'Tigers',
   ab: 40,
@@ -68,7 +68,7 @@ const battingRow = {
 };
 
 const pitchingRow = {
-  playerId: '501',
+  contactId: '501',
   playerName: 'John Pitcher',
   teamName: 'Tigers',
   ip: 12.5,

--- a/draco-nodejs/mcp-server/src/tools/helpers/shapeTeamSeasonStats.ts
+++ b/draco-nodejs/mcp-server/src/tools/helpers/shapeTeamSeasonStats.ts
@@ -54,7 +54,7 @@ export interface ShapedTeamPitchingStatsResult {
 
 export function shapeTeamBattingStats(rows: PlayerBattingStats[]): ShapedTeamBattingStatsResult {
   const shaped: ShapedTeamBattingRow[] = rows.map((r) => ({
-    player_id: r.playerId,
+    player_id: r.contactId,
     player_name: r.playerName,
     team_name: r.teamName,
     ab: r.ab,
@@ -86,7 +86,7 @@ export function shapeTeamBattingStats(rows: PlayerBattingStats[]): ShapedTeamBat
 
 export function shapeTeamPitchingStats(rows: PlayerPitchingStats[]): ShapedTeamPitchingStatsResult {
   const shaped: ShapedTeamPitchingRow[] = rows.map((r) => ({
-    player_id: r.playerId,
+    player_id: r.contactId,
     player_name: r.playerName,
     team_name: r.teamName,
     ip: r.ip,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "frontend:e2e:reap": "pnpm --filter @draco/frontend-next e2e:reap",
     "dev": "concurrently \"pnpm --filter @draco/backend dev\" \"pnpm --filter @draco/frontend-next dev\"",
     "dev:debug": "concurrently \"pnpm --filter @draco/backend dev:debug\" \"pnpm --filter @draco/frontend-next dev\"",
-    "build": "pnpm --filter @draco/shared-schemas build && pnpm run sync:api && pnpm --filter @draco/backend build && pnpm --filter @draco/frontend-next build",
+    "build": "pnpm --filter @draco/shared-schemas build && pnpm run sync:api && pnpm --filter @draco/backend build && pnpm --filter @draco/frontend-next build && pnpm --filter @draco/mcp-server build",
     "lint": "pnpm -r run lint",
     "lint:fix": "pnpm -r run lint:fix",
     "format": "pnpm -r run format",


### PR DESCRIPTION
## Problem
PR #860 renamed `playerId` → `contactId` on `PlayerBattingStats` / `PlayerPitchingStats`, but missed the **mcp-server** consumer, breaking `tsc`:

```
src/tools/helpers/shapeTeamSeasonStats.ts(57,18): error TS2339: Property 'playerId' does not exist on type 'PlayerBattingStats'.
src/tools/helpers/shapeTeamSeasonStats.ts(89,18): error TS2339: Property 'playerId' does not exist on type 'PlayerPitchingStats'.
```

This shipped to `main` green because **CI never built the mcp-server**.

## Fixes
1. **Unbreak the build** — source the MCP `player_id` output (its own external contract, unchanged) from the renamed `contactId`. `shapeLeaders.ts` is untouched: it uses `LeaderRow`, whose `playerId` was not renamed.
2. **Close the CI gap** — the root `build` script (run by the PR validation pipeline, and the repo's "build = includes type checking" contract) only compiled `shared-schemas`, `backend`, and `frontend`. Appended `pnpm --filter @draco/mcp-server build` (after `sync:api`, since it depends on the generated client) so `tsc` runs against mcp-server in CI and in local `pnpm build`.

## Why CI missed it
- CI's "Build" step runs `pnpm run build`, which did **not** include mcp-server.
- Lint is recursive (`pnpm -r run lint`) but lint does not catch type errors.
- There is no standalone `type-check` step in the pipeline.

## Verification
- `pnpm build` (full chain incl. mcp-server) ✅ — re-run `sync:api` produced byte-identical OpenAPI output.
- `pnpm --filter @draco/mcp-server build` / `type-check` ✅

## Known pre-existing (out of scope, unrelated to this change)
- `@draco/shared-api-client` `type-check` has no tsconfig → prints tsc usage, exits non-zero (no-op script).
- `@draco/mobile` `type-check` fails on generated `queryKeySerializer.gen.ts` (`URLSearchParams.entries` / iterator lib errors) — a TS lib/target config issue independent of schema field changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)