### PR TITLE
Add periodic GC to bound frontend memory growth

### DIFF
--- a/draco-nodejs/frontend-next/instrumentation.ts
+++ b/draco-nodejs/frontend-next/instrumentation.ts
@@ -1,0 +1,12 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  const globalWithGc = globalThis as typeof globalThis & { gc?: () => void };
+  if (typeof globalWithGc.gc !== 'function') return;
+
+  const intervalMs = Number(process.env.GC_INTERVAL_MS ?? 5 * 60 * 1000);
+  const timer = setInterval(() => {
+    globalWithGc.gc?.();
+  }, intervalMs);
+  timer.unref();
+}

--- a/draco-nodejs/frontend-next/instrumentation.ts
+++ b/draco-nodejs/frontend-next/instrumentation.ts
@@ -4,7 +4,8 @@ export async function register() {
   const globalWithGc = globalThis as typeof globalThis & { gc?: () => void };
   if (typeof globalWithGc.gc !== 'function') return;
 
-  const intervalMs = Number(process.env.GC_INTERVAL_MS ?? 5 * 60 * 1000);
+  const parsed = Number(process.env.GC_INTERVAL_MS);
+  const intervalMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60 * 1000;
   const timer = setInterval(() => {
     globalWithGc.gc?.();
   }, intervalMs);


### PR DESCRIPTION
## Problem

The `draco-frontend` Next.js service on Railway shows steady memory growth (~520 → ~620 MB over ~18h, then plateau). A daily 3 AM container restart only helps momentarily — memory creeps back and is never reclaimed.

## Root cause (most likely)

Next.js 16 / V8 defers full GC when there is no memory pressure. The frontend service has **no `NODE_OPTIONS` heap cap**, so V8 sizes old-space generously and never runs aggressive collection — RSS climbs and stays high without a true leak. This matches the observed "restart helps briefly, then creeps back" behavior. (There is also a cluster of open upstream Next.js 16 leak reports — [#90433](https://github.com/vercel/next.js/issues/90433), [#85914](https://github.com/vercel/next.js/issues/85914), [#88603](https://github.com/vercel/next.js/discussions/88603) — kept in mind as the escalation path if forced GC doesn't help.)

## Change

Add `instrumentation.ts` that runs `global.gc()` on an interval:
- **Node runtime only** (`NEXT_RUNTIME === 'nodejs'` guard)
- **Safe no-op** unless `--expose-gc` is set, so it's inert until explicitly activated
- Timer is `.unref()`'d so it never blocks shutdown
- Interval tunable via `GC_INTERVAL_MS` (default 5 min)

This is intentionally the **only** change — one isolated variable — so the memory signal is unambiguous.

## Activation (separate, manual)

Set on the Railway **draco-frontend** service (production):

```
NODE_OPTIONS=--expose-gc
```

## Why this approach (and not a heap cap)

A tight `--max-old-space-size` only helps if the growth is *reclaimable*; if it's a true referenced-object leak, a tight cap just causes OOM crashes (exit 137) instead of helping. Forced GC has **no crash risk** and is **self-diagnosing**:
- Memory drops on each GC cycle → it was lazy GC. Solved; retire the restart cron.
- Memory keeps climbing through GC cycles → it's a real upstream leak. Escalate (proxy bypass / `cacheComponents` toggle / heap snapshot / upstream fix).

## Validation

Deploy with the env var, watch Railway memory for 3–5 days for a sawtooth instead of monotonic creep. No `exit status 137` expected (no tight cap set). Retire the 3 AM restart cron once memory holds flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)