### PR TITLE
Add 'scroll to today' support to schedule

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/schedule/Schedule.tsx
@@ -63,6 +63,11 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
   const defaultViewMode = prefersListView ? 'list' : 'calendar';
   const [manualViewMode, setManualViewMode] = useState<ViewMode | null>(null);
   const viewMode = manualViewMode ?? defaultViewMode;
+  const [scrollToTodayNonce, setScrollToTodayNonce] = useState(0);
+
+  const handleScrollToToday = () => {
+    setScrollToTodayNonce((nonce) => nonce + 1);
+  };
 
   const [viewDialogOpen, setViewDialogOpen] = useState(false);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
@@ -303,6 +308,8 @@ const Schedule: React.FC<ScheduleProps> = ({ accountId }) => {
       onFeedbackClose={handleFeedbackClose}
       recapError={recapError}
       onRecapErrorClose={clearRecapError}
+      scrollToTodayNonce={scrollToTodayNonce}
+      onScrollToToday={handleScrollToToday}
     >
       {!isGolfLeague && (
         <GameDialog

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -75,6 +75,11 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
   const defaultViewMode = prefersListView ? 'list' : 'calendar';
   const [manualViewMode, setManualViewMode] = useState<ViewMode | null>(null);
   const viewMode = manualViewMode ?? defaultViewMode;
+  const [scrollToTodayNonce, setScrollToTodayNonce] = useState(0);
+
+  const handleScrollToToday = () => {
+    setScrollToTodayNonce((nonce) => nonce + 1);
+  };
 
   const [viewDialogOpen, setViewDialogOpen] = useState(false);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
@@ -387,6 +392,8 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
       onFeedbackClose={handleFeedbackClose}
       recapError={recapError}
       onRecapErrorClose={clearRecapError}
+      scrollToTodayNonce={scrollToTodayNonce}
+      onScrollToToday={handleScrollToToday}
       showLeagueTeamFilters={false}
       summaryContent={
         <SeasonSummaryWidget

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleLayout.tsx
@@ -71,6 +71,8 @@ export interface ScheduleLayoutProps {
   onRecapErrorClose?: () => void;
   showLeagueTeamFilters?: boolean;
   summaryContent?: React.ReactNode;
+  scrollToTodayNonce?: number;
+  onScrollToToday?: () => void;
   children?: React.ReactNode;
 }
 
@@ -119,6 +121,8 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
   onRecapErrorClose,
   showLeagueTeamFilters = true,
   summaryContent,
+  scrollToTodayNonce,
+  onScrollToToday,
   children,
 }) => {
   if (loadingStaticData) {
@@ -288,6 +292,8 @@ const ScheduleLayout: React.FC<ScheduleLayoutProps> = ({
             isNavigating={isNavigating}
             navigateToWeek={navigateToWeek}
             navigate={navigate}
+            scrollToTodayNonce={scrollToTodayNonce}
+            onScrollToToday={onScrollToToday}
           />
         </Container>
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useScrollToTarget.test.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useScrollToTarget.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useScrollToTarget } from '../useScrollToTarget';
+
+interface HarnessProps {
+  targetKey: string | null | undefined;
+  ready?: boolean;
+  trigger?: number;
+}
+
+function Harness({ targetKey, ready, trigger }: HarnessProps) {
+  const ref = useScrollToTarget<HTMLDivElement>(targetKey, {
+    ready,
+    trigger,
+    behavior: 'auto',
+  });
+  return <div ref={ref} data-testid="target" />;
+}
+
+describe('useScrollToTarget', () => {
+  let scrollSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not scroll while not ready, then scrolls once ready becomes true', () => {
+    const { rerender } = render(<Harness targetKey="2026-06-13" ready={false} trigger={0} />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    rerender(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not scroll when there is no target key', () => {
+    const { rerender } = render(<Harness targetKey={null} ready={true} trigger={0} />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    rerender(<Harness targetKey={undefined} ready={true} trigger={0} />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('scrolls only once for an unchanged key and trigger across re-renders', () => {
+    const { rerender } = render(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    rerender(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-scrolls when the trigger changes (e.g. Today button) even with the same key', () => {
+    const { rerender } = render(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness targetKey="2026-06-13" ready={true} trigger={1} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-scrolls when the target key changes', () => {
+    const { rerender } = render(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness targetKey="2026-06-20" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not scroll when target transitions to null and back to a previously scrolled key', () => {
+    const { rerender } = render(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness targetKey={null} ready={true} trigger={0} />);
+    rerender(<Harness targetKey="2026-06-13" ready={true} trigger={0} />);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useScrollToTarget.test.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/__tests__/useScrollToTarget.test.tsx
@@ -18,14 +18,20 @@ function Harness({ targetKey, ready, trigger }: HarnessProps) {
 }
 
 describe('useScrollToTarget', () => {
-  let scrollSpy: ReturnType<typeof vi.fn>;
+  let scrollSpy: ReturnType<typeof vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>>;
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
 
   beforeEach(() => {
-    scrollSpy = vi.fn();
-    Element.prototype.scrollIntoView = scrollSpy;
+    scrollSpy = vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>();
+    Element.prototype.scrollIntoView = function scrollIntoView(
+      arg?: boolean | ScrollIntoViewOptions,
+    ) {
+      scrollSpy(arg);
+    };
   });
 
   afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
     vi.restoreAllMocks();
   });
 

--- a/draco-nodejs/frontend-next/components/schedule/hooks/useScrollToTarget.ts
+++ b/draco-nodejs/frontend-next/components/schedule/hooks/useScrollToTarget.ts
@@ -1,20 +1,27 @@
 import { useEffect, useRef } from 'react';
 
-interface ScrollIntoViewOnceOptions {
+interface ScrollToTargetOptions {
   block?: ScrollLogicalPosition;
   behavior?: ScrollBehavior;
+  ready?: boolean;
+  trigger?: number;
 }
 
-export function useScrollIntoViewOnce<T extends HTMLElement>(
+export function useScrollToTarget<T extends HTMLElement>(
   targetKey: string | null | undefined,
-  options: ScrollIntoViewOnceOptions = {},
+  options: ScrollToTargetOptions = {},
 ) {
-  const { block = 'start', behavior = 'smooth' } = options;
+  const { block = 'start', behavior = 'smooth', ready = true, trigger = 0 } = options;
   const ref = useRef<T | null>(null);
-  const hasScrolledRef = useRef(false);
+  const lastScrolledRef = useRef<{ key: string; trigger: number } | null>(null);
 
   useEffect(() => {
-    if (hasScrolledRef.current || !targetKey) {
+    if (!ready || !targetKey) {
+      return;
+    }
+
+    const last = lastScrolledRef.current;
+    if (last && last.key === targetKey && last.trigger === trigger) {
       return;
     }
 
@@ -28,7 +35,7 @@ export function useScrollIntoViewOnce<T extends HTMLElement>(
       }
 
       element.scrollIntoView({ block, behavior });
-      hasScrolledRef.current = true;
+      lastScrolledRef.current = { key: targetKey, trigger };
       frameId = null;
     };
 
@@ -39,7 +46,7 @@ export function useScrollIntoViewOnce<T extends HTMLElement>(
         cancelAnimationFrame(frameId);
       }
     };
-  }, [targetKey, block, behavior]);
+  }, [targetKey, ready, trigger, block, behavior]);
 
   return ref;
 }

--- a/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
@@ -9,7 +9,7 @@ import {
   getDateKeyInTimezone,
   isSameDayInTimezone,
 } from '../../../utils/dateUtils';
-import { useScrollIntoViewOnce } from '../hooks/useScrollIntoViewOnce';
+import { useScrollToTarget } from '../hooks/useScrollToTarget';
 import { alpha, useTheme } from '@mui/material/styles';
 
 export interface CalendarGridProps {
@@ -20,7 +20,8 @@ export interface CalendarGridProps {
   gridType: 'week' | 'month';
   showZoomColumn?: boolean;
   currentMonthDate?: Date;
-  focusDate?: Date;
+  loadingGames?: boolean;
+  scrollToTodayNonce?: number;
 
   // Data
   days: Date[];
@@ -69,7 +70,8 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
   gridType: _gridType,
   showZoomColumn = false,
   currentMonthDate,
-  focusDate,
+  loadingGames = false,
+  scrollToTodayNonce,
   days,
   filteredGames,
   minHeight = '300px',
@@ -147,8 +149,15 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
 
   const gamesByDateKey = buildGamesByDateKey(filteredGames, timeZone);
 
-  const focusDateKey = focusDate ? getDateKeyInTimezone(focusDate, timeZone) : null;
-  const focusCellRef = useScrollIntoViewOnce<HTMLDivElement>(focusDateKey, { block: 'nearest' });
+  const todayKey = getDateKeyInTimezone(new Date(), timeZone);
+  const todayInView =
+    !!todayKey && days.some((day) => getDateKeyInTimezone(day, timeZone) === todayKey);
+  const focusDateKey = todayInView ? todayKey : null;
+  const focusCellRef = useScrollToTarget<HTMLDivElement>(focusDateKey, {
+    block: 'nearest',
+    ready: !loadingGames,
+    trigger: scrollToTodayNonce,
+  });
 
   const monthReference = currentMonthDate
     ? {

--- a/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
@@ -10,7 +10,7 @@ import {
   isSameDayInTimezone,
 } from '../../../utils/dateUtils';
 import WidgetShell from '../../ui/WidgetShell';
-import { useScrollIntoViewOnce } from '../hooks/useScrollIntoViewOnce';
+import { useScrollToTarget } from '../hooks/useScrollToTarget';
 import { useTheme } from '@mui/material/styles';
 
 interface DayListViewProps extends ViewComponentProps {
@@ -42,6 +42,9 @@ const DayListView: React.FC<DayListViewProps> = ({
   isNavigating,
   viewMode,
   canEditRecap,
+  loadingGames,
+  scrollToTodayNonce,
+  onScrollToToday,
 }) => {
   const theme = useTheme();
   const [currentDate, setCurrentDate] = React.useState(filterDate);
@@ -68,6 +71,7 @@ const DayListView: React.FC<DayListViewProps> = ({
     const today = new Date();
     setCurrentDate(today);
     setFilterDate(today);
+    onScrollToToday?.();
   };
 
   const navigateList = (direction: 'prev' | 'next') => {
@@ -119,12 +123,20 @@ const DayListView: React.FC<DayListViewProps> = ({
   const computedWeekStart = isDayView ? startOfWeek(currentDate) : _startDate;
   const computedWeekEnd = isDayView ? endOfWeek(currentDate) : _endDate;
 
-  const focusDateKey = getDateKeyInTimezone(filterDate, timeZone);
+  const todayInRange =
+    !isDayView &&
+    !!todayKey &&
+    sortedDates !== null &&
+    sortedDates.length > 0 &&
+    todayKey >= sortedDates[0] &&
+    todayKey <= sortedDates[sortedDates.length - 1];
   const scrollTargetKey =
-    !isDayView && sortedDates && focusDateKey
-      ? (sortedDates.find((key) => key >= focusDateKey) ?? sortedDates[sortedDates.length - 1])
-      : undefined;
-  const focusGroupRef = useScrollIntoViewOnce<HTMLDivElement>(scrollTargetKey, { block: 'start' });
+    todayInRange && todayKey ? sortedDates!.find((key) => key >= todayKey) : undefined;
+  const focusGroupRef = useScrollToTarget<HTMLDivElement>(scrollTargetKey, {
+    block: 'start',
+    ready: !loadingGames,
+    trigger: scrollToTodayNonce,
+  });
 
   const renderDayContent = () => {
     if (dayGames.length === 0) {

--- a/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
@@ -123,15 +123,17 @@ const DayListView: React.FC<DayListViewProps> = ({
   const computedWeekStart = isDayView ? startOfWeek(currentDate) : _startDate;
   const computedWeekEnd = isDayView ? endOfWeek(currentDate) : _endDate;
 
+  const periodStartKey = _startDate ? getDateKeyInTimezone(_startDate, timeZone) : null;
+  const periodEndKey = _endDate ? getDateKeyInTimezone(_endDate, timeZone) : null;
   const todayInRange =
     !isDayView &&
     !!todayKey &&
-    sortedDates !== null &&
-    sortedDates.length > 0 &&
-    todayKey >= sortedDates[0] &&
-    todayKey <= sortedDates[sortedDates.length - 1];
+    (periodStartKey === null || todayKey >= periodStartKey) &&
+    (periodEndKey === null || todayKey <= periodEndKey);
   const scrollTargetKey =
-    todayInRange && todayKey ? sortedDates!.find((key) => key >= todayKey) : undefined;
+    todayInRange && todayKey && sortedDates !== null && sortedDates.length > 0
+      ? (sortedDates.find((key) => key >= todayKey) ?? sortedDates[sortedDates.length - 1])
+      : undefined;
   const focusGroupRef = useScrollToTarget<HTMLDivElement>(scrollTargetKey, {
     block: 'start',
     ready: !loadingGames,

--- a/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
@@ -32,6 +32,9 @@ const MonthView: React.FC<ViewComponentProps> = ({
   navigate,
   isNavigating,
   canEditRecap,
+  loadingGames,
+  scrollToTodayNonce,
+  onScrollToToday,
 }) => {
   const [currentMonth, setCurrentMonth] = React.useState(filterDate);
 
@@ -56,6 +59,7 @@ const MonthView: React.FC<ViewComponentProps> = ({
     const today = new Date();
     setCurrentMonth(today);
     setFilterDate(today);
+    onScrollToToday?.();
   };
 
   // Calculate month days including padding days from previous/next months
@@ -92,7 +96,8 @@ const MonthView: React.FC<ViewComponentProps> = ({
         currentTeamSeasonId={currentTeamSeasonId}
         gridType="month"
         showZoomColumn={true}
-        focusDate={filterDate}
+        loadingGames={loadingGames}
+        scrollToTodayNonce={scrollToTodayNonce}
         days={monthDays}
         filteredGames={filteredGames}
         minHeight="200px"

--- a/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
@@ -29,6 +29,9 @@ const WeekView: React.FC<ViewComponentProps> = ({
   navigateToWeek,
   navigate,
   canEditRecap,
+  loadingGames,
+  scrollToTodayNonce,
+  onScrollToToday,
 }) => {
   const weekDays =
     startDate && endDate ? eachDayOfInterval({ start: startDate, end: endDate }) : [];
@@ -42,6 +45,7 @@ const WeekView: React.FC<ViewComponentProps> = ({
     setStartDate(todayStart);
     setEndDate(todayEnd);
     setFilterDate(today);
+    onScrollToToday?.();
   };
 
   // Navigation function for week view
@@ -83,6 +87,8 @@ const WeekView: React.FC<ViewComponentProps> = ({
         currentTeamSeasonId={currentTeamSeasonId}
         gridType="week"
         showZoomColumn={false}
+        loadingGames={loadingGames}
+        scrollToTodayNonce={scrollToTodayNonce}
         days={weekDays}
         filteredGames={filteredGames}
         minHeight="300px"

--- a/draco-nodejs/frontend-next/types/schedule.ts
+++ b/draco-nodejs/frontend-next/types/schedule.ts
@@ -186,6 +186,8 @@ export interface ViewComponentProps {
   navigate?: (direction: NavigationDirection, type?: FilterType) => void;
   loadingGames: boolean;
   canEditRecap?: (game: GameCardData) => boolean;
+  scrollToTodayNonce?: number;
+  onScrollToToday?: () => void;
 }
 
 export interface DialogComponentProps {


### PR DESCRIPTION
Introduce a reusable scroll-to-target mechanism and wire a "scroll to today" trigger through the schedule UI. Renamed and enhanced the hook to useScrollToTarget (adds ready and trigger options) and added unit tests for its behavior. Propagated scrollToTodayNonce and onScrollToToday from Schedule/TeamSchedulePage through ScheduleLayout into Month/Week/DayList/CalendarGrid views so the Today button can re-trigger scrolling even when the target key is unchanged, and prevent scrolling while games are still loading. Also updated schedule types accordingly.