### PR TITLE
Collapse excessive blank lines in game recaps

### DIFF
--- a/draco-nodejs/backend/src/responseFormatters/scheduleResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/scheduleResponseFormatter.ts
@@ -8,6 +8,7 @@ import {
 import { dbScheduleGameWithDetails, dbScheduleGameWithRecaps } from '../repositories/index.js';
 import { DateUtils } from '../utils/dateUtils.js';
 import { getGameStatusShortText, getGameStatusText } from '../utils/gameStatus.js';
+import { collapseHtmlBlankLines } from '../utils/recapContent.js';
 import { formatFieldFromAvailableField } from './fieldFormatterUtils.js';
 
 export type ScheduleGameWithRecapsType = GamesWithRecapsType['games'][number];
@@ -111,7 +112,7 @@ export class ScheduleResponseFormatter {
         team: {
           id: recap.teamid.toString(),
         },
-        recap: recap.recap,
+        recap: collapseHtmlBlankLines(recap.recap),
       }));
     }
 

--- a/draco-nodejs/backend/src/services/scheduleService.ts
+++ b/draco-nodejs/backend/src/services/scheduleService.ts
@@ -40,6 +40,7 @@ import { getGameStatusText } from '../utils/gameStatus.js';
 import { GameStatus } from '../types/gameEnums.js';
 import { DateUtils } from '../utils/dateUtils.js';
 import { sanitizePlainText } from '../utils/htmlSanitizer.js';
+import { collapseHtmlBlankLines } from '../utils/recapContent.js';
 
 interface GameListFilters {
   startDate?: Date;
@@ -896,7 +897,7 @@ export class ScheduleService {
       return '';
     }
 
-    return recap.recap;
+    return collapseHtmlBlankLines(recap.recap);
   }
 
   async upsertGameRecap(
@@ -915,8 +916,9 @@ export class ScheduleService {
 
     this.ensureTeamInGame(game, teamSeasonId);
 
-    const recap = await this.scheduleRepository.upsertRecap(gameId, teamSeasonId, payload.recap);
-    return recap.recap;
+    const normalized = collapseHtmlBlankLines(payload.recap);
+    const recap = await this.scheduleRepository.upsertRecap(gameId, teamSeasonId, normalized);
+    return collapseHtmlBlankLines(recap.recap);
   }
 
   private async validateTeamsBelongToLeagueSeason(

--- a/draco-nodejs/backend/src/utils/__tests__/recapContent.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/recapContent.test.ts
@@ -35,6 +35,17 @@ describe('collapseHtmlBlankLines', () => {
     expect(collapseHtmlBlankLines(html)).toBe('<p>Only real line.</p>');
   });
 
+  it('removes leading and trailing standalone <br> tags', () => {
+    expect(collapseHtmlBlankLines('<br><br>Text')).toBe('Text');
+    expect(collapseHtmlBlankLines('Text<br><br>')).toBe('Text');
+    expect(collapseHtmlBlankLines('<br /><br/>Text<br /><br>')).toBe('Text');
+  });
+
+  it('removes mixed leading and trailing blank primitives (<br> and empty blocks)', () => {
+    const html = '<br><p><br></p><p>Real line.</p><p><br></p><br>';
+    expect(collapseHtmlBlankLines(html)).toBe('<p>Real line.</p>');
+  });
+
   it('preserves content paragraphs and inline formatting verbatim', () => {
     const html =
       '<p>Royals win <strong>big</strong>.</p>' +

--- a/draco-nodejs/backend/src/utils/__tests__/recapContent.test.ts
+++ b/draco-nodejs/backend/src/utils/__tests__/recapContent.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { collapseHtmlBlankLines } from '../recapContent.js';
+
+describe('collapseHtmlBlankLines', () => {
+  it('returns empty string for null/undefined/empty input', () => {
+    expect(collapseHtmlBlankLines(null)).toBe('');
+    expect(collapseHtmlBlankLines(undefined)).toBe('');
+    expect(collapseHtmlBlankLines('')).toBe('');
+  });
+
+  it('collapses a long run of empty paragraphs between content to one blank line', () => {
+    const html =
+      '<p>Royals win.</p>' +
+      '<p><br></p><p><br></p><p><br></p><p><br></p><p><br></p>' +
+      '<p>Mark homered.</p>';
+
+    expect(collapseHtmlBlankLines(html)).toBe('<p>Royals win.</p><p><br></p><p>Mark homered.</p>');
+  });
+
+  it('collapses a mixed run of empty block types to one blank line', () => {
+    const html =
+      '<p>First.</p>' + '<p></p><p>&nbsp;</p><div><br></div><p><br /></p>' + '<p>Second.</p>';
+
+    expect(collapseHtmlBlankLines(html)).toBe('<p>First.</p><p></p><p>Second.</p>');
+  });
+
+  it('collapses consecutive <br> runs (any spelling) to one', () => {
+    expect(collapseHtmlBlankLines('Line one<br><br><br>Line two')).toBe('Line one<br>Line two');
+    expect(collapseHtmlBlankLines('Line one<br/><br /><br>Line two')).toBe('Line one<br>Line two');
+  });
+
+  it('removes leading and trailing empty blocks', () => {
+    const html = '<p><br></p><p><br></p><p>Only real line.</p><p><br></p><p><br></p>';
+    expect(collapseHtmlBlankLines(html)).toBe('<p>Only real line.</p>');
+  });
+
+  it('preserves content paragraphs and inline formatting verbatim', () => {
+    const html =
+      '<p>Royals win <strong>big</strong>.</p>' +
+      '<p><br></p><p><br></p>' +
+      '<p><a href="https://example.com">box score</a> and ' +
+      '<span style="color: red">notes</span>.</p>';
+
+    expect(collapseHtmlBlankLines(html)).toBe(
+      '<p>Royals win <strong>big</strong>.</p>' +
+        '<p><br></p>' +
+        '<p><a href="https://example.com">box score</a> and ' +
+        '<span style="color: red">notes</span>.</p>',
+    );
+  });
+
+  it('leaves a single blank line untouched (one empty block is allowed)', () => {
+    const html = '<p>First.</p><p><br></p><p>Second.</p>';
+    expect(collapseHtmlBlankLines(html)).toBe(html);
+  });
+
+  it('leaves already-clean content unchanged', () => {
+    const html = '<p>First paragraph.</p><p>Second paragraph.</p>';
+    expect(collapseHtmlBlankLines(html)).toBe(html);
+  });
+
+  it('is idempotent: collapsing twice equals collapsing once', () => {
+    const html =
+      '<p>Royals win.</p>' +
+      '<p><br></p><p><br></p><p><br></p>' +
+      '<p>Mark homered.</p>' +
+      '<p><br></p><p><br></p>';
+
+    const once = collapseHtmlBlankLines(html);
+    expect(collapseHtmlBlankLines(once)).toBe(once);
+  });
+
+  it('supports a maxBlankLines of 0 (removes all blank lines)', () => {
+    const html = '<p>First.</p><p><br></p><p><br></p><p>Second.</p>';
+    expect(collapseHtmlBlankLines(html, 0)).toBe('<p>First.</p><p>Second.</p>');
+  });
+
+  it('supports a maxBlankLines of 2', () => {
+    const html =
+      '<p>First.</p>' + '<p><br></p><p><br></p><p><br></p><p><br></p>' + '<p>Second.</p>';
+    expect(collapseHtmlBlankLines(html, 2)).toBe(
+      '<p>First.</p><p><br></p><p><br></p><p>Second.</p>',
+    );
+  });
+});

--- a/draco-nodejs/backend/src/utils/recapContent.ts
+++ b/draco-nodejs/backend/src/utils/recapContent.ts
@@ -26,9 +26,10 @@ export const collapseHtmlBlankLines = (
     return blocks.slice(0, limit).join('');
   });
 
-  const leadingEmptyBlocks = new RegExp(`^(?:\\s*${EMPTY_BLOCK})+`, 'i');
-  const trailingEmptyBlocks = new RegExp(`(?:${EMPTY_BLOCK}\\s*)+$`, 'i');
-  result = result.replace(leadingEmptyBlocks, '').replace(trailingEmptyBlocks, '');
+  const BLANK_UNIT = `(?:${EMPTY_BLOCK}|${BR})`;
+  const leadingBlanks = new RegExp(`^(?:\\s*${BLANK_UNIT})+`, 'i');
+  const trailingBlanks = new RegExp(`(?:${BLANK_UNIT}\\s*)+$`, 'i');
+  result = result.replace(leadingBlanks, '').replace(trailingBlanks, '');
 
   return result.trim();
 };

--- a/draco-nodejs/backend/src/utils/recapContent.ts
+++ b/draco-nodejs/backend/src/utils/recapContent.ts
@@ -1,0 +1,34 @@
+const BLOCK_TAGS = 'p|div|h[1-6]|li|blockquote|pre';
+const BR = '<br\\s*/?>';
+const EMPTY_BLOCK_INNER = `(?:\\s|&nbsp;|${BR})*`;
+const EMPTY_BLOCK = `<(${BLOCK_TAGS})\\b[^>]*>${EMPTY_BLOCK_INNER}</\\1\\s*>`;
+
+export const collapseHtmlBlankLines = (
+  html: string | null | undefined,
+  maxBlankLines = 1,
+): string => {
+  if (!html) {
+    return '';
+  }
+
+  const limit = Math.max(0, maxBlankLines);
+  let result = html;
+
+  const brRun = new RegExp(`(?:${BR}\\s*){${limit + 1},}`, 'gi');
+  result = result.replace(brRun, '<br>'.repeat(limit));
+
+  const emptyBlockRun = new RegExp(`(?:${EMPTY_BLOCK}\\s*){${limit + 1},}`, 'gi');
+  result = result.replace(emptyBlockRun, (match) => {
+    if (limit === 0) {
+      return '';
+    }
+    const blocks = match.match(new RegExp(EMPTY_BLOCK, 'gi')) ?? [];
+    return blocks.slice(0, limit).join('');
+  });
+
+  const leadingEmptyBlocks = new RegExp(`^(?:\\s*${EMPTY_BLOCK})+`, 'i');
+  const trailingEmptyBlocks = new RegExp(`(?:${EMPTY_BLOCK}\\s*)+$`, 'i');
+  result = result.replace(leadingEmptyBlocks, '').replace(trailingEmptyBlocks, '');
+
+  return result.trim();
+};


### PR DESCRIPTION
## Intent

Some users pad game recaps with long runs of blank lines (e.g. a recap followed by dozens of empty lines, then one trailing sentence). Recaps are authored in a Lexical rich-text editor and stored as **HTML** in `gamerecap.recap`, so the visible blank lines are HTML newline primitives — runs of empty block elements (`<p><br></p>`, `<p></p>`, …) and/or consecutive `<br>` tags.

This caps consecutive blank lines at **one**, fixing existing recaps on read (no DB migration) and normalizing on write so new recaps are stored clean.

## Approach

New util `backend/src/utils/recapContent.ts` → `collapseHtmlBlankLines(html, maxBlankLines = 1)`. It targets HTML's newline **primitives generically** rather than editor-specific markup, so it stays correct regardless of which editor/paste produced the HTML:

- Any `<br>` spelling (`<br>`, `<br/>`, `<br />`)
- Empty / whitespace-only block elements of any block tag (`p|div|h1-6|li|blockquote|pre`), any attributes, inner content only whitespace / `&nbsp;` / `<br>`

It collapses runs of 2+ blank units down to 1, trims leading/trailing empties, and never touches blocks containing real text. Regex-based, no new dependency, consistent with the existing `htmlSanitizer.ts` convention. (CSS in this content is limited to font/color/text-align/line-height — no `margin`/`white-space` — so those are the only blank-line producers.)

## Affected areas

The only three sites that emit recap text (verified by grep; all other refs are boolean/count flags like `hasGameRecap` / `_count.gamerecap`):

- **Read (single):** `scheduleService.getGameRecap`
- **Read (games list):** `scheduleResponseFormatter.formatGameWithRecaps`
- **Write:** `scheduleService.upsertGameRecap` (normalizes before persisting)

No shared-schema, OpenAPI, or DB changes.

## Known limitation

A trailing `<br>` *inside* a content paragraph immediately followed by empty paragraphs is reduced but not DOM-counted (rare for this content). A parser-based approach would handle that DOM-exactly at the cost of a new backend dependency.

## Testing

- New unit tests `backend/src/utils/__tests__/recapContent.test.ts` (11 cases): long empty-`<p>` runs, mixed empty block types, `<br>` runs, leading/trailing trim, content/inline-formatting preserved verbatim, idempotency, and `maxBlankLines` 0/1/2.
- `pnpm backend:lint` ✅
- `pnpm backend:type-check` ✅
- `pnpm backend:test` — schedule service + formatter + new util suites pass (34 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)