### PR TITLE
Add runs & next-game to standings

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -10609,10 +10609,15 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^\\d+$",
+                            "example": "12345"
                           },
                           "gameDate": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-03-01T18:30:00Z",
+                            "description": "ISO 8601 timestamp string with timezone offset."
                           },
                           "opponent": {
                             "type": "object",
@@ -10772,10 +10777,15 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^\\d+$",
+                "example": "12345"
               },
               "gameDate": {
-                "type": "string"
+                "type": "string",
+                "format": "date-time",
+                "example": "2024-03-01T18:30:00Z",
+                "description": "ISO 8601 timestamp string with timezone offset."
               },
               "opponent": {
                 "type": "object",

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -7827,7 +7827,8 @@
                     "SyncInstagramToGallery",
                     "NotifyTeamsWantedOnPlayersWanted",
                     "NotifyPlayersWantedOnTeamsWanted",
-                    "EnableLiveScoring"
+                    "EnableLiveScoring",
+                    "UseDivisionRecordInStandings"
                   ]
                 },
                 "label": {
@@ -7917,7 +7918,8 @@
                           "SyncInstagramToGallery",
                           "NotifyTeamsWantedOnPlayersWanted",
                           "NotifyPlayersWantedOnTeamsWanted",
-                          "EnableLiveScoring"
+                          "EnableLiveScoring",
+                          "UseDivisionRecordInStandings"
                         ]
                       },
                       "value": {
@@ -8074,7 +8076,8 @@
                   "SyncInstagramToGallery",
                   "NotifyTeamsWantedOnPlayersWanted",
                   "NotifyPlayersWantedOnTeamsWanted",
-                  "EnableLiveScoring"
+                  "EnableLiveScoring",
+                  "UseDivisionRecordInStandings"
                 ]
               },
               "label": {
@@ -8164,7 +8167,8 @@
                         "SyncInstagramToGallery",
                         "NotifyTeamsWantedOnPlayersWanted",
                         "NotifyPlayersWantedOnTeamsWanted",
-                        "EnableLiveScoring"
+                        "EnableLiveScoring",
+                        "UseDivisionRecordInStandings"
                       ]
                     },
                     "value": {
@@ -8332,7 +8336,8 @@
           "SyncInstagramToGallery",
           "NotifyTeamsWantedOnPlayersWanted",
           "NotifyPlayersWantedOnTeamsWanted",
-          "EnableLiveScoring"
+          "EnableLiveScoring",
+          "UseDivisionRecordInStandings"
         ]
       },
       "Sponsor": {
@@ -10593,6 +10598,50 @@
                           "l",
                           "t"
                         ]
+                      },
+                      "rs": {
+                        "type": "number"
+                      },
+                      "ra": {
+                        "type": "number"
+                      },
+                      "nextGame": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "gameDate": {
+                            "type": "string"
+                          },
+                          "opponent": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "pattern": "^\\d+$",
+                                "example": "12345"
+                              },
+                              "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 100
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "isHome": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "gameDate",
+                          "opponent",
+                          "isHome"
+                        ]
                       }
                     },
                     "required": [
@@ -10601,7 +10650,9 @@
                       "t",
                       "team",
                       "pct",
-                      "gb"
+                      "gb",
+                      "rs",
+                      "ra"
                     ]
                   }
                 }
@@ -10710,6 +10761,50 @@
               "l",
               "t"
             ]
+          },
+          "rs": {
+            "type": "number"
+          },
+          "ra": {
+            "type": "number"
+          },
+          "nextGame": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "gameDate": {
+                "type": "string"
+              },
+              "opponent": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "example": "12345"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              },
+              "isHome": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "gameDate",
+              "opponent",
+              "isHome"
+            ]
           }
         },
         "required": [
@@ -10718,7 +10813,9 @@
           "t",
           "team",
           "pct",
-          "gb"
+          "gb",
+          "rs",
+          "ra"
         ]
       },
       "TeamSeasonRecord": {
@@ -40424,7 +40521,8 @@
                 "SyncInstagramToGallery",
                 "NotifyTeamsWantedOnPlayersWanted",
                 "NotifyPlayersWantedOnTeamsWanted",
-                "EnableLiveScoring"
+                "EnableLiveScoring",
+                "UseDivisionRecordInStandings"
               ]
             }
           }

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -5826,6 +5826,7 @@ components:
                   - NotifyTeamsWantedOnPlayersWanted
                   - NotifyPlayersWantedOnTeamsWanted
                   - EnableLiveScoring
+                  - UseDivisionRecordInStandings
               label:
                 type: string
               description:
@@ -5896,6 +5897,7 @@ components:
                         - NotifyTeamsWantedOnPlayersWanted
                         - NotifyPlayersWantedOnTeamsWanted
                         - EnableLiveScoring
+                        - UseDivisionRecordInStandings
                     value:
                       anyOf:
                         - type: boolean
@@ -6002,6 +6004,7 @@ components:
                 - NotifyTeamsWantedOnPlayersWanted
                 - NotifyPlayersWantedOnTeamsWanted
                 - EnableLiveScoring
+                - UseDivisionRecordInStandings
             label:
               type: string
             description:
@@ -6072,6 +6075,7 @@ components:
                       - NotifyTeamsWantedOnPlayersWanted
                       - NotifyPlayersWantedOnTeamsWanted
                       - EnableLiveScoring
+                      - UseDivisionRecordInStandings
                   value:
                     anyOf:
                       - type: boolean
@@ -6181,6 +6185,7 @@ components:
         - NotifyTeamsWantedOnPlayersWanted
         - NotifyPlayersWantedOnTeamsWanted
         - EnableLiveScoring
+        - UseDivisionRecordInStandings
     Sponsor:
       type: object
       properties:
@@ -7848,6 +7853,37 @@ components:
                         - w
                         - l
                         - t
+                    rs:
+                      type: number
+                    ra:
+                      type: number
+                    nextGame:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        gameDate:
+                          type: string
+                        opponent:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              pattern: ^\d+$
+                              example: "12345"
+                            name:
+                              type: string
+                              minLength: 1
+                              maxLength: 100
+                          required:
+                            - id
+                        isHome:
+                          type: boolean
+                      required:
+                        - id
+                        - gameDate
+                        - opponent
+                        - isHome
                   required:
                     - w
                     - l
@@ -7855,6 +7891,8 @@ components:
                     - team
                     - pct
                     - gb
+                    - rs
+                    - ra
             required:
               - division
               - teams
@@ -7928,6 +7966,37 @@ components:
             - w
             - l
             - t
+        rs:
+          type: number
+        ra:
+          type: number
+        nextGame:
+          type: object
+          properties:
+            id:
+              type: string
+            gameDate:
+              type: string
+            opponent:
+              type: object
+              properties:
+                id:
+                  type: string
+                  pattern: ^\d+$
+                  example: "12345"
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+              required:
+                - id
+            isHome:
+              type: boolean
+          required:
+            - id
+            - gameDate
+            - opponent
+            - isHome
       required:
         - w
         - l
@@ -7935,6 +8004,8 @@ components:
         - team
         - pct
         - gb
+        - rs
+        - ra
     TeamSeasonRecord:
       type: object
       properties:
@@ -29638,6 +29709,7 @@ paths:
               - NotifyTeamsWantedOnPlayersWanted
               - NotifyPlayersWantedOnTeamsWanted
               - EnableLiveScoring
+              - UseDivisionRecordInStandings
       requestBody:
         content:
           application/json:

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -7862,8 +7862,13 @@ components:
                       properties:
                         id:
                           type: string
+                          pattern: ^\d+$
+                          example: "12345"
                         gameDate:
                           type: string
+                          format: date-time
+                          example: 2024-03-01T18:30:00Z
+                          description: ISO 8601 timestamp string with timezone offset.
                         opponent:
                           type: object
                           properties:
@@ -7975,8 +7980,13 @@ components:
           properties:
             id:
               type: string
+              pattern: ^\d+$
+              example: "12345"
             gameDate:
               type: string
+              format: date-time
+              example: 2024-03-01T18:30:00Z
+              description: ISO 8601 timestamp string with timezone offset.
             opponent:
               type: object
               properties:

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaScheduleRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaScheduleRepository.ts
@@ -601,6 +601,20 @@ export class PrismaScheduleRepository implements IScheduleRepository {
     return games;
   }
 
+  async listScheduledGamesForSeason(seasonId: bigint, referenceDate: Date): Promise<dbGameInfo[]> {
+    const games: TeamGameInfoPayload[] = await this.prisma.leagueschedule.findMany({
+      where: {
+        leagueseason: { seasonid: seasonId },
+        gamestatus: 0,
+        gamedate: { gte: referenceDate },
+      },
+      select: teamGameSelect,
+      orderBy: [{ gamedate: 'asc' }, { id: 'asc' }],
+    });
+
+    return games;
+  }
+
   async findTeamSeasonCalendarContext(teamSeasonId: bigint): Promise<{
     teamName: string;
     leagueName: string;

--- a/draco-nodejs/backend/src/repositories/interfaces/IScheduleRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IScheduleRepository.ts
@@ -109,6 +109,7 @@ export interface IScheduleRepository extends IBaseRepository<leagueschedule> {
     referenceDate: Date,
   ): Promise<dbGameInfo[]>;
   listAllGamesForTeam(teamSeasonId: bigint, seasonId: bigint): Promise<dbGameInfo[]>;
+  listScheduledGamesForSeason(seasonId: bigint, referenceDate: Date): Promise<dbGameInfo[]>;
   findTeamSeasonCalendarContext(teamSeasonId: bigint): Promise<{
     teamName: string;
     leagueName: string;

--- a/draco-nodejs/backend/src/routes/standings.ts
+++ b/draco-nodejs/backend/src/routes/standings.ts
@@ -35,11 +35,24 @@ router.get(
             t: team.t,
             pct: team.pct,
             gb: team.gb,
+            rs: team.rs,
+            ra: team.ra,
             divisionRecord: team.divisionRecord
               ? {
                   w: team.divisionRecord.w,
                   l: team.divisionRecord.l,
                   t: team.divisionRecord.t,
+                }
+              : undefined,
+            nextGame: team.nextGame
+              ? {
+                  id: team.nextGame.id,
+                  gameDate: team.nextGame.gameDate,
+                  opponent: {
+                    id: team.nextGame.opponentId,
+                    name: team.nextGame.opponentName,
+                  },
+                  isHome: team.nextGame.isHome,
                 }
               : undefined,
           })),
@@ -57,6 +70,8 @@ router.get(
         t: team.t,
         pct: team.pct,
         gb: team.gb,
+        rs: team.rs,
+        ra: team.ra,
         league: team.leagueId ? { id: team.leagueId.toString(), name: team.leagueName } : undefined,
         division: team.divisionId
           ? { id: team.divisionId.toString(), name: team.divisionName || '' }
@@ -66,6 +81,14 @@ router.get(
               w: team.divisionRecord.w,
               l: team.divisionRecord.l,
               t: team.divisionRecord.t,
+            }
+          : undefined,
+        nextGame: team.nextGame
+          ? {
+              id: team.nextGame.id,
+              gameDate: team.nextGame.gameDate,
+              opponent: { id: team.nextGame.opponentId, name: team.nextGame.opponentName },
+              isHome: team.nextGame.isHome,
             }
           : undefined,
       }));

--- a/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerApplyService.test.ts
@@ -61,6 +61,7 @@ class ScheduleRepositoryStub implements IScheduleRepository {
   listUpcomingGamesForTeam = vi.fn<IScheduleRepository['listUpcomingGamesForTeam']>();
   listRecentGamesForTeam = vi.fn<IScheduleRepository['listRecentGamesForTeam']>();
   listAllGamesForTeam = vi.fn<IScheduleRepository['listAllGamesForTeam']>();
+  listScheduledGamesForSeason = vi.fn<IScheduleRepository['listScheduledGamesForSeason']>();
   findTeamSeasonCalendarContext = vi.fn<IScheduleRepository['findTeamSeasonCalendarContext']>();
 }
 

--- a/draco-nodejs/backend/src/services/__tests__/statisticsService.standings.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/statisticsService.standings.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatisticsService } from '../statisticsService.js';
+import type {
+  IBattingStatisticsRepository,
+  IContactRepository,
+  ILeagueLeadersDisplayRepository,
+  IPitchingStatisticsRepository,
+  IScheduleRepository,
+} from '../../repositories/interfaces/index.js';
+import type { dbGameInfo } from '../../repositories/index.js';
+import { GameStatus } from '../../types/gameEnums.js';
+import { partialMock, partialPrismaMock } from '../../test-utils/partialMock.js';
+
+const makeRawTeam = (teamId: bigint, overrides: Record<string, unknown> = {}) => ({
+  teamName: `Team ${teamId}`,
+  teamId,
+  leagueId: 5n,
+  leagueName: 'Test League',
+  divisionId: 7n,
+  divisionName: 'East',
+  divisionPriority: 1,
+  w: 5,
+  l: 3,
+  t: 0,
+  div_w: 2,
+  div_l: 1,
+  div_t: 0,
+  rs: 40,
+  ra: 25,
+  ...overrides,
+});
+
+const makeGame = (id: bigint, overrides: Partial<dbGameInfo> = {}): dbGameInfo =>
+  ({
+    id,
+    gamedate: new Date('2025-06-15T18:00:00Z'),
+    hteamid: 10n,
+    vteamid: 20n,
+    leagueid: 5n,
+    fieldid: null,
+    hscore: null,
+    vscore: null,
+    gamestatus: GameStatus.Scheduled,
+    gametype: 0,
+    comment: null,
+    umpire1: null,
+    umpire2: null,
+    umpire3: null,
+    umpire4: null,
+    availablefields: null,
+    hometeam: { id: 10n, name: 'Home Team' },
+    visitingteam: { id: 20n, name: 'Visitor Team' },
+    leagueseason: { id: 5n, league: { name: 'Test League' } },
+    _count: { gamerecap: 0 },
+    ...overrides,
+  }) as dbGameInfo;
+
+describe('StatisticsService.getStandings', () => {
+  let queryRawUnsafe: ReturnType<typeof vi.fn>;
+  let scheduleRepository: IScheduleRepository;
+  let service: StatisticsService;
+
+  const buildService = () => {
+    queryRawUnsafe = vi.fn();
+    const prisma = partialPrismaMock({ $queryRawUnsafe: queryRawUnsafe });
+    scheduleRepository = partialMock<IScheduleRepository>({
+      listScheduledGamesForSeason: vi.fn().mockResolvedValue([]),
+    });
+    return new StatisticsService(
+      prisma,
+      partialMock<IBattingStatisticsRepository>({}),
+      partialMock<IPitchingStatisticsRepository>({}),
+      partialMock<ILeagueLeadersDisplayRepository>({}),
+      partialMock<IContactRepository>({}),
+      scheduleRepository,
+    );
+  };
+
+  beforeEach(() => {
+    service = buildService();
+  });
+
+  it('maps runs scored and runs against onto each standings row', async () => {
+    queryRawUnsafe.mockResolvedValue([
+      makeRawTeam(10n, { rs: 40, ra: 25 }),
+      makeRawTeam(20n, { rs: 18, ra: 33 }),
+    ]);
+
+    const standings = await service.getStandings(1n, 100n);
+
+    const team10 = standings.find((t) => t.teamId === 10n);
+    const team20 = standings.find((t) => t.teamId === 20n);
+    expect(team10).toMatchObject({ rs: 40, ra: 25 });
+    expect(team20).toMatchObject({ rs: 18, ra: 33 });
+  });
+
+  it('assigns each team its earliest scheduled game from home and away perspectives', async () => {
+    queryRawUnsafe.mockResolvedValue([makeRawTeam(10n), makeRawTeam(20n)]);
+
+    // Ordered by date ascending, as the repository returns them.
+    (scheduleRepository.listScheduledGamesForSeason as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeGame(100n, {
+        gamedate: new Date('2025-07-01T18:00:00Z'),
+        hteamid: 10n,
+        vteamid: 20n,
+        hometeam: { id: 10n, name: 'Team 10' },
+        visitingteam: { id: 20n, name: 'Team 20' },
+      }),
+      makeGame(200n, {
+        gamedate: new Date('2025-07-05T18:00:00Z'),
+        hteamid: 20n,
+        vteamid: 30n,
+        hometeam: { id: 20n, name: 'Team 20' },
+        visitingteam: { id: 30n, name: 'Team 30' },
+      }),
+    ]);
+
+    const standings = await service.getStandings(1n, 100n);
+
+    const team10 = standings.find((t) => t.teamId === 10n);
+    const team20 = standings.find((t) => t.teamId === 20n);
+
+    expect(team10?.nextGame).toEqual({
+      id: '100',
+      gameDate: new Date('2025-07-01T18:00:00Z').toISOString(),
+      opponentId: '20',
+      opponentName: 'Team 20',
+      isHome: true,
+    });
+
+    // Team 20's earliest game is still game 100 (as the away side), not game 200.
+    expect(team20?.nextGame).toEqual({
+      id: '100',
+      gameDate: new Date('2025-07-01T18:00:00Z').toISOString(),
+      opponentId: '10',
+      opponentName: 'Team 10',
+      isHome: false,
+    });
+  });
+
+  it('leaves nextGame undefined for teams without an upcoming game', async () => {
+    queryRawUnsafe.mockResolvedValue([makeRawTeam(10n), makeRawTeam(99n)]);
+    (scheduleRepository.listScheduledGamesForSeason as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeGame(100n, {
+        hteamid: 10n,
+        vteamid: 20n,
+        hometeam: { id: 10n, name: 'Team 10' },
+        visitingteam: { id: 20n, name: 'Team 20' },
+      }),
+    ]);
+
+    const standings = await service.getStandings(1n, 100n);
+
+    expect(standings.find((t) => t.teamId === 10n)?.nextGame).toBeDefined();
+    expect(standings.find((t) => t.teamId === 99n)?.nextGame).toBeUndefined();
+  });
+});

--- a/draco-nodejs/backend/src/services/serviceFactory.ts
+++ b/draco-nodejs/backend/src/services/serviceFactory.ts
@@ -346,12 +346,14 @@ export class ServiceFactory {
       const pitchingRepository = RepositoryFactory.getPitchingStatisticsRepository();
       const leagueLeadersRepository = RepositoryFactory.getLeagueLeadersDisplayRepository();
       const contactRepository = RepositoryFactory.getContactRepository();
+      const scheduleRepository = RepositoryFactory.getScheduleRepository();
       this.statisticsService = new StatisticsService(
         prisma,
         battingRepository,
         pitchingRepository,
         leagueLeadersRepository,
         contactRepository,
+        scheduleRepository,
       );
     }
     return this.statisticsService;

--- a/draco-nodejs/backend/src/services/statisticsService.ts
+++ b/draco-nodejs/backend/src/services/statisticsService.ts
@@ -17,6 +17,7 @@ import {
   IContactRepository,
   ILeagueLeadersDisplayRepository,
   IPitchingStatisticsRepository,
+  IScheduleRepository,
   PlayerTeamsQueryOptions,
 } from '../repositories/interfaces/index.js';
 import {
@@ -25,6 +26,7 @@ import {
   dbPlayerTeamAssignment,
   dbPlayerCareerBattingRow,
   dbPlayerCareerPitchingRow,
+  dbGameInfo,
 } from '../repositories/types/dbTypes.js';
 import { StatsResponseFormatter } from '../responseFormatters/statsResponseFormatter.js';
 import { NotFoundError } from '../utils/customErrors.js';
@@ -44,6 +46,15 @@ export interface StandingsRow {
   pct: number;
   gb: number; // games back
   divisionRecord?: { w: number; l: number; t: number };
+  rs: number; // runs scored
+  ra: number; // runs against
+  nextGame?: {
+    id: string;
+    gameDate: string;
+    opponentId: string;
+    opponentName: string;
+    isHome: boolean;
+  };
 }
 
 export interface GroupedStandingsResponse {
@@ -87,6 +98,7 @@ export class StatisticsService {
     private readonly pitchingStatisticsRepository: IPitchingStatisticsRepository,
     private readonly leagueLeadersDisplayRepository: ILeagueLeadersDisplayRepository,
     private readonly contactRepository: IContactRepository,
+    private readonly scheduleRepository: IScheduleRepository,
   ) {
     this.minimumCalculator = new MinimumCalculator(prisma);
   }
@@ -402,7 +414,17 @@ export class StatisticsService {
             AND hts.divisionseasonid = vts.divisionseasonid
             AND hts.divisionseasonid = ts.divisionseasonid
             AND hts.divisionseasonid IS NOT NULL
-          THEN 1 ELSE 0 END), 0)::int as div_t
+          THEN 1 ELSE 0 END), 0)::int as div_t,
+        -- Runs Scored
+        COALESCE(SUM(CASE
+          WHEN lg.gamestatus IN (1, 4) AND lg.hteamid = ts.id THEN lg.hscore
+          WHEN lg.gamestatus IN (1, 4) AND lg.vteamid = ts.id THEN lg.vscore
+          ELSE 0 END), 0)::int as rs,
+        -- Runs Against
+        COALESCE(SUM(CASE
+          WHEN lg.gamestatus IN (1, 4) AND lg.hteamid = ts.id THEN lg.vscore
+          WHEN lg.gamestatus IN (1, 4) AND lg.vteamid = ts.id THEN lg.hscore
+          ELSE 0 END), 0)::int as ra
       FROM teams t
       INNER JOIN teamsseason ts ON t.id = ts.teamid
       INNER JOIN leagueseason ls ON ts.leagueseasonid = ls.id
@@ -435,7 +457,11 @@ export class StatisticsService {
       div_w: number;
       div_l: number;
       div_t: number;
+      rs: number;
+      ra: number;
     }>;
+
+    const nextGames = await this.getNextGames(seasonId);
 
     // Map to StandingsRow format and calculate pct
     const standings: StandingsRow[] = rawStandings.map((team) => {
@@ -459,10 +485,52 @@ export class StatisticsService {
         pct,
         gb: 0, // Will be calculated later
         divisionRecord: { w: team.div_w, l: team.div_l, t: team.div_t },
+        rs: Number(team.rs),
+        ra: Number(team.ra),
+        nextGame: nextGames.get(team.teamId.toString()),
       };
     });
 
     return standings;
+  }
+
+  private async getNextGames(
+    seasonId: bigint,
+  ): Promise<Map<string, NonNullable<StandingsRow['nextGame']>>> {
+    const games: dbGameInfo[] = await this.scheduleRepository.listScheduledGamesForSeason(
+      seasonId,
+      new Date(),
+    );
+
+    const nextGames = new Map<string, NonNullable<StandingsRow['nextGame']>>();
+
+    for (const game of games) {
+      const gameDate = game.gamedate.toISOString();
+      const homeId = game.hteamid.toString();
+      const awayId = game.vteamid.toString();
+
+      if (!nextGames.has(homeId)) {
+        nextGames.set(homeId, {
+          id: game.id.toString(),
+          gameDate,
+          opponentId: game.visitingteam.id.toString(),
+          opponentName: game.visitingteam.name,
+          isHome: true,
+        });
+      }
+
+      if (!nextGames.has(awayId)) {
+        nextGames.set(awayId, {
+          id: game.id.toString(),
+          gameDate,
+          opponentId: game.hometeam.id.toString(),
+          opponentName: game.hometeam.name,
+          isHome: false,
+        });
+      }
+    }
+
+    return nextGames;
   }
 
   async getGroupedStandings(

--- a/draco-nodejs/frontend-next/components/Standings.tsx
+++ b/draco-nodejs/frontend-next/components/Standings.tsx
@@ -12,7 +12,6 @@ import {
   TableHead,
   TableRow,
   Paper,
-  Chip,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import Link from 'next/link';
@@ -20,6 +19,7 @@ import { getSeasonStandings } from '@draco/shared-api-client';
 import type { SeasonStandingsResponse } from '@draco/shared-api-client';
 import { StandingsLeagueType, StandingsTeamType } from '@draco/shared-schemas';
 import { useApiClient } from '../hooks/useApiClient';
+import { useAccountSettings } from '../hooks/useAccountSettings';
 import { unwrapApiResult } from '../utils/apiResult';
 import WidgetShell from './ui/WidgetShell';
 
@@ -51,6 +51,40 @@ const formatTies = (value: number): string => {
   return value.toString();
 };
 
+const PYTHAGOREAN_EXPONENT = 2;
+
+const formatRuns = (value: number): string => {
+  const num = Number.isFinite(value) ? value : 0;
+  return Math.round(num).toString();
+};
+
+export const formatRunDifferential = (rs: number, ra: number): string => {
+  const diff = (Number.isFinite(rs) ? rs : 0) - (Number.isFinite(ra) ? ra : 0);
+  if (diff > 0) return `+${diff}`;
+  return diff.toString();
+};
+
+export const formatExpectedRecord = (rs: number, ra: number, games: number): string => {
+  if (games <= 0 || rs + ra <= 0) return '-';
+  const scored = Math.pow(rs, PYTHAGOREAN_EXPONENT);
+  const allowed = Math.pow(ra, PYTHAGOREAN_EXPONENT);
+  const expectedWinPct = scored / (scored + allowed);
+  const expectedWins = Math.round(expectedWinPct * games);
+  const expectedLosses = games - expectedWins;
+  return `${expectedWins}-${expectedLosses}`;
+};
+
+const nextGameDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+});
+
+const formatNextGameDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return nextGameDateFormatter.format(date);
+};
+
 export default function Standings({
   accountId,
   seasonId,
@@ -58,9 +92,17 @@ export default function Standings({
   showHeader = true,
 }: StandingsProps) {
   const apiClient = useApiClient();
+  const { settings: accountSettings } = useAccountSettings(accountId);
   const [groupedStandings, setGroupedStandings] = useState<StandingsLeagueType[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const showDivisionRecord =
+    accountSettings?.some(
+      (setting) =>
+        setting.definition.key === 'UseDivisionRecordInStandings' &&
+        setting.effectiveValue === true,
+    ) ?? false;
 
   useEffect(() => {
     if (!seasonId || seasonId === '0') return;
@@ -119,7 +161,7 @@ export default function Standings({
       component={Paper}
       sx={{
         mb: 3,
-        maxWidth: 800,
+        maxWidth: 1150,
         mx: 'auto',
         borderRadius: 2,
         backgroundColor: (theme) => theme.palette.widget.surface,
@@ -141,7 +183,7 @@ export default function Standings({
           <TableRow
             sx={{
               backgroundColor: (theme) =>
-                alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.2 : 0.08),
+                alpha(theme.palette.text.primary, theme.palette.mode === 'dark' ? 0.08 : 0.04),
               '& .MuiTableCell-root': {
                 borderBottom: (theme) => `1px solid ${theme.palette.widget.border}`,
                 color: (theme) => theme.palette.widget.headerText,
@@ -164,21 +206,32 @@ export default function Standings({
             <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
               GB
             </TableCell>
+            {showDivisionRecord && (
+              <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
+                Div
+              </TableCell>
+            )}
             <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
-              Div
+              RS
             </TableCell>
+            <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
+              RA
+            </TableCell>
+            <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
+              DIFF
+            </TableCell>
+            <TableCell align="right" sx={{ fontWeight: 600, whiteSpace: 'nowrap', width: '1%' }}>
+              X-W/L
+            </TableCell>
+            <TableCell sx={{ fontWeight: 600, whiteSpace: 'nowrap' }}>NEXT GAME</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortTeams(teams).map((team, index) => (
+          {sortTeams(teams).map((team) => (
             <TableRow
               key={team.team.id}
               sx={{
                 '&:hover': { backgroundColor: (theme) => theme.palette.action.hover },
-                backgroundColor: (theme) =>
-                  index === 0
-                    ? alpha(theme.palette.success.main, theme.palette.mode === 'dark' ? 0.3 : 0.12)
-                    : 'transparent',
                 borderBottom: (theme) => `1px solid ${theme.palette.widget.border}`,
               }}
             >
@@ -194,19 +247,9 @@ export default function Standings({
                   },
                 }}
               >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                  <Link href={`/account/${accountId}/seasons/${seasonId}/teams/${team.team.id}`}>
-                    {team.team.name ?? 'Unnamed Team'}
-                  </Link>
-                  {index === 0 && (
-                    <Chip
-                      label="1st"
-                      size="small"
-                      color="success"
-                      sx={{ fontSize: '0.65rem', height: 18, ml: 0.5 }}
-                    />
-                  )}
-                </Box>
+                <Link href={`/account/${accountId}/seasons/${seasonId}/teams/${team.team.id}`}>
+                  {team.team.name ?? 'Unnamed Team'}
+                </Link>
               </TableCell>
               <TableCell
                 align="right"
@@ -223,10 +266,9 @@ export default function Standings({
               <TableCell
                 align="right"
                 sx={{
-                  fontWeight: 700,
+                  fontWeight: 600,
                   whiteSpace: 'nowrap',
                   width: '1%',
-                  color: (theme) => theme.palette.primary.main,
                 }}
               >
                 {formatPercentage(team.pct)}
@@ -234,16 +276,82 @@ export default function Standings({
               <TableCell align="right" sx={{ whiteSpace: 'nowrap', width: '1%' }}>
                 {formatGamesBehind(team.gb)}
               </TableCell>
+              {showDivisionRecord && (
+                <TableCell
+                  align="right"
+                  sx={{
+                    fontSize: '0.875rem',
+                    whiteSpace: 'nowrap',
+                    width: '1%',
+                    color: 'text.secondary',
+                  }}
+                >
+                  {formatDivisionRecord(team.divisionRecord)}
+                </TableCell>
+              )}
+              <TableCell align="right" sx={{ whiteSpace: 'nowrap', width: '1%' }}>
+                {formatRuns(team.rs)}
+              </TableCell>
+              <TableCell align="right" sx={{ whiteSpace: 'nowrap', width: '1%' }}>
+                {formatRuns(team.ra)}
+              </TableCell>
               <TableCell
                 align="right"
                 sx={{
-                  fontSize: '0.875rem',
+                  fontWeight: 'medium',
                   whiteSpace: 'nowrap',
                   width: '1%',
-                  color: 'text.secondary',
+                  color: (theme) => {
+                    const diff = team.rs - team.ra;
+                    if (diff > 0) return theme.palette.success.main;
+                    if (diff < 0) return theme.palette.error.main;
+                    return theme.palette.text.secondary;
+                  },
                 }}
               >
-                {formatDivisionRecord(team.divisionRecord)}
+                {formatRunDifferential(team.rs, team.ra)}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ whiteSpace: 'nowrap', width: '1%', color: 'text.secondary' }}
+              >
+                {formatExpectedRecord(team.rs, team.ra, team.w + team.l + team.t)}
+              </TableCell>
+              <TableCell
+                sx={{
+                  whiteSpace: 'nowrap',
+                  color: 'text.secondary',
+                  '& a': {
+                    color: 'primary.main',
+                    textDecoration: 'none',
+                    '&:hover': { textDecoration: 'underline' },
+                  },
+                }}
+              >
+                {team.nextGame ? (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <span>
+                      {formatNextGameDate(team.nextGame.gameDate)}
+                      {team.nextGame.isHome ? ' vs. ' : ' @ '}
+                    </span>
+                    <Link
+                      href={`/account/${accountId}/seasons/${seasonId}/teams/${team.nextGame.opponent.id}`}
+                      title={team.nextGame.opponent.name ?? undefined}
+                      style={{
+                        display: 'inline-block',
+                        maxWidth: '6rem',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        verticalAlign: 'bottom',
+                      }}
+                    >
+                      {team.nextGame.opponent.name ?? 'Unnamed Team'}
+                    </Link>
+                  </Box>
+                ) : (
+                  '-'
+                )}
               </TableCell>
             </TableRow>
           ))}
@@ -256,7 +364,7 @@ export default function Standings({
     if (!groupedStandings) return null;
 
     return (
-      <Box sx={{ maxWidth: 1000, mx: 'auto' }}>
+      <Box sx={{ maxWidth: 1250, mx: 'auto' }}>
         {groupedStandings.map((league) => (
           <Box key={league.league.id ?? 'no-league'} sx={{ mb: 5 }}>
             <Typography
@@ -266,7 +374,7 @@ export default function Standings({
                 fontWeight: 'bold',
                 textAlign: 'center',
                 color: (theme) => theme.palette.widget.headerText,
-                borderBottom: (theme) => `2px solid ${theme.palette.primary.main}`,
+                borderBottom: (theme) => `2px solid ${theme.palette.widget.border}`,
                 pb: 1,
                 letterSpacing: '0.05em',
               }}
@@ -286,12 +394,11 @@ export default function Standings({
                       mb: 2,
                       fontWeight: 700,
                       textAlign: 'center',
-                      color: (theme) => theme.palette.secondary.main,
+                      color: (theme) => theme.palette.text.secondary,
                       textTransform: 'uppercase',
                       fontSize: '1rem',
                       letterSpacing: '0.08em',
-                      borderBottom: (theme) =>
-                        `1px solid ${alpha(theme.palette.secondary.main, 0.4)}`,
+                      borderBottom: (theme) => `1px solid ${theme.palette.widget.border}`,
                       pb: 0.5,
                       display: 'inline-block',
                       minWidth: '200px',

--- a/draco-nodejs/frontend-next/components/__tests__/Standings.test.tsx
+++ b/draco-nodejs/frontend-next/components/__tests__/Standings.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { formatExpectedRecord, formatRunDifferential } from '../Standings';
+
+describe('formatRunDifferential', () => {
+  it('prefixes positive differentials with a plus sign', () => {
+    expect(formatRunDifferential(40, 25)).toBe('+15');
+  });
+
+  it('renders negative differentials with a minus sign', () => {
+    expect(formatRunDifferential(18, 33)).toBe('-15');
+  });
+
+  it('renders an even differential as 0', () => {
+    expect(formatRunDifferential(30, 30)).toBe('0');
+  });
+});
+
+describe('formatExpectedRecord', () => {
+  it('splits games evenly when runs scored equals runs against', () => {
+    // ExpWin% = 1/2, so 10 games -> 5-5.
+    expect(formatExpectedRecord(50, 50, 10)).toBe('5-5');
+  });
+
+  it('is win-heavy when runs scored greatly exceeds runs against', () => {
+    // 100^2 / (100^2 + 50^2) = 0.8 -> round(0.8 * 10) = 8 wins.
+    expect(formatExpectedRecord(100, 50, 10)).toBe('8-2');
+  });
+
+  it('is loss-heavy when runs against greatly exceeds runs scored', () => {
+    expect(formatExpectedRecord(50, 100, 10)).toBe('2-8');
+  });
+
+  it('returns a dash when no games have been played', () => {
+    expect(formatExpectedRecord(0, 0, 0)).toBe('-');
+  });
+
+  it('returns a dash when no runs have been recorded', () => {
+    expect(formatExpectedRecord(0, 0, 8)).toBe('-');
+  });
+});

--- a/draco-nodejs/shared/shared-schemas/accountSettings.ts
+++ b/draco-nodejs/shared/shared-schemas/accountSettings.ts
@@ -35,6 +35,7 @@ export const ACCOUNT_SETTING_KEYS = [
   'NotifyTeamsWantedOnPlayersWanted',
   'NotifyPlayersWantedOnTeamsWanted',
   'EnableLiveScoring',
+  'UseDivisionRecordInStandings',
 ] as const;
 
 export const AccountSettingKeySchema = z.enum(ACCOUNT_SETTING_KEYS);
@@ -652,6 +653,15 @@ export const ACCOUNT_SETTING_DEFINITIONS: AccountSettingDefinition[] = [
         expectedValue: true,
       },
     ],
+  }),
+  booleanSetting({
+    key: 'UseDivisionRecordInStandings',
+    label: 'Show Division Record in Standings',
+    description:
+      'Adds a Division (Div) record column to the standings tables. Useful when teams play games against other divisions; otherwise the division record always matches the overall record.',
+    groupId: AccountSettingGroupEnum.enum.accountFeatures,
+    groupLabel: 'Account Features',
+    sortOrder: 25,
   }),
 ];
 

--- a/draco-nodejs/shared/shared-schemas/standing.ts
+++ b/draco-nodejs/shared/shared-schemas/standing.ts
@@ -3,6 +3,8 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { DivisionNameSchema, DivisionSeasonSchema } from './division.js';
 import { LeagueNameSchema } from './league.js';
 import { TeamSeasonNameSchema, TeamSeasonSchema } from './team.js';
+import { bigintToStringSchema } from './standardSchema.js';
+import { isoDateTimeSchema } from './date.js';
 
 extendZodWithOpenApi(z);
 
@@ -13,8 +15,8 @@ export const TeamRecordSchema = z.object({
 });
 
 export const StandingsNextGameSchema = z.object({
-  id: z.string(),
-  gameDate: z.string(),
+  id: bigintToStringSchema,
+  gameDate: isoDateTimeSchema,
   opponent: TeamSeasonNameSchema,
   isHome: z.boolean(),
 });

--- a/draco-nodejs/shared/shared-schemas/standing.ts
+++ b/draco-nodejs/shared/shared-schemas/standing.ts
@@ -12,6 +12,13 @@ export const TeamRecordSchema = z.object({
   t: z.number(),
 });
 
+export const StandingsNextGameSchema = z.object({
+  id: z.string(),
+  gameDate: z.string(),
+  opponent: TeamSeasonNameSchema,
+  isHome: z.boolean(),
+});
+
 export const StandingsTeamSchema = TeamRecordSchema.extend({
   team: TeamSeasonNameSchema,
   league: LeagueNameSchema.optional(),
@@ -19,6 +26,9 @@ export const StandingsTeamSchema = TeamRecordSchema.extend({
   pct: z.number(),
   gb: z.number(),
   divisionRecord: TeamRecordSchema.optional(),
+  rs: z.number(),
+  ra: z.number(),
+  nextGame: StandingsNextGameSchema.optional(),
 });
 
 export const StandingsDivisionSchema = z.object({
@@ -36,6 +46,7 @@ export const TeamSeasonRecordSchema = TeamSeasonSchema.extend({
 });
 
 export type TeamRecordType = z.infer<typeof TeamRecordSchema>;
+export type StandingsNextGameType = z.infer<typeof StandingsNextGameSchema>;
 export type StandingsTeamType = z.infer<typeof StandingsTeamSchema>;
 export type StandingsDivisionType = z.infer<typeof StandingsDivisionSchema>;
 export type StandingsLeagueType = z.infer<typeof StandingsLeagueSchema>;


### PR DESCRIPTION
Expose runs scored (rs), runs against (ra) and next scheduled game on standings rows across backend and frontend. Backend: update OpenAPI (json/yaml) schemas, extend shared standing schema, add IScheduleRepository.listScheduledGamesForSeason and its Prisma implementation, inject schedule repository via ServiceFactory, compute rs/ra in StatisticsService SQL and resolve nextGame mapping from scheduled games. Also update standings route output. Frontend: update Standings component to show RS, RA, DIFF, expected record and NEXT GAME display, add account setting toggle (UseDivisionRecordInStandings) and corresponding shared schema/definition, adjust styles/layout, and add unit tests for statistics service and Standings formatting. Tests: add statisticsService.standings.test.ts and Standings.test.tsx; update scheduler test stub to include new repo method. OpenAPI docs updated to include new fields and account setting key.