### PR TITLE
Show schedule Summary widget on user schedule page

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -17,6 +17,8 @@ import {
   FilterType,
   ViewMode,
 } from '../../../../components/schedule';
+import { getFilteredScheduleSummary } from '../../../../components/schedule/utils/getFilteredScheduleSummary';
+import SeasonSummaryWidget from '../../../../components/schedule/SeasonSummaryWidget';
 import { isGolfLeagueAccountType } from '../../../../utils/accountTypeUtils';
 import GolfScorecardDialog from '../../../../components/golf/GolfScorecardDialog';
 import usePrintAction from '../../../../components/print/usePrintAction';
@@ -123,6 +125,13 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
   const leagueTeams = filterLeagueSeasonId
     ? (leagueTeamsCache.get(filterLeagueSeasonId) ?? [])
     : [];
+
+  const filteredSummary = getFilteredScheduleSummary({
+    games: filteredGames,
+    timeZone,
+    teamSeasonId: filterTeamSeasonId || undefined,
+    ready: !loadingStaticData,
+  });
 
   const convertGameToGameCardDataWithTeams = (game: Game): GameCardData => {
     return convertGameToGameCardData(game, teams, locations);
@@ -250,7 +259,18 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
           </Button>
         </Box>
       }
-      summaryContent={scheduleHiddenNotice}
+      summaryContent={
+        <>
+          <SeasonSummaryWidget
+            summary={filteredSummary}
+            loading={false}
+            ready={!loadingStaticData}
+            games={filteredGames}
+            timeZone={timeZone}
+          />
+          {scheduleHiddenNotice}
+        </>
+      }
       filteredGames={filteredGames}
       teams={teams}
       locations={locations}


### PR DESCRIPTION
## Intent
The Summary widget appears on the admin schedule-management page and the team schedule page, but not on the account-level user schedule page (`/account/[accountId]/schedule`). There's no reason to omit it there. This adds it, honoring the page's active filters.

## Changes
- `frontend-next/app/account/[accountId]/schedule/Schedule.tsx`
  - Import `getFilteredScheduleSummary` and `SeasonSummaryWidget`.
  - Derive `filteredSummary` from the already-filtered games (`filteredGames`), passing `filterTeamSeasonId` so home/away stats show when a team is selected.
  - Render `SeasonSummaryWidget` in the `summaryContent` slot, alongside the existing "schedule not published" notice.

## Why this approach
The user schedule page already uses `useScheduleData` + `useScheduleFilters` exactly like the admin schedule-management page, so reusing `getFilteredScheduleSummary(filteredGames, …)` is the natural fit and automatically reflects filter changes (league, team, date range). The team page's `useTeamSeasonSummary` hook fetches a whole season independently and would not honor the account-level filters, so it was not used here.

The widget self-hides when the filtered set has zero games, so the existing empty/hidden-notice behavior is preserved.

## Testing
- `pnpm frontend:type-check` — pass
- `pnpm frontend:lint` — pass
- Pre-commit E2E suite — 253 passed, 27 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)