### PR TITLE
Add drag-and-drop column reordering for stats

### DIFF
--- a/draco-nodejs/frontend-next/components/statistics/SortableStatHeaderCell.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/SortableStatHeaderCell.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React from 'react';
+import { Box, TableCell, TableSortLabel, Tooltip, Typography, alpha } from '@mui/material';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+export interface StatHeaderColumn {
+  field: string;
+  label: string;
+  align: 'left' | 'right' | 'center';
+  tooltip?: string;
+  sortable?: boolean;
+}
+
+interface StatHeaderLabelProps {
+  column: StatHeaderColumn;
+  activeField?: string;
+  sortOrder: 'asc' | 'desc';
+  onSort?: (field: string) => void;
+}
+
+export const StatHeaderLabel: React.FC<StatHeaderLabelProps> = ({
+  column,
+  activeField,
+  sortOrder,
+  onSort,
+}) => {
+  const justifyContent =
+    column.align === 'right' ? 'flex-end' : column.align === 'center' ? 'center' : 'flex-start';
+  const sharedSx = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent,
+    width: '100%',
+    textAlign: column.align,
+    gap: column.align === 'center' ? 0.5 : 0.25,
+  } as const;
+  const labelNode = (
+    <Box component="span" sx={{ flexShrink: 0 }}>
+      {column.label}
+    </Box>
+  );
+  const centerFiller =
+    column.align === 'center' ? (
+      <Box
+        component="span"
+        sx={{ display: 'inline-block', width: '1.5em', flexShrink: 0 }}
+        aria-hidden="true"
+      />
+    ) : null;
+
+  if (column.sortable !== false && onSort) {
+    return (
+      <Tooltip title={column.tooltip || ''}>
+        <TableSortLabel
+          active={activeField === column.field}
+          direction={activeField === column.field ? sortOrder : 'asc'}
+          onClick={() => onSort(String(column.field))}
+          sx={{
+            ...sharedSx,
+            '& .MuiTableSortLabel-icon': {
+              order: -1,
+              marginRight: column.align === 'center' ? 0.5 : 0.25,
+              marginLeft: 0,
+            },
+          }}
+        >
+          {labelNode}
+          {centerFiller}
+        </TableSortLabel>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={column.tooltip || ''}>
+      <Typography variant="inherit" component="span" sx={sharedSx}>
+        {labelNode}
+        {centerFiller}
+      </Typography>
+    </Tooltip>
+  );
+};
+
+interface SortableStatHeaderCellProps extends StatHeaderLabelProps {
+  active: boolean;
+}
+
+export const SortableStatHeaderCell: React.FC<SortableStatHeaderCellProps> = ({
+  column,
+  activeField,
+  sortOrder,
+  onSort,
+  active,
+}) => {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: column.field,
+  });
+
+  return (
+    <TableCell
+      ref={setNodeRef}
+      align={column.align}
+      aria-roledescription="sortable column"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      sx={{
+        fontWeight: 'bold',
+        cursor: 'grab',
+        touchAction: 'none',
+        userSelect: 'none',
+        opacity: isDragging ? 0.6 : 1,
+        zIndex: isDragging ? 3 : undefined,
+        backgroundColor: 'background.paper',
+        ...(active && {
+          backgroundColor: (theme) => alpha(theme.palette.action.hover, 0.02),
+        }),
+      }}
+      {...listeners}
+    >
+      <StatHeaderLabel
+        column={column}
+        activeField={activeField}
+        sortOrder={sortOrder}
+        onSort={onSort}
+      />
+    </TableCell>
+  );
+};

--- a/draco-nodejs/frontend-next/components/statistics/SortableStatHeaderCell.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/SortableStatHeaderCell.tsx
@@ -94,7 +94,7 @@ export const SortableStatHeaderCell: React.FC<SortableStatHeaderCellProps> = ({
   onSort,
   active,
 }) => {
-  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: column.field,
   });
 
@@ -102,6 +102,8 @@ export const SortableStatHeaderCell: React.FC<SortableStatHeaderCellProps> = ({
     <TableCell
       ref={setNodeRef}
       align={column.align}
+      {...attributes}
+      role="columnheader"
       aria-roledescription="sortable column"
       style={{
         transform: CSS.Transform.toString(transform),

--- a/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
@@ -5,23 +5,35 @@ import NextLink from 'next/link';
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
 import {
   Box,
+  Button,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  TableSortLabel,
   Paper,
   Typography,
   CircularProgress,
-  Tooltip,
   alpha,
   Chip,
 } from '@mui/material';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, horizontalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 
 import ScrollableTable from './ScrollableTable';
 import TeamBadges from './TeamBadges';
+import { SortableStatHeaderCell, StatHeaderLabel } from './SortableStatHeaderCell';
+import { useStatColumnOrder, applyColumnOrder } from '../../hooks/useStatColumnOrder';
 import {
   BATTING_FIELD_LABELS,
   BATTING_FIELD_TOOLTIPS,
@@ -42,6 +54,7 @@ export interface ColumnConfig<T> {
   tooltip?: string;
   primary?: boolean;
   sortable?: boolean;
+  pinned?: boolean;
   formatter?: (value: unknown, row: T) => React.ReactNode;
   render?: (args: {
     value: unknown;
@@ -64,6 +77,8 @@ interface StatisticsTableBaseProps<T> {
   hideHeader?: boolean;
   maxHeight?: string | number;
   fullWidth?: boolean;
+  reorderable?: boolean;
+  onColumnReorder?: (newReorderableOrder: string[]) => void;
 }
 
 export const StatisticsTableBase = <T extends Record<string, unknown>>({
@@ -78,9 +93,35 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
   hideHeader = false,
   maxHeight,
   fullWidth = false,
+  reorderable = false,
+  onColumnReorder,
 }: StatisticsTableBaseProps<T>) => {
   const activeField = sortField !== undefined ? String(sortField) : undefined;
   const dataVersion = `${String(activeField)}-${sortOrder}-${data.length}`;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+  );
+
+  const reorderableFieldIds = columns
+    .filter((column) => !column.pinned)
+    .map((column) => column.field);
+  const reorderEnabled =
+    reorderable && !hideHeader && !!onColumnReorder && reorderableFieldIds.length > 1;
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+    const oldIndex = reorderableFieldIds.indexOf(String(active.id));
+    const newIndex = reorderableFieldIds.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) {
+      return;
+    }
+    onColumnReorder?.(arrayMove(reorderableFieldIds, oldIndex, newIndex));
+  };
 
   if (loading) {
     return (
@@ -119,167 +160,139 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
     return String(value);
   };
 
-  return (
-    <ScrollableTable preserveScrollOnUpdate dataVersion={dataVersion}>
-      <TableContainer
-        component={Paper}
+  const tableContent = (
+    <TableContainer
+      component={Paper}
+      sx={{
+        width: fullWidth ? '100%' : 'fit-content',
+        maxWidth: '100%',
+        ...(maxHeight
+          ? {
+              maxHeight,
+              overflowY: 'auto',
+            }
+          : {}),
+        '& .MuiTableHead-root': {
+          position: 'sticky',
+          top: 0,
+          zIndex: 2,
+          backgroundColor: 'background.paper',
+        },
+      }}
+    >
+      <Table
+        size="small"
+        stickyHeader={!hideHeader}
         sx={{
-          width: fullWidth ? '100%' : 'fit-content',
-          maxWidth: '100%',
-          ...(maxHeight
-            ? {
-                maxHeight,
-                overflowY: 'auto',
-              }
-            : {}),
-          '& .MuiTableHead-root': {
-            position: 'sticky',
-            top: 0,
-            zIndex: 2,
-            backgroundColor: 'background.paper',
+          width: fullWidth ? '100%' : 'auto',
+          tableLayout: 'auto',
+          '& .MuiTableCell-root': {
+            py: 0.75,
+            px: 1.25,
+            fontSize: '0.85rem',
+            whiteSpace: 'nowrap',
+          },
+          '& .MuiTableCell-head': {
+            fontSize: '0.75rem',
+            letterSpacing: 0.4,
           },
         }}
       >
-        <Table
-          size="small"
-          stickyHeader={!hideHeader}
-          sx={{
-            width: fullWidth ? '100%' : 'auto',
-            tableLayout: 'auto',
-            '& .MuiTableCell-root': {
-              py: 0.75,
-              px: 1.25,
-              fontSize: '0.85rem',
-              whiteSpace: 'nowrap',
-            },
-            '& .MuiTableCell-head': {
-              fontSize: '0.75rem',
-              letterSpacing: 0.4,
-            },
-          }}
-        >
-          {!hideHeader && (
-            <TableHead>
-              <TableRow>
-                {columns.map((column) => (
+        {!hideHeader && (
+          <TableHead>
+            <TableRow>
+              {columns.map((column) => {
+                const active = activeField === column.field;
+                if (reorderEnabled && !column.pinned) {
+                  return (
+                    <SortableStatHeaderCell
+                      key={column.field}
+                      column={column}
+                      activeField={activeField}
+                      sortOrder={sortOrder}
+                      onSort={onSort}
+                      active={active}
+                    />
+                  );
+                }
+                return (
                   <TableCell
                     key={column.field}
                     align={column.align}
                     sx={{
                       fontWeight: 'bold',
                       backgroundColor: 'background.paper',
-                      ...(sortField === column.field && {
+                      ...(active && {
                         backgroundColor: (theme) => alpha(theme.palette.action.hover, 0.02),
                       }),
                     }}
                   >
-                    {(() => {
-                      const justifyContent =
-                        column.align === 'right'
-                          ? 'flex-end'
-                          : column.align === 'center'
-                            ? 'center'
-                            : 'flex-start';
-                      const sharedSx = {
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        justifyContent,
-                        width: '100%',
-                        textAlign: column.align,
-                        gap: column.align === 'center' ? 0.5 : 0.25,
-                      } as const;
-                      const labelNode = (
-                        <Box component="span" sx={{ flexShrink: 0 }}>
-                          {column.label}
-                        </Box>
-                      );
-                      const centerFiller =
-                        column.align === 'center' ? (
-                          <Box
-                            component="span"
-                            sx={{ display: 'inline-block', width: '1.5em', flexShrink: 0 }}
-                            aria-hidden="true"
-                          />
-                        ) : null;
-
-                      if (column.sortable !== false && onSort) {
-                        return (
-                          <Tooltip title={column.tooltip || ''}>
-                            <TableSortLabel
-                              active={activeField === column.field}
-                              direction={activeField === column.field ? sortOrder : 'asc'}
-                              onClick={() => onSort(String(column.field))}
-                              sx={{
-                                ...sharedSx,
-                                '& .MuiTableSortLabel-icon': {
-                                  order: -1,
-                                  marginRight: column.align === 'center' ? 0.5 : 0.25,
-                                  marginLeft: 0,
-                                },
-                              }}
-                            >
-                              {labelNode}
-                              {centerFiller}
-                            </TableSortLabel>
-                          </Tooltip>
-                        );
-                      }
-
-                      return (
-                        <Tooltip title={column.tooltip || ''}>
-                          <Typography variant="inherit" component="span" sx={sharedSx}>
-                            {labelNode}
-                            {centerFiller}
-                          </Typography>
-                        </Tooltip>
-                      );
-                    })()}
+                    <StatHeaderLabel
+                      column={column}
+                      activeField={activeField}
+                      sortOrder={sortOrder}
+                      onSort={onSort}
+                    />
                   </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-          )}
-          <TableBody>
-            {data.map((row, index) => (
-              <TableRow
-                key={getRowKey(row, index)}
-                hover
-                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-              >
-                {columns.map((column) => {
-                  const value = row[column.field];
-                  const formattedValue = column.formatter ? column.formatter(value, row) : value;
-                  const normalizedFormattedValue = normalizeToReactNode(formattedValue);
-                  const rendered = column.render
-                    ? column.render({
-                        value,
-                        formattedValue: normalizedFormattedValue,
-                        row,
-                        rowIndex: index,
-                        column,
-                      })
-                    : normalizedFormattedValue;
-                  const content = normalizeToReactNode(rendered);
+                );
+              })}
+            </TableRow>
+          </TableHead>
+        )}
+        <TableBody>
+          {data.map((row, index) => (
+            <TableRow
+              key={getRowKey(row, index)}
+              hover
+              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+            >
+              {columns.map((column) => {
+                const value = row[column.field];
+                const formattedValue = column.formatter ? column.formatter(value, row) : value;
+                const normalizedFormattedValue = normalizeToReactNode(formattedValue);
+                const rendered = column.render
+                  ? column.render({
+                      value,
+                      formattedValue: normalizedFormattedValue,
+                      row,
+                      rowIndex: index,
+                      column,
+                    })
+                  : normalizedFormattedValue;
+                const content = normalizeToReactNode(rendered);
 
-                  return (
-                    <TableCell
-                      key={column.field}
-                      align={column.align}
-                      sx={{
-                        ...(activeField === column.field && {
-                          backgroundColor: (theme) => alpha(theme.palette.action.hover, 0.04),
-                        }),
-                      }}
-                    >
-                      {content}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+                return (
+                  <TableCell
+                    key={column.field}
+                    align={column.align}
+                    sx={{
+                      ...(activeField === column.field && {
+                        backgroundColor: (theme) => alpha(theme.palette.action.hover, 0.04),
+                      }),
+                    }}
+                  >
+                    {content}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  return (
+    <ScrollableTable preserveScrollOnUpdate dataVersion={dataVersion}>
+      {reorderEnabled ? (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={reorderableFieldIds} strategy={horizontalListSortingStrategy}>
+            {tableContent}
+          </SortableContext>
+        </DndContext>
+      ) : (
+        tableContent
+      )}
     </ScrollableTable>
   );
 };
@@ -335,6 +348,7 @@ interface SharedStatisticsTableProps<T extends StatsRowBase> {
   omitFields?: string[];
   buildPlayerHref?: (row: T) => string | null;
   playerLinkLabel?: string;
+  disableColumnReorder?: boolean;
 }
 
 const BATTER_COMPACT_FIELDS: ReadonlyArray<string> = [
@@ -591,6 +605,10 @@ const buildColumns = <T extends StatsRowBase>(
       align,
     };
 
+    if (field === 'playerNumber' || field === 'playerName' || field === 'teamName') {
+      columnConfig.pinned = true;
+    }
+
     if (field === 'teamName') {
       columnConfig.sortable = false;
     }
@@ -647,7 +665,9 @@ const StatisticsTable = <T extends StatsRowBase>({
   omitFields,
   buildPlayerHref,
   playerLinkLabel,
+  disableColumnReorder,
 }: SharedStatisticsTableProps<T>) => {
+  const { order, isCustomized, applyReorder, reset } = useStatColumnOrder(variant);
   const params = useParams();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -709,37 +729,70 @@ const StatisticsTable = <T extends StatsRowBase>({
   const resolvedBuildPlayerHref = buildPlayerHref ?? defaultBuildPlayerHref;
 
   const omitSet = new Set(omitFields ?? []);
-  const columns = (() => {
-    const baseColumns = buildColumns<T>(
-      variant,
-      extendedStats,
-      data,
-      omitSet,
-      resolvedBuildPlayerHref,
-    );
-    if (!prependColumns || prependColumns.length === 0) {
-      return baseColumns;
-    }
-    return [...prependColumns, ...baseColumns];
-  })();
+  const baseColumns = buildColumns<T>(
+    variant,
+    extendedStats,
+    data,
+    omitSet,
+    resolvedBuildPlayerHref,
+  );
+  const preparedColumns =
+    !prependColumns || prependColumns.length === 0
+      ? baseColumns
+      : [...prependColumns.map((column) => ({ ...column, pinned: true })), ...baseColumns];
+
+  const pinnedColumns = preparedColumns.filter((column) => column.pinned);
+  const reorderableColumns = preparedColumns.filter((column) => !column.pinned);
+  const reorderableFields = reorderableColumns.map((column) => String(column.field));
+  const reorderableByField = new Map(
+    reorderableColumns.map((column) => [String(column.field), column]),
+  );
+  const reorderedColumns = applyColumnOrder(reorderableFields, order)
+    .map((field) => reorderableByField.get(field))
+    .filter((column): column is ColumnConfig<T> => Boolean(column));
+  const columns = [...pinnedColumns, ...reorderedColumns];
+
+  const reorderActive = !disableColumnReorder && !hideHeader;
+  const showReset = reorderActive && isCustomized;
 
   const handleInternalSort = (field: string) => {
     onSort?.(field);
   };
 
+  const handleColumnReorder = (newReorderableOrder: string[]) => {
+    applyReorder(reorderableFields, newReorderableOrder);
+  };
+
   return (
-    <StatisticsTableBase
-      data={data}
-      columns={columns}
-      loading={loading}
-      emptyMessage={emptyMessage}
-      getRowKey={getRowKey}
-      sortField={sortField}
-      sortOrder={sortOrder}
-      onSort={handleInternalSort}
-      hideHeader={hideHeader}
-      maxHeight={maxHeight}
-    />
+    <Box>
+      {showReset && (
+        <Box sx={{ mb: 0.5 }}>
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<RestartAltIcon fontSize="small" />}
+            onClick={reset}
+            sx={{ textTransform: 'none' }}
+          >
+            Reset columns
+          </Button>
+        </Box>
+      )}
+      <StatisticsTableBase
+        data={data}
+        columns={columns}
+        loading={loading}
+        emptyMessage={emptyMessage}
+        getRowKey={getRowKey}
+        sortField={sortField}
+        sortOrder={sortOrder}
+        onSort={handleInternalSort}
+        hideHeader={hideHeader}
+        maxHeight={maxHeight}
+        reorderable={reorderActive}
+        onColumnReorder={handleColumnReorder}
+      />
+    </Box>
   );
 };
 

--- a/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/StatisticsTable.tsx
@@ -22,13 +22,19 @@ import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import {
   DndContext,
   closestCenter,
+  KeyboardSensor,
   PointerSensor,
   TouchSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
 } from '@dnd-kit/core';
-import { SortableContext, horizontalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  arrayMove,
+} from '@dnd-kit/sortable';
 
 import ScrollableTable from './ScrollableTable';
 import TeamBadges from './TeamBadges';
@@ -102,6 +108,7 @@ export const StatisticsTableBase = <T extends Record<string, unknown>>({
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
   const reorderableFieldIds = columns

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StatisticsTable, { type StatsRowBase } from '../StatisticsTable';
+import { statColumnOrderKey } from '../../../constants/storageKeys';
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ accountId: '1' }),
@@ -57,5 +58,72 @@ describe('StatisticsTable player links', () => {
 
     expect(screen.getByText('Totals')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Totals' })).not.toBeInTheDocument();
+  });
+});
+
+describe('StatisticsTable column reordering', () => {
+  const battingKey = statColumnOrderKey('batting');
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const renderExtended = (data: Row[]) =>
+    render(
+      <StatisticsTable
+        variant="batting"
+        extendedStats
+        data={data}
+        getRowKey={(row) => (row as Row).id}
+      />,
+    );
+
+  const headerLabels = (): string[] =>
+    screen.getAllByRole('columnheader').map((cell) => cell.textContent?.trim() ?? '');
+
+  it('applies a persisted column order, moving PA ahead of AB while keeping Player pinned first', () => {
+    window.localStorage.setItem(battingKey, JSON.stringify(['pa', 'ab']));
+
+    renderExtended([{ id: 'r1', playerName: 'Ordered Player', contactId: '1', ab: 10, pa: 12 }]);
+
+    const labels = headerLabels();
+    const playerIdx = labels.indexOf('Player');
+    const paIdx = labels.indexOf('PA');
+    const abIdx = labels.indexOf('AB');
+
+    expect(playerIdx).toBe(1);
+    expect(paIdx).toBeGreaterThan(playerIdx);
+    expect(paIdx).toBeLessThan(abIdx);
+  });
+
+  it('renders stat headers as sortable draggable cells but leaves pinned identity columns non-draggable', () => {
+    renderExtended([{ id: 'r1', playerName: 'Drag Player', contactId: '1', ab: 10 }]);
+
+    const headers = screen.getAllByRole('columnheader');
+    const abHeader = headers.find((cell) => within(cell).queryByText('AB'));
+    const playerHeader = headers.find((cell) => within(cell).queryByText('Player'));
+
+    expect(abHeader?.getAttribute('aria-roledescription')).toBe('sortable column');
+    expect(playerHeader?.getAttribute('aria-roledescription')).toBeNull();
+  });
+
+  it('shows a reset control only when a custom order is saved, and clears it on click', () => {
+    const { rerender } = renderExtended([{ id: 'r1', playerName: 'P', contactId: '1', ab: 10 }]);
+    expect(screen.queryByRole('button', { name: /reset columns/i })).not.toBeInTheDocument();
+
+    window.localStorage.setItem(battingKey, JSON.stringify(['pa', 'ab']));
+    rerender(
+      <StatisticsTable
+        variant="batting"
+        extendedStats
+        data={[{ id: 'r1', playerName: 'P', contactId: '1', ab: 10 }]}
+        getRowKey={(row) => (row as Row).id}
+      />,
+    );
+
+    const resetButton = screen.getByRole('button', { name: /reset columns/i });
+    fireEvent.click(resetButton);
+
+    expect(window.localStorage.getItem(battingKey)).toBeNull();
   });
 });

--- a/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/__tests__/StatisticsTable.test.tsx
@@ -104,6 +104,8 @@ describe('StatisticsTable column reordering', () => {
     const playerHeader = headers.find((cell) => within(cell).queryByText('Player'));
 
     expect(abHeader?.getAttribute('aria-roledescription')).toBe('sortable column');
+    expect(abHeader?.getAttribute('role')).toBe('columnheader');
+    expect(abHeader?.getAttribute('tabindex')).toBe('0');
     expect(playerHeader?.getAttribute('aria-roledescription')).toBeNull();
   });
 

--- a/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
@@ -32,6 +32,11 @@ export const battingViewFieldOrder = [
   ...battingSummaryFields,
 ] as const;
 
+export const BATTING_STAT_FIELD_ORDER: string[] = [
+  ...editableBattingFields,
+  ...battingSummaryFields,
+];
+
 export type BattingViewField = (typeof battingViewFieldOrder)[number];
 
 export type BattingFieldMetadata = {

--- a/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
@@ -111,11 +111,11 @@ const battingFieldMetadata: Record<BattingViewField, BattingFieldMetadata> = {
   },
   re: {
     label: 'RE',
-    tooltip: 'RE',
+    tooltip: 'Reached On Error',
   },
   intr: {
     label: 'INTR',
-    tooltip: 'INTR',
+    tooltip: 'Catcher/Fielder Interference',
   },
   lob: {
     label: 'LOB',

--- a/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/battingColumns.ts
@@ -32,7 +32,7 @@ export const battingViewFieldOrder = [
   ...battingSummaryFields,
 ] as const;
 
-export const BATTING_STAT_FIELD_ORDER: string[] = [
+export const BATTING_STAT_FIELD_ORDER: readonly string[] = [
   ...editableBattingFields,
   ...battingSummaryFields,
 ];

--- a/draco-nodejs/frontend-next/components/team-stats-entry/pitchingColumns.ts
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/pitchingColumns.ts
@@ -29,7 +29,7 @@ export const pitchingViewFieldOrder = [
   ...pitchingSummaryFields,
 ] as const;
 
-export const PITCHING_STAT_FIELD_ORDER: string[] = [
+export const PITCHING_STAT_FIELD_ORDER: readonly string[] = [
   ...editablePitchingFields,
   ...pitchingSummaryFields,
 ];

--- a/draco-nodejs/frontend-next/components/team-stats-entry/pitchingColumns.ts
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/pitchingColumns.ts
@@ -29,6 +29,11 @@ export const pitchingViewFieldOrder = [
   ...pitchingSummaryFields,
 ] as const;
 
+export const PITCHING_STAT_FIELD_ORDER: string[] = [
+  ...editablePitchingFields,
+  ...pitchingSummaryFields,
+];
+
 export type PitchingViewField = (typeof pitchingViewFieldOrder)[number];
 export type PitchingSummaryField = (typeof pitchingSummaryFields)[number];
 

--- a/draco-nodejs/frontend-next/constants/storageKeys.ts
+++ b/draco-nodejs/frontend-next/constants/storageKeys.ts
@@ -1,2 +1,7 @@
 export const ACCOUNT_STORAGE_KEY = 'draco:selected-account';
 export const REMEMBER_ME_KEY = 'draco:rememberMe';
+
+export const STAT_COLUMN_ORDER_KEY_PREFIX = 'draco:stat-column-order';
+
+export const statColumnOrderKey = (variant: 'batting' | 'pitching'): string =>
+  `${STAT_COLUMN_ORDER_KEY_PREFIX}:${variant}`;

--- a/draco-nodejs/frontend-next/hooks/useStatColumnOrder.ts
+++ b/draco-nodejs/frontend-next/hooks/useStatColumnOrder.ts
@@ -8,7 +8,7 @@ import { applyColumnOrder, mergeColumnOrder, reconcileOrder } from '../utils/sta
 
 export type StatColumnVariant = 'batting' | 'pitching';
 
-const CANONICAL_ORDER: Record<StatColumnVariant, string[]> = {
+const CANONICAL_ORDER: Record<StatColumnVariant, readonly string[]> = {
   batting: BATTING_STAT_FIELD_ORDER,
   pitching: PITCHING_STAT_FIELD_ORDER,
 };
@@ -29,7 +29,7 @@ const parseSavedOrder = (raw: string | null): string[] => {
 };
 
 interface StatColumnOrderStore {
-  canonical: string[];
+  canonical: readonly string[];
   getSnapshot: () => string | null;
   subscribe: (callback: () => void) => () => void;
   write: (value: string[] | null) => void;

--- a/draco-nodejs/frontend-next/hooks/useStatColumnOrder.ts
+++ b/draco-nodejs/frontend-next/hooks/useStatColumnOrder.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { statColumnOrderKey } from '../constants/storageKeys';
+import { BATTING_STAT_FIELD_ORDER } from '../components/team-stats-entry/battingColumns';
+import { PITCHING_STAT_FIELD_ORDER } from '../components/team-stats-entry/pitchingColumns';
+import { applyColumnOrder, mergeColumnOrder, reconcileOrder } from '../utils/statColumnOrder';
+
+export type StatColumnVariant = 'batting' | 'pitching';
+
+const CANONICAL_ORDER: Record<StatColumnVariant, string[]> = {
+  batting: BATTING_STAT_FIELD_ORDER,
+  pitching: PITCHING_STAT_FIELD_ORDER,
+};
+
+const parseSavedOrder = (raw: string | null): string[] => {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((entry) => typeof entry === 'string')) {
+      return parsed;
+    }
+  } catch {
+    return [];
+  }
+  return [];
+};
+
+interface StatColumnOrderStore {
+  canonical: string[];
+  getSnapshot: () => string | null;
+  subscribe: (callback: () => void) => () => void;
+  write: (value: string[] | null) => void;
+}
+
+const createStore = (variant: StatColumnVariant): StatColumnOrderStore => {
+  const key = statColumnOrderKey(variant);
+  const listeners = new Set<() => void>();
+
+  const getSnapshot = (): string | null => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  };
+
+  const subscribe = (callback: () => void) => {
+    listeners.add(callback);
+    const handler = (event: StorageEvent) => {
+      if (event.key === key) {
+        callback();
+      }
+    };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', handler);
+    }
+    return () => {
+      listeners.delete(callback);
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('storage', handler);
+      }
+    };
+  };
+
+  const write = (value: string[] | null) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      if (value && value.length > 0) {
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } else {
+        window.localStorage.removeItem(key);
+      }
+    } catch {
+      return;
+    }
+    listeners.forEach((listener) => listener());
+  };
+
+  return { canonical: CANONICAL_ORDER[variant], getSnapshot, subscribe, write };
+};
+
+const stores: Record<StatColumnVariant, StatColumnOrderStore> = {
+  batting: createStore('batting'),
+  pitching: createStore('pitching'),
+};
+
+const getServerSnapshot = (): string | null => null;
+
+export interface UseStatColumnOrderResult {
+  order: string[];
+  isCustomized: boolean;
+  applyReorder: (visibleFields: string[], newVisibleOrder: string[]) => void;
+  reset: () => void;
+}
+
+export const useStatColumnOrder = (variant: StatColumnVariant): UseStatColumnOrderResult => {
+  const store = stores[variant];
+  const raw = useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
+  const order = reconcileOrder(parseSavedOrder(raw), store.canonical);
+
+  const applyReorder = (visibleFields: string[], newVisibleOrder: string[]) => {
+    const current = reconcileOrder(parseSavedOrder(store.getSnapshot()), store.canonical);
+    store.write(mergeColumnOrder(current, visibleFields, newVisibleOrder));
+  };
+
+  const reset = () => {
+    store.write(null);
+  };
+
+  return { order, isCustomized: raw !== null, applyReorder, reset };
+};
+
+export { applyColumnOrder };

--- a/draco-nodejs/frontend-next/package.json
+++ b/draco-nodejs/frontend-next/package.json
@@ -27,6 +27,9 @@
     "e2e:reap": "dotenv -e ../backend/.env -e .env.e2e -- tsx e2e/scripts/reap-e2e-data.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@draco/shared-api-client": "workspace:*",
     "@draco/shared-schemas": "workspace:*",
     "@emotion/cache": "^11.14.0",

--- a/draco-nodejs/frontend-next/utils/__tests__/statColumnOrder.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/statColumnOrder.test.ts
@@ -21,6 +21,12 @@ describe('reconcileOrder', () => {
       'avg',
     ]);
   });
+
+  it('deduplicates repeated saved fields (corrupted storage), keeping first-seen order and all canonical fields once', () => {
+    const result = reconcileOrder(['pa', 'ab', 'pa', 'ab'], canonical);
+    expect(result).toEqual(['pa', 'ab', 'h', 'r', 'avg']);
+    expect(new Set(result).size).toBe(result.length);
+  });
 });
 
 describe('applyColumnOrder', () => {

--- a/draco-nodejs/frontend-next/utils/__tests__/statColumnOrder.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/statColumnOrder.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { applyColumnOrder, mergeColumnOrder, reconcileOrder } from '../statColumnOrder';
+
+describe('reconcileOrder', () => {
+  const canonical = ['ab', 'h', 'r', 'pa', 'avg'];
+
+  it('returns the full canonical order in canonical order when nothing is saved', () => {
+    expect(reconcileOrder([], canonical)).toEqual(canonical);
+  });
+
+  it('keeps saved fields in saved order and appends missing canonical fields in canonical order', () => {
+    expect(reconcileOrder(['pa', 'ab'], canonical)).toEqual(['pa', 'ab', 'h', 'r', 'avg']);
+  });
+
+  it('drops saved fields that no longer exist in canonical', () => {
+    expect(reconcileOrder(['pa', 'legacy', 'ab'], canonical)).toEqual([
+      'pa',
+      'ab',
+      'h',
+      'r',
+      'avg',
+    ]);
+  });
+});
+
+describe('applyColumnOrder', () => {
+  it('returns the original order untouched when nothing is saved', () => {
+    const original = ['ab', 'h', 'r', 'pa'];
+    expect(applyColumnOrder(original, [])).toEqual(original);
+  });
+
+  it('reorders visible fields according to the saved order', () => {
+    const original = ['ab', 'h', 'r', 'pa'];
+    const saved = ['pa', 'ab', 'h', 'r'];
+    expect(applyColumnOrder(original, saved)).toEqual(['pa', 'ab', 'h', 'r']);
+  });
+
+  it('only moves fields present in the saved order, leaving others in their original slot', () => {
+    const original = ['ab', 'h', 'r', 'pa'];
+    const saved = ['pa', 'ab'];
+    expect(applyColumnOrder(original, saved)).toEqual(['pa', 'h', 'r', 'ab']);
+  });
+
+  it('ignores saved fields the table does not display', () => {
+    const original = ['ab', 'h'];
+    const saved = ['pa', 'h', 'ab'];
+    expect(applyColumnOrder(original, saved)).toEqual(['h', 'ab']);
+  });
+});
+
+describe('mergeColumnOrder', () => {
+  it('writes a subset edit back into the full stored order, leaving hidden fields fixed', () => {
+    const storedFull = ['ab', 'h', 'r', 'pa', 'avg'];
+    const visibleFields = ['ab', 'h', 'r', 'pa'];
+    const newVisibleOrder = ['pa', 'ab', 'h', 'r'];
+    expect(mergeColumnOrder(storedFull, visibleFields, newVisibleOrder)).toEqual([
+      'pa',
+      'ab',
+      'h',
+      'r',
+      'avg',
+    ]);
+  });
+
+  it('round-trips: applying a merged order to the same subset reproduces the new visible order', () => {
+    const storedFull = ['ab', 'h', 'r', 'd', 't', 'hr', 'pa', 'avg', 'obp'];
+    const visibleFields = ['ab', 'h', 'r', 'pa'];
+    const newVisibleOrder = ['pa', 'r', 'ab', 'h'];
+
+    const merged = mergeColumnOrder(storedFull, visibleFields, newVisibleOrder);
+    expect(applyColumnOrder(visibleFields, merged)).toEqual(newVisibleOrder);
+
+    const hidden = storedFull.filter((field) => !visibleFields.includes(field));
+    expect(merged.filter((field) => !visibleFields.includes(field))).toEqual(hidden);
+  });
+
+  it('propagates a subset edit to a different table that shows other columns', () => {
+    const storedFull = ['ab', 'h', 'r', 'pa', 'avg', 'obp'];
+    const editedVisible = ['ab', 'pa'];
+    const merged = mergeColumnOrder(storedFull, editedVisible, ['pa', 'ab']);
+
+    const otherTable = ['ab', 'r', 'pa', 'obp'];
+    expect(applyColumnOrder(otherTable, merged)).toEqual(['pa', 'r', 'ab', 'obp']);
+  });
+});

--- a/draco-nodejs/frontend-next/utils/statColumnOrder.ts
+++ b/draco-nodejs/frontend-next/utils/statColumnOrder.ts
@@ -1,0 +1,29 @@
+export const reconcileOrder = (saved: string[], canonical: string[]): string[] => {
+  const canonicalSet = new Set(canonical);
+  const kept = saved.filter((field) => canonicalSet.has(field));
+  const keptSet = new Set(kept);
+  const appended = canonical.filter((field) => !keptSet.has(field));
+  return [...kept, ...appended];
+};
+
+export const applyColumnOrder = (originalVisibleFields: string[], saved: string[]): string[] => {
+  if (saved.length === 0) {
+    return [...originalVisibleFields];
+  }
+  const visibleSet = new Set(originalVisibleFields);
+  const queue = saved.filter((field) => visibleSet.has(field));
+  const savedSet = new Set(saved);
+  let next = 0;
+  return originalVisibleFields.map((field) => (savedSet.has(field) ? queue[next++] : field));
+};
+
+export const mergeColumnOrder = (
+  storedFull: string[],
+  visibleFields: string[],
+  newVisibleOrder: string[],
+): string[] => {
+  const visibleSet = new Set(visibleFields);
+  const queue = [...newVisibleOrder];
+  let next = 0;
+  return storedFull.map((field) => (visibleSet.has(field) ? queue[next++] : field));
+};

--- a/draco-nodejs/frontend-next/utils/statColumnOrder.ts
+++ b/draco-nodejs/frontend-next/utils/statColumnOrder.ts
@@ -1,12 +1,24 @@
-export const reconcileOrder = (saved: string[], canonical: string[]): string[] => {
+export const reconcileOrder = (
+  saved: readonly string[],
+  canonical: readonly string[],
+): string[] => {
   const canonicalSet = new Set(canonical);
-  const kept = saved.filter((field) => canonicalSet.has(field));
-  const keptSet = new Set(kept);
-  const appended = canonical.filter((field) => !keptSet.has(field));
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  for (const field of saved) {
+    if (canonicalSet.has(field) && !seen.has(field)) {
+      seen.add(field);
+      kept.push(field);
+    }
+  }
+  const appended = canonical.filter((field) => !seen.has(field));
   return [...kept, ...appended];
 };
 
-export const applyColumnOrder = (originalVisibleFields: string[], saved: string[]): string[] => {
+export const applyColumnOrder = (
+  originalVisibleFields: readonly string[],
+  saved: readonly string[],
+): string[] => {
   if (saved.length === 0) {
     return [...originalVisibleFields];
   }
@@ -18,9 +30,9 @@ export const applyColumnOrder = (originalVisibleFields: string[], saved: string[
 };
 
 export const mergeColumnOrder = (
-  storedFull: string[],
-  visibleFields: string[],
-  newVisibleOrder: string[],
+  storedFull: readonly string[],
+  visibleFields: readonly string[],
+  newVisibleOrder: readonly string[],
 ): string[] => {
   const visibleSet = new Set(visibleFields);
   const queue = [...newVisibleOrder];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,15 @@ importers:
 
   draco-nodejs/frontend-next:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@draco/shared-api-client':
         specifier: workspace:*
         version: link:../shared/shared-api-client
@@ -1968,6 +1977,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -10823,6 +10854,31 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@egjs/hammerjs@2.0.17':
     dependencies:


### PR DESCRIPTION
Enable drag-and-drop reordering of statistic columns in the stats table and persist user order in localStorage. Introduces a SortableStatHeaderCell component and integrates @dnd-kit to allow horizontal column dragging (with identity columns pinned). Adds useStatColumnOrder hook and storage key helpers to read/write a reconciled canonical order, plus utility functions (reconcileOrder, applyColumnOrder, mergeColumnOrder) with unit tests. Updates StatisticsTable to apply persisted orders, expose a reset control when customized, and wire up reorder callbacks; also adds BATTING/PITCHING canonical field arrays and test coverage for UI reorder behavior. Adds @dnd-kit dependencies to package.json.