### PR TITLE
Support guest (substitute) players for stat entry

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -12284,7 +12284,9 @@
         "type": "object",
         "properties": {
           "contactId": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^\\d+$",
+            "example": "12345"
           }
         },
         "required": [

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -12267,6 +12267,9 @@
             "type": "string",
             "nullable": true,
             "format": "uri"
+          },
+          "isSubstitute": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -12275,6 +12278,17 @@
           "contactId",
           "playerName",
           "playerNumber"
+        ]
+      },
+      "AddGuestPlayer": {
+        "type": "object",
+        "properties": {
+          "contactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "contactId"
         ]
       },
       "GameBattingStatLine": {
@@ -12762,6 +12776,9 @@
                   "type": "string",
                   "nullable": true,
                   "format": "uri"
+                },
+                "isSubstitute": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -13297,6 +13314,9 @@
                   "type": "string",
                   "nullable": true,
                   "format": "uri"
+                },
+                "isSubstitute": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -77754,6 +77774,131 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/stat-entry/guests": {
+      "post": {
+        "summary": "Add a guest (substitute) player for stat entry",
+        "description": "Adds an existing account contact as a non-rostered guest player on the team so their stats can be recorded for a game. Does not affect the contact’s active roster membership elsewhere.",
+        "tags": [
+          "Team Stats Entry"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddGuestPlayer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Guest player added.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamStatsPlayerSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Team manage permission required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Player is already on this team roster.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictError"
                 }
               }
             }

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -9123,12 +9123,21 @@ components:
           type: string
           nullable: true
           format: uri
+        isSubstitute:
+          type: boolean
       required:
         - rosterSeasonId
         - playerId
         - contactId
         - playerName
         - playerNumber
+    AddGuestPlayer:
+      type: object
+      properties:
+        contactId:
+          type: string
+      required:
+        - contactId
     GameBattingStatLine:
       type: object
       properties:
@@ -9516,6 +9525,8 @@ components:
                 type: string
                 nullable: true
                 format: uri
+              isSubstitute:
+                type: boolean
             required:
               - rosterSeasonId
               - playerId
@@ -9939,6 +9950,8 @@ components:
                 type: string
                 nullable: true
                 format: uri
+              isSubstitute:
+                type: boolean
             required:
               - rosterSeasonId
               - playerId
@@ -52278,6 +52291,69 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/stat-entry/guests:
+    post:
+      summary: Add a guest (substitute) player for stat entry
+      description: Adds an existing account contact as a non-rostered guest player on
+        the team so their stats can be recorded for a game. Does not affect the
+        contact’s active roster membership elsewhere.
+      tags:
+        - Team Stats Entry
+      security:
+        - bearerAuth: []
+      parameters:
+        - *a42
+        - *a43
+        - *a44
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddGuestPlayer"
+      responses:
+        "201":
+          description: Guest player added.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamStatsPlayerSummary"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Team manage permission required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "409":
+          description: Player is already on this team roster.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictError"
         "500":
           description: Unexpected server error.
           content:

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -9136,6 +9136,8 @@ components:
       properties:
         contactId:
           type: string
+          pattern: ^\d+$
+          example: "12345"
       required:
         - contactId
     GameBattingStatLine:

--- a/draco-nodejs/backend/prisma/migrations/20260613000000_add_substitute_to_rosterseason/migration.sql
+++ b/draco-nodejs/backend/prisma/migrations/20260613000000_add_substitute_to_rosterseason/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "rosterseason" ADD COLUMN "substitute" BOOLEAN NOT NULL DEFAULT false;

--- a/draco-nodejs/backend/prisma/schema.prisma
+++ b/draco-nodejs/backend/prisma/schema.prisma
@@ -1645,6 +1645,7 @@ model rosterseason {
   teamseasonid    BigInt
   playernumber    String          @default("") @db.VarChar(2)
   inactive        Boolean
+  substitute      Boolean         @default(false)
   submittedwaiver Boolean
   dateadded       DateTime?       @db.Timestamptz(6)
   batstatsum      batstatsum[]

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -102,6 +102,7 @@ import {
   PlayerSurveyCategorySchema,
   PlayerSurveyDetailSchema,
   TeamStatsPlayerSummarySchema,
+  AddGuestPlayerSchema,
   GameBattingStatLineSchema,
   GameBattingStatsSchema,
   GamePitchingStatLineSchema,
@@ -902,6 +903,7 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     'TeamStatsPlayerSummary',
     TeamStatsPlayerSummarySchema,
   );
+  const AddGuestPlayerSchemaRef = registry.register('AddGuestPlayer', AddGuestPlayerSchema);
   const GameBattingStatLineSchemaRef = registry.register(
     'GameBattingStatLine',
     GameBattingStatLineSchema,
@@ -1945,6 +1947,7 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     PublicPlayerProfileSchemaRef,
     PublicPlayerTeamAffiliationSchemaRef,
     TeamStatsPlayerSummarySchemaRef,
+    AddGuestPlayerSchemaRef,
     GameBattingStatLineSchemaRef,
     GameBattingStatsSchemaRef,
     GamePitchingStatLineSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/team-stats-entry/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/team-stats-entry/index.ts
@@ -2,6 +2,7 @@ import { RegisterContext } from '../../openapiTypes.js';
 
 const registerTeamStatsEntryEndpoints = ({ registry, schemaRefs }: RegisterContext) => {
   const {
+    AddGuestPlayerSchemaRef,
     AuthenticationErrorSchemaRef,
     AuthorizationErrorSchemaRef,
     ConflictErrorSchemaRef,
@@ -13,6 +14,7 @@ const registerTeamStatsEntryEndpoints = ({ registry, schemaRefs }: RegisterConte
     InternalServerErrorSchemaRef,
     NotFoundErrorSchemaRef,
     TeamCompletedGamesSchemaRef,
+    TeamStatsPlayerSummarySchemaRef,
     UpdateGameAttendanceSchemaRef,
     CreateGameBattingStatSchemaRef,
     UpdateGameBattingStatSchemaRef,
@@ -100,6 +102,34 @@ const registerTeamStatsEntryEndpoints = ({ registry, schemaRefs }: RegisterConte
       200: {
         description: 'Completed games retrieved.',
         content: { 'application/json': { schema: TeamCompletedGamesSchemaRef } },
+      },
+      ...errorResponses,
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/stat-entry/guests',
+    summary: 'Add a guest (substitute) player for stat entry',
+    description:
+      'Adds an existing account contact as a non-rostered guest player on the team so their stats can be recorded for a game. Does not affect the contact’s active roster membership elsewhere.',
+    tags: ['Team Stats Entry'],
+    security: [{ bearerAuth: [] }],
+    parameters: [...commonParameters],
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: AddGuestPlayerSchemaRef } },
+      },
+    },
+    responses: {
+      201: {
+        description: 'Guest player added.',
+        content: { 'application/json': { schema: TeamStatsPlayerSummarySchemaRef } },
+      },
+      409: {
+        description: 'Player is already on this team roster.',
+        content: { 'application/json': { schema: ConflictErrorSchemaRef } },
       },
       ...errorResponses,
     },

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaRosterRepository.ts
@@ -166,6 +166,24 @@ export class PrismaRosterRepository implements IRosterRepository {
     });
   }
 
+  async createSubstituteRosterSeasonEntry(
+    playerId: bigint,
+    teamSeasonId: bigint,
+  ): Promise<dbRosterMember> {
+    return this.prisma.rosterseason.create({
+      data: {
+        playerid: playerId,
+        teamseasonid: teamSeasonId,
+        playernumber: '',
+        inactive: true,
+        substitute: true,
+        submittedwaiver: false,
+        dateadded: new Date(),
+      },
+      include: { roster: { include: { contacts: true } } },
+    });
+  }
+
   async updateRosterSeasonEntry(
     rosterSeasonId: bigint,
     playerNumber?: string,

--- a/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IRosterRepository.ts
@@ -50,6 +50,10 @@ export interface IRosterRepository {
     playerNumber: string,
     submittedWaiver: boolean,
   ): Promise<dbRosterMember>;
+  createSubstituteRosterSeasonEntry(
+    playerId: bigint,
+    teamSeasonId: bigint,
+  ): Promise<dbRosterMember>;
   updateRosterSeasonEntry(
     rosterSeasonId: bigint,
     playerNumber?: string,

--- a/draco-nodejs/backend/src/routes/team-stats-entry.ts
+++ b/draco-nodejs/backend/src/routes/team-stats-entry.ts
@@ -4,6 +4,7 @@ import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { extractBigIntParams } from '../utils/paramExtraction.js';
 import {
+  AddGuestPlayerSchema,
   CreateGameBattingStatSchema,
   CreateGamePitchingStatSchema,
   UpdateGameAttendanceSchema,
@@ -13,6 +14,7 @@ import {
 
 const router = Router({ mergeParams: true });
 const statsEntryService = ServiceFactory.getStatsEntryService();
+const rosterService = ServiceFactory.getRosterService();
 const routeProtection = ServiceFactory.getRouteProtection();
 
 const teamStatMiddlewares = [
@@ -37,6 +39,28 @@ router.get(
 
     const games = await statsEntryService.listCompletedGames(accountId, seasonId, teamSeasonId);
     res.json(games);
+  }),
+);
+
+router.post(
+  '/:teamSeasonId/stat-entry/guests',
+  teamStatMiddlewares,
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'teamSeasonId',
+    );
+    const payload = AddGuestPlayerSchema.parse(req.body);
+
+    const player = await rosterService.addSubstitutePlayer(
+      teamSeasonId,
+      seasonId,
+      accountId,
+      BigInt(payload.contactId),
+    );
+    res.status(201).json(player);
   }),
 );
 

--- a/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/csvExportService.test.ts
@@ -34,6 +34,8 @@ class RosterRepositoryStub implements IRosterRepository {
   createRosterPlayer = vi.fn<IRosterRepository['createRosterPlayer']>();
   updateRosterPlayer = vi.fn<IRosterRepository['updateRosterPlayer']>();
   createRosterSeasonEntry = vi.fn<IRosterRepository['createRosterSeasonEntry']>();
+  createSubstituteRosterSeasonEntry =
+    vi.fn<IRosterRepository['createSubstituteRosterSeasonEntry']>();
   updateRosterSeasonEntry = vi.fn<IRosterRepository['updateRosterSeasonEntry']>();
   deleteRosterMember = vi.fn<IRosterRepository['deleteRosterMember']>();
   hasGameStats = vi.fn<IRosterRepository['hasGameStats']>();

--- a/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
@@ -308,7 +308,6 @@ describe('RosterService.addSubstitutePlayer', () => {
       mockRosterPlayer.id,
       teamSeasonId,
     );
-    // Guests are active elsewhere by design — the one-team conflict check must not run.
     expect(rosterRepo.findRosterMemberInLeagueSeason).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       rosterSeasonId: '200',

--- a/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
@@ -38,6 +38,9 @@ class RosterRepositoryStub implements IRosterRepository {
 
   createRosterSeasonEntry = vi.fn<IRosterRepository['createRosterSeasonEntry']>();
 
+  createSubstituteRosterSeasonEntry =
+    vi.fn<IRosterRepository['createSubstituteRosterSeasonEntry']>();
+
   updateRosterSeasonEntry = vi.fn<IRosterRepository['updateRosterSeasonEntry']>();
 
   deleteRosterMember = vi.fn<IRosterRepository['deleteRosterMember']>();
@@ -220,5 +223,177 @@ describe('RosterService.addPlayerToRoster', () => {
       '',
       false,
     );
+  });
+});
+
+describe('RosterService.addSubstitutePlayer', () => {
+  let rosterRepo: RosterRepositoryStub;
+  let teamRepo: ITeamRepository;
+  let contactRepo: IContactRepository;
+  let seasonsRepo: ISeasonsRepository;
+  let service: RosterService;
+
+  const teamSeasonId = 10n;
+  const seasonId = 20n;
+  const accountId = 30n;
+  const contactId = 2n;
+
+  const mockTeamSeason = {
+    id: teamSeasonId,
+    leagueseasonid: 40n,
+    teamid: 50n,
+    name: 'Test Team',
+    divisionseasonid: null,
+  };
+
+  const mockRosterPlayer: dbRosterPlayer = partialMock<dbRosterPlayer>({
+    id: 1n,
+    contactid: contactId,
+    submitteddriverslicense: false,
+    firstyear: 0,
+    contacts: partialMock<dbRosterPlayer['contacts']>({
+      id: contactId,
+      firstname: 'Jane',
+      lastname: 'Doe',
+    }),
+  });
+
+  const mockSubstituteMember: dbRosterMember = partialMock<dbRosterMember>({
+    id: 200n,
+    playerid: 1n,
+    teamseasonid: teamSeasonId,
+    playernumber: '',
+    inactive: true,
+    substitute: true,
+    submittedwaiver: false,
+    dateadded: new Date(),
+    roster: mockRosterPlayer,
+  });
+
+  beforeEach(() => {
+    rosterRepo = new RosterRepositoryStub();
+    teamRepo = partialMock<ITeamRepository>({
+      findTeamSeason: vi.fn().mockResolvedValue(mockTeamSeason),
+    });
+    contactRepo = partialMock<IContactRepository>({
+      findContactInAccount: vi.fn().mockResolvedValue({ id: contactId }),
+    });
+    seasonsRepo = partialMock<ISeasonsRepository>({});
+
+    vi.spyOn(ServiceFactory, 'getAccountsService').mockReturnValue(
+      {} as ReturnType<typeof ServiceFactory.getAccountsService>,
+    );
+    vi.spyOn(ServiceFactory, 'getDiscordIntegrationService').mockReturnValue(
+      partialMock<ReturnType<typeof ServiceFactory.getDiscordIntegrationService>>({
+        updateTeamForumMemberForContact: vi.fn().mockResolvedValue(undefined),
+      }),
+    );
+
+    rosterRepo.findRosterPlayerByContactId.mockResolvedValue(mockRosterPlayer);
+    rosterRepo.createSubstituteRosterSeasonEntry.mockResolvedValue(mockSubstituteMember);
+
+    service = new RosterService(rosterRepo, teamRepo, contactRepo, seasonsRepo);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates an inactive substitute entry and returns a guest summary without the league active-roster check', async () => {
+    rosterRepo.findRosterMembersByTeamSeason.mockResolvedValue([]);
+
+    const result = await service.addSubstitutePlayer(teamSeasonId, seasonId, accountId, contactId);
+
+    expect(rosterRepo.createSubstituteRosterSeasonEntry).toHaveBeenCalledWith(
+      mockRosterPlayer.id,
+      teamSeasonId,
+    );
+    // Guests are active elsewhere by design — the one-team conflict check must not run.
+    expect(rosterRepo.findRosterMemberInLeagueSeason).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      rosterSeasonId: '200',
+      playerName: 'Jane Doe',
+      isSubstitute: true,
+    });
+  });
+
+  it('reuses an existing substitute row instead of creating a duplicate', async () => {
+    rosterRepo.findRosterMembersByTeamSeason.mockResolvedValue([mockSubstituteMember]);
+
+    const result = await service.addSubstitutePlayer(teamSeasonId, seasonId, accountId, contactId);
+
+    expect(rosterRepo.createSubstituteRosterSeasonEntry).not.toHaveBeenCalled();
+    expect(result.rosterSeasonId).toBe('200');
+  });
+
+  it('throws when the contact is already an active roster member of this team', async () => {
+    const activeMember: dbRosterMember = partialMock<dbRosterMember>({
+      id: 300n,
+      playerid: 1n,
+      teamseasonid: teamSeasonId,
+      inactive: false,
+      substitute: false,
+      roster: mockRosterPlayer,
+    });
+    rosterRepo.findRosterMembersByTeamSeason.mockResolvedValue([activeMember]);
+
+    await expect(
+      service.addSubstitutePlayer(teamSeasonId, seasonId, accountId, contactId),
+    ).rejects.toThrow('already on this team');
+    expect(rosterRepo.createSubstituteRosterSeasonEntry).not.toHaveBeenCalled();
+  });
+});
+
+describe('RosterService.releaseOrActivatePlayer substitute guard', () => {
+  let rosterRepo: RosterRepositoryStub;
+  let teamRepo: ITeamRepository;
+  let contactRepo: IContactRepository;
+  let seasonsRepo: ISeasonsRepository;
+  let service: RosterService;
+
+  const teamSeasonId = 10n;
+  const seasonId = 20n;
+  const accountId = 30n;
+
+  beforeEach(() => {
+    rosterRepo = new RosterRepositoryStub();
+    teamRepo = partialMock<ITeamRepository>({});
+    contactRepo = partialMock<IContactRepository>({});
+    seasonsRepo = partialMock<ISeasonsRepository>({});
+
+    vi.spyOn(ServiceFactory, 'getAccountsService').mockReturnValue(
+      {} as ReturnType<typeof ServiceFactory.getAccountsService>,
+    );
+    vi.spyOn(ServiceFactory, 'getDiscordIntegrationService').mockReturnValue(
+      partialMock<ReturnType<typeof ServiceFactory.getDiscordIntegrationService>>({
+        updateTeamForumMemberForContact: vi.fn().mockResolvedValue(undefined),
+      }),
+    );
+
+    service = new RosterService(rosterRepo, teamRepo, contactRepo, seasonsRepo);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refuses to release or activate a substitute (guest) roster row', async () => {
+    const substituteMember: dbRosterMember = partialMock<dbRosterMember>({
+      id: 200n,
+      playerid: 1n,
+      teamseasonid: teamSeasonId,
+      inactive: true,
+      substitute: true,
+      roster: partialMock<dbRosterMember['roster']>({
+        contactid: 2n,
+        contacts: partialMock<dbRosterMember['roster']['contacts']>({ userid: null }),
+      }),
+    });
+    rosterRepo.findRosterMemberForAccount.mockResolvedValue(substituteMember);
+
+    await expect(
+      service.releaseOrActivatePlayer(200n, teamSeasonId, seasonId, accountId, true),
+    ).rejects.toThrow('Substitute');
+    expect(rosterRepo.updateRosterSeasonEntry).not.toHaveBeenCalled();
   });
 });

--- a/draco-nodejs/backend/src/services/__tests__/statsEntryService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/statsEntryService.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatsEntryService } from '../statsEntryService.js';
+import { TeamService } from '../teamService.js';
+import {
+  IRosterRepository,
+  IStatsEntryRepository,
+  dbGameBattingStat,
+  dbRosterSeason,
+  dbStatsEntryGame,
+} from '../../repositories/index.js';
+import { partialMock } from '../../test-utils/partialMock.js';
+
+const accountId = 30n;
+const seasonId = 20n;
+const teamSeasonId = 10n;
+const gameId = 5n;
+const leagueSeasonId = 40n;
+
+const makeMember = (overrides: Partial<dbRosterSeason>): dbRosterSeason =>
+  partialMock<dbRosterSeason>({
+    id: 0n,
+    playerid: 0n,
+    teamseasonid: teamSeasonId,
+    playernumber: '',
+    inactive: false,
+    substitute: false,
+    roster: partialMock<dbRosterSeason['roster']>({
+      contacts: partialMock<dbRosterSeason['roster']['contacts']>({
+        id: 0n,
+        firstname: 'First',
+        lastname: 'Last',
+      }),
+    }),
+    ...overrides,
+  });
+
+const activeMember = makeMember({ id: 100n, playerid: 1n, inactive: false, substitute: false });
+const substituteMember = makeMember({ id: 200n, playerid: 2n, inactive: true, substitute: true });
+const releasedMember = makeMember({ id: 300n, playerid: 3n, inactive: true, substitute: false });
+
+describe('StatsEntryService guest (substitute) handling', () => {
+  let statsRepo: IStatsEntryRepository;
+  let rosterRepo: IRosterRepository;
+  let teamService: TeamService;
+  let service: StatsEntryService;
+  let createGameBattingStat: ReturnType<
+    typeof vi.fn<IStatsEntryRepository['createGameBattingStat']>
+  >;
+
+  beforeEach(() => {
+    createGameBattingStat = vi.fn<IStatsEntryRepository['createGameBattingStat']>();
+    createGameBattingStat.mockResolvedValue(
+      partialMock<dbGameBattingStat>({ id: 999n, playerid: 200n, rosterseason: substituteMember }),
+    );
+
+    statsRepo = partialMock<IStatsEntryRepository>({
+      findTeamGame: vi.fn().mockResolvedValue(partialMock<dbStatsEntryGame>({ id: gameId })),
+      listGameBattingStats: vi.fn().mockResolvedValue([]),
+      addAttendance: vi.fn().mockResolvedValue(undefined),
+      createGameBattingStat,
+    });
+
+    rosterRepo = partialMock<IRosterRepository>({
+      findRosterMembersByTeamSeason: vi
+        .fn()
+        .mockResolvedValue([activeMember, substituteMember, releasedMember]),
+    });
+
+    teamService = partialMock<TeamService>({
+      validateTeamSeasonBasic: vi
+        .fn()
+        .mockResolvedValue(partialMock({ leagueseason: { id: leagueSeasonId } })),
+    });
+
+    service = new StatsEntryService(statsRepo, rosterRepo, teamService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes active and substitute players in availablePlayers but excludes released players', async () => {
+    const result = await service.getGameBattingStats(accountId, seasonId, teamSeasonId, gameId);
+
+    const ids = result.availablePlayers.map((player) => player.rosterSeasonId);
+    expect(ids).toContain('100');
+    expect(ids).toContain('200');
+    expect(ids).not.toContain('300');
+
+    const guest = result.availablePlayers.find((player) => player.rosterSeasonId === '200');
+    expect(guest?.isSubstitute).toBe(true);
+  });
+
+  it('allows creating a batting stat for a substitute roster member', async () => {
+    await service.createGameBattingStat(accountId, seasonId, teamSeasonId, gameId, {
+      rosterSeasonId: '200',
+      ab: 0,
+      h: 0,
+      r: 0,
+      d: 0,
+      t: 0,
+      hr: 0,
+      rbi: 0,
+      so: 0,
+      bb: 0,
+      hbp: 0,
+      sb: 0,
+      cs: 0,
+      sf: 0,
+      sh: 0,
+      re: 0,
+      intr: 0,
+      lob: 0,
+    });
+
+    expect(createGameBattingStat).toHaveBeenCalledWith(
+      gameId,
+      teamSeasonId,
+      200n,
+      expect.any(Object),
+    );
+  });
+
+  it('rejects creating a batting stat for a released (non-substitute) roster member', async () => {
+    await expect(
+      service.createGameBattingStat(accountId, seasonId, teamSeasonId, gameId, {
+        rosterSeasonId: '300',
+        ab: 0,
+        h: 0,
+        r: 0,
+        d: 0,
+        t: 0,
+        hr: 0,
+        rbi: 0,
+        so: 0,
+        bb: 0,
+        hbp: 0,
+        sb: 0,
+        cs: 0,
+        sf: 0,
+        sh: 0,
+        re: 0,
+        intr: 0,
+        lob: 0,
+      }),
+    ).rejects.toThrow('not found on team roster');
+  });
+});

--- a/draco-nodejs/backend/src/services/rosterService.ts
+++ b/draco-nodejs/backend/src/services/rosterService.ts
@@ -7,6 +7,7 @@ import {
   TeamRosterCardType,
   TeamRosterMembersType,
   TeamRosterWaiverSummariesType,
+  TeamStatsPlayerSummaryType,
   UpdateRosterMemberType,
 } from '@draco/shared-schemas';
 import { RosterResponseFormatter, ContactResponseFormatter } from '../responseFormatters/index.js';
@@ -53,10 +54,9 @@ export class RosterService {
       throw new NotFoundError('Team season not found');
     }
 
-    const rosterMembers = await this.rosterRepository.findRosterMembersByTeamSeason(
-      teamSeasonId,
-      includeInactive,
-    );
+    const rosterMembers = (
+      await this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId, includeInactive)
+    ).filter((member) => !member.substitute);
 
     let gamesPlayedMap: Map<string, number> | undefined;
     if (includeGamesPlayed) {
@@ -91,10 +91,9 @@ export class RosterService {
       throw new NotFoundError('Team season not found');
     }
 
-    const rosterMembers = await this.rosterRepository.findRosterMembersByTeamSeason(
-      teamSeasonId,
-      includeInactive,
-    );
+    const rosterMembers = (
+      await this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId, includeInactive)
+    ).filter((member) => !member.substitute);
 
     let gamesPlayedMap: Map<string, number> | undefined;
     if (includeGamesPlayed) {
@@ -308,6 +307,73 @@ export class RosterService {
     return RosterResponseFormatter.formatRosterMemberResponse(rosterMember);
   }
 
+  async addSubstitutePlayer(
+    teamSeasonId: bigint,
+    seasonId: bigint,
+    accountId: bigint,
+    contactId: bigint,
+  ): Promise<TeamStatsPlayerSummaryType> {
+    const teamSeason = await this.teamRepository.findTeamSeason(teamSeasonId, seasonId, accountId);
+
+    if (!teamSeason) {
+      throw new NotFoundError('Team season not found');
+    }
+
+    const existingContact = await this.contactRepository.findContactInAccount(contactId, accountId);
+
+    if (!existingContact) {
+      throw new NotFoundError('Contact not found');
+    }
+
+    let rosterPlayer: dbRosterPlayer | null =
+      await this.rosterRepository.findRosterPlayerByContactId(contactId);
+
+    if (!rosterPlayer) {
+      rosterPlayer = await this.rosterRepository.createRosterPlayer(contactId, false, 0);
+    }
+
+    const teamMembers = await this.rosterRepository.findRosterMembersByTeamSeason(
+      teamSeasonId,
+      true,
+    );
+
+    const activeMember = teamMembers.find(
+      (member) => member.playerid === rosterPlayer.id && !member.inactive && !member.substitute,
+    );
+
+    if (activeMember) {
+      throw new ConflictError('Player is already on this team roster');
+    }
+
+    let substituteMember: dbRosterMember | undefined = teamMembers.find(
+      (member) => member.playerid === rosterPlayer.id && member.substitute,
+    );
+
+    if (!substituteMember) {
+      substituteMember = await this.rosterRepository.createSubstituteRosterSeasonEntry(
+        rosterPlayer.id,
+        teamSeasonId,
+      );
+    }
+
+    return this.formatSubstituteSummary(substituteMember);
+  }
+
+  private formatSubstituteSummary(member: dbRosterMember): TeamStatsPlayerSummaryType {
+    const contact = member.roster?.contacts;
+    const name = `${contact?.firstname ?? ''} ${contact?.lastname ?? ''}`.trim();
+
+    return {
+      rosterSeasonId: member.id.toString(),
+      playerId: member.playerid.toString(),
+      contactId: contact?.id.toString() ?? '0',
+      playerName: name.length > 0 ? name : 'Unknown Player',
+      playerNumber: member.playernumber ?? null,
+      photoUrl: null,
+      isSubstitute: member.substitute,
+    };
+  }
+
   async updateRosterMember(
     rosterMemberId: bigint,
     teamSeasonId: bigint,
@@ -364,6 +430,10 @@ export class RosterService {
       seasonId,
       accountId,
     );
+
+    if (rosterMember.substitute) {
+      throw new ConflictError('Substitute (guest) players cannot be released or activated');
+    }
 
     if (inactive && rosterMember.inactive) {
       throw new ConflictError('Player is already released');

--- a/draco-nodejs/backend/src/services/statsEntryService.ts
+++ b/draco-nodejs/backend/src/services/statsEntryService.ts
@@ -137,7 +137,7 @@ export class StatsEntryService {
 
     const [statsRows, rosterMembers] = await Promise.all([
       this.statsEntryRepository.listGameBattingStats(gameId, teamSeasonId),
-      this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId),
+      this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId, true),
     ]);
 
     const stats = statsRows.map((row) => this.mapBattingStatRow(row));
@@ -145,7 +145,10 @@ export class StatsEntryService {
     const usedRosterIds = new Set(statsRows.map((row) => row.playerid.toString()));
 
     const availablePlayers = rosterMembers
-      .filter((member) => !member.inactive && !usedRosterIds.has(member.id.toString()))
+      .filter(
+        (member) =>
+          (!member.inactive || member.substitute) && !usedRosterIds.has(member.id.toString()),
+      )
       .map((member) => this.mapPlayerSummary(member));
 
     return {
@@ -280,7 +283,7 @@ export class StatsEntryService {
 
     const [statsRows, rosterMembers] = await Promise.all([
       this.statsEntryRepository.listGamePitchingStats(gameId, teamSeasonId),
-      this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId),
+      this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId, true),
     ]);
 
     const stats = statsRows.map((row) => this.mapPitchingStatRow(row));
@@ -289,7 +292,10 @@ export class StatsEntryService {
 
     const usedRosterIds = new Set(statsRows.map((row) => row.playerid.toString()));
     const availablePlayers = rosterMembers
-      .filter((member) => !member.inactive && !usedRosterIds.has(member.id.toString()))
+      .filter(
+        (member) =>
+          (!member.inactive || member.substitute) && !usedRosterIds.has(member.id.toString()),
+      )
       .map((member) => this.mapPlayerSummary(member));
 
     return {
@@ -485,8 +491,8 @@ export class StatsEntryService {
     teamSeasonId: bigint,
     rosterSeasonId: bigint,
   ): Promise<dbRosterSeason> {
-    const members = await this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId);
-    const member = members.find((m) => m.id === rosterSeasonId && !m.inactive);
+    const members = await this.rosterRepository.findRosterMembersByTeamSeason(teamSeasonId, true);
+    const member = members.find((m) => m.id === rosterSeasonId && (!m.inactive || m.substitute));
     if (!member) {
       throw new NotFoundError('Player not found on team roster.');
     }
@@ -517,6 +523,7 @@ export class StatsEntryService {
       playerName: formatName(contact?.firstname, contact?.lastname),
       playerNumber: member.playernumber ?? null,
       photoUrl: null,
+      isSubstitute: member.substitute,
     };
   }
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/stat-entry/TeamStatEntryPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/stat-entry/TeamStatEntryPage.tsx
@@ -768,6 +768,42 @@ const TeamStatEntryPage: React.FC<TeamStatEntryPageProps> = ({
     showSnackbar(error.message, 'error');
   };
 
+  const handleAddGuestPlayer = async (contactId: string): Promise<TeamStatsPlayerSummaryType> => {
+    const service = new TeamStatsEntryService(token, apiClient);
+    const summary = await service.addGuestPlayer(accountId, seasonId, teamSeasonId, contactId);
+
+    const appendPlayer = <T extends { availablePlayers: TeamStatsPlayerSummaryType[] }>(
+      stats: T | null,
+    ): T | null => {
+      if (!stats) {
+        return stats;
+      }
+      if (
+        stats.availablePlayers.some((player) => player.rosterSeasonId === summary.rosterSeasonId)
+      ) {
+        return stats;
+      }
+      return { ...stats, availablePlayers: [...stats.availablePlayers, summary] };
+    };
+
+    setBattingStats((previous) => appendPlayer(previous));
+    setPitchingStats((previous) => appendPlayer(previous));
+
+    if (selectedGameId) {
+      const cachedEntry = cachedGameStatsRef.current.get(selectedGameId);
+      if (cachedEntry) {
+        cachedGameStatsRef.current.set(selectedGameId, {
+          ...cachedEntry,
+          batting: appendPlayer(cachedEntry.batting) ?? cachedEntry.batting,
+          pitching: appendPlayer(cachedEntry.pitching) ?? cachedEntry.pitching,
+        });
+      }
+    }
+
+    showSnackbar(`${summary.playerName} added as a guest player.`);
+    return summary;
+  };
+
   const handleCreateBattingStat = async (payload: CreateGameBattingStatType) => {
     if (!selectedGameId || !battingStats) {
       throw new Error('Batting stats are not available for editing.');
@@ -1539,6 +1575,7 @@ const TeamStatEntryPage: React.FC<TeamStatEntryPageProps> = ({
           tab={tabValue}
           onTabChange={handleTabChange}
           canManageStats={canManageStats}
+          accountId={accountId}
           teamSeasonId={teamSeasonId}
           canManageAllTeams={canManageAllTeams}
           enableAttendanceTracking={trackGamesPlayedEnabled}
@@ -1551,6 +1588,7 @@ const TeamStatEntryPage: React.FC<TeamStatEntryPageProps> = ({
           pitchingTotals={pitchingTotals}
           availableBatters={availableBattingPlayers}
           availablePitchers={availablePitchingPlayers}
+          onAddGuestPlayer={handleAddGuestPlayer}
           onCreateBattingStat={handleCreateBattingStat}
           onUpdateBattingStat={handleUpdateBattingStat}
           onDeleteBattingStat={setDeleteBattingTarget}

--- a/draco-nodejs/frontend-next/components/team-stats-entry/BattingStatsEditableGrid.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/BattingStatsEditableGrid.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
-import { Add, Check, Close, Delete } from '@mui/icons-material';
+import { Add, Check, Close, Delete, PersonAddAlt1 } from '@mui/icons-material';
 import {
   DataGrid,
   GridCellParams,
@@ -45,11 +45,14 @@ import {
   BATTING_FIELD_TOOLTIPS,
 } from './battingColumns';
 import { focusEditor, useCellFocusEditMode } from './useCellFocusEditMode';
+import GuestPlayerDialog from './GuestPlayerDialog';
 
 interface BattingStatsEditableGridProps {
   stats: GameBattingStatsType | null;
   totals: GameBattingStatsType['totals'] | null;
   availablePlayers: TeamStatsPlayerSummaryType[];
+  accountId: string;
+  onAddGuestPlayer: (contactId: string) => Promise<TeamStatsPlayerSummaryType>;
   onCreateStat: (payload: CreateGameBattingStatType) => Promise<void>;
   onUpdateStat: (statId: string, payload: UpdateGameBattingStatType) => Promise<void>;
   onDeleteStat: (stat: GameBattingStatLineType) => void;
@@ -147,6 +150,8 @@ const BattingStatsEditableGrid = forwardRef<
       stats,
       totals,
       availablePlayers,
+      accountId,
+      onAddGuestPlayer,
       onCreateStat,
       onUpdateStat,
       onDeleteStat,
@@ -159,6 +164,7 @@ const BattingStatsEditableGrid = forwardRef<
     ref,
   ) => {
     const apiRef = useGridApiRef();
+    const [guestDialogOpen, setGuestDialogOpen] = useState(false);
     const originalRowsRef = useRef<Map<string, BattingRow>>(new Map());
 
     const [rowsState, setRowsState] = useState<BattingRow[]>(
@@ -665,22 +671,35 @@ const BattingStatsEditableGrid = forwardRef<
                   event.stopPropagation();
                 }}
               >
-                <Autocomplete
-                  options={availablePlayers}
-                  getOptionLabel={(option) => option.playerName}
-                  value={selectedNewRowPlayer}
-                  onChange={(_event, option) =>
-                    setNewRow((prev) => ({
-                      ...prev,
-                      rosterSeasonId: option?.rosterSeasonId ?? '',
-                    }))
-                  }
-                  renderInput={(inputParams) => (
-                    <TextField {...inputParams} variant="standard" placeholder="Select player" />
-                  )}
-                  size="small"
-                  fullWidth
-                />
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  <Autocomplete
+                    options={availablePlayers}
+                    getOptionLabel={(option) =>
+                      option.isSubstitute ? `${option.playerName} (Guest)` : option.playerName
+                    }
+                    value={selectedNewRowPlayer}
+                    onChange={(_event, option) =>
+                      setNewRow((prev) => ({
+                        ...prev,
+                        rosterSeasonId: option?.rosterSeasonId ?? '',
+                      }))
+                    }
+                    renderInput={(inputParams) => (
+                      <TextField {...inputParams} variant="standard" placeholder="Select player" />
+                    )}
+                    size="small"
+                    fullWidth
+                  />
+                  <Tooltip title="Add guest player">
+                    <IconButton
+                      size="small"
+                      aria-label="Add guest player"
+                      onClick={() => setGuestDialogOpen(true)}
+                    >
+                      <PersonAddAlt1 fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
               </Box>
             );
           }
@@ -1010,6 +1029,18 @@ const BattingStatsEditableGrid = forwardRef<
             },
           }}
         />
+
+        {guestDialogOpen && (
+          <GuestPlayerDialog
+            accountId={accountId}
+            open
+            onClose={() => setGuestDialogOpen(false)}
+            onAdd={async (contactId) => {
+              const summary = await onAddGuestPlayer(contactId);
+              setNewRow((prev) => ({ ...prev, rosterSeasonId: summary.rosterSeasonId }));
+            }}
+          />
+        )}
       </Box>
     );
   },

--- a/draco-nodejs/frontend-next/components/team-stats-entry/BattingStatsSection.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/BattingStatsSection.tsx
@@ -21,6 +21,8 @@ interface BattingStatsSectionProps {
   stats: GameBattingStatsType | null;
   totals: GameBattingStatsType['totals'] | null;
   availablePlayers: TeamStatsPlayerSummaryType[];
+  accountId: string;
+  onAddGuestPlayer: (contactId: string) => Promise<TeamStatsPlayerSummaryType>;
   onCreateStat?: (payload: CreateGameBattingStatType) => Promise<void>;
   onUpdateStat?: (statId: string, payload: UpdateGameBattingStatType) => Promise<void>;
   onDeleteStat?: (stat: GameBattingStatLineType) => void;
@@ -37,6 +39,8 @@ const BattingStatsSection: React.FC<BattingStatsSectionProps> = ({
   stats,
   totals,
   availablePlayers,
+  accountId,
+  onAddGuestPlayer,
   onCreateStat,
   onUpdateStat,
   onDeleteStat,
@@ -62,6 +66,8 @@ const BattingStatsSection: React.FC<BattingStatsSectionProps> = ({
         stats={stats}
         totals={totals ?? null}
         availablePlayers={availablePlayers}
+        accountId={accountId}
+        onAddGuestPlayer={onAddGuestPlayer}
         onCreateStat={onCreateStat}
         onUpdateStat={onUpdateStat}
         onDeleteStat={onDeleteStat}

--- a/draco-nodejs/frontend-next/components/team-stats-entry/GuestPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/GuestPlayerDialog.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Autocomplete,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from '@mui/material';
+import { searchContacts } from '@draco/shared-api-client';
+import type { BaseContactType, PagedContactType } from '@draco/shared-schemas';
+
+import { useApiClient } from '../../hooks/useApiClient';
+import { unwrapApiResult } from '../../utils/apiResult';
+
+interface GuestPlayerDialogProps {
+  accountId: string;
+  open: boolean;
+  onClose: () => void;
+  onAdd: (contactId: string) => Promise<void>;
+}
+
+const formatContactLabel = (contact: BaseContactType) =>
+  `${contact.firstName} ${contact.lastName}`.trim() || contact.email || contact.id;
+
+const GuestPlayerDialog: React.FC<GuestPlayerDialogProps> = ({
+  accountId,
+  open,
+  onClose,
+  onAdd,
+}) => {
+  const apiClient = useApiClient();
+  const [contactOptions, setContactOptions] = useState<BaseContactType[]>([]);
+  const [selectedContact, setSelectedContact] = useState<BaseContactType | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setContactOptions([]);
+    setSelectedContact(null);
+    setSearchInput('');
+    setError(null);
+    setSubmitting(false);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    const controller = new AbortController();
+
+    const runSearch = async () => {
+      const trimmed = searchInput.trim();
+
+      if (!trimmed) {
+        setContactOptions([]);
+        return;
+      }
+
+      setSearching(true);
+
+      try {
+        const result = await searchContacts({
+          client: apiClient,
+          path: { accountId },
+          query: {
+            q: trimmed,
+            page: 1,
+            limit: 10,
+            sortOrder: 'asc',
+          },
+          signal: controller.signal,
+          throwOnError: false,
+        });
+
+        if (controller.signal.aborted) return;
+        const data = unwrapApiResult(result, 'Failed to search contacts') as PagedContactType;
+        setContactOptions(data.contacts ?? []);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        console.warn('Failed to search contacts:', err);
+        setContactOptions([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setSearching(false);
+        }
+      }
+    };
+
+    searchTimeoutRef.current = setTimeout(() => {
+      void runSearch();
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+      controller.abort();
+    };
+  }, [open, searchInput, accountId, apiClient]);
+
+  const handleSubmit = async () => {
+    if (!selectedContact) {
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await onAdd(selectedContact.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add guest player');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Add Guest Player</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          Add an existing contact as a one-time guest so you can record their stats for this team.
+          This does not change the player&apos;s roster on their own team.
+        </DialogContentText>
+        <Autocomplete
+          filterOptions={(x) => x}
+          options={contactOptions}
+          value={selectedContact}
+          inputValue={searchInput}
+          onInputChange={(_event, value) => {
+            setSearchInput(value);
+          }}
+          onChange={(_event, value) => {
+            setSelectedContact(value);
+            if (value) {
+              setSearchInput(formatContactLabel(value));
+            }
+          }}
+          getOptionLabel={(option) => formatContactLabel(option)}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          loading={searching}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Search contacts"
+              placeholder="Type a name"
+              autoFocus
+              error={Boolean(error)}
+              helperText={error ?? undefined}
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {searching ? <CircularProgress color="inherit" size={20} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting || !selectedContact}
+        >
+          {submitting ? 'Adding…' : 'Add Guest'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default GuestPlayerDialog;

--- a/draco-nodejs/frontend-next/components/team-stats-entry/GuestPlayerDialog.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/GuestPlayerDialog.tsx
@@ -53,6 +53,7 @@ const GuestPlayerDialog: React.FC<GuestPlayerDialogProps> = ({
     setSearchInput('');
     setError(null);
     setSubmitting(false);
+    setSearching(false);
   }, [open]);
 
   useEffect(() => {
@@ -71,6 +72,7 @@ const GuestPlayerDialog: React.FC<GuestPlayerDialogProps> = ({
 
       if (!trimmed) {
         setContactOptions([]);
+        setSearching(false);
         return;
       }
 

--- a/draco-nodejs/frontend-next/components/team-stats-entry/PitchingStatsEditableGrid.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/PitchingStatsEditableGrid.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
-import { Add, Check, Close, Delete } from '@mui/icons-material';
+import { Add, Check, Close, Delete, PersonAddAlt1 } from '@mui/icons-material';
 import {
   DataGrid,
   GridCellParams,
@@ -46,11 +46,14 @@ import {
   PITCHING_FIELD_TOOLTIPS,
 } from './pitchingColumns';
 import { focusEditor, useCellFocusEditMode } from './useCellFocusEditMode';
+import GuestPlayerDialog from './GuestPlayerDialog';
 
 interface PitchingStatsEditableGridProps {
   stats: GamePitchingStatsType | null;
   totals: GamePitchingStatsType['totals'] | null;
   availablePlayers: TeamStatsPlayerSummaryType[];
+  accountId: string;
+  onAddGuestPlayer: (contactId: string) => Promise<TeamStatsPlayerSummaryType>;
   onCreateStat: (payload: CreateGamePitchingStatType) => Promise<void>;
   onUpdateStat: (statId: string, payload: UpdateGamePitchingStatType) => Promise<void>;
   onDeleteStat: (stat: GamePitchingStatLineType) => void;
@@ -303,6 +306,8 @@ const PitchingStatsEditableGrid = forwardRef<
       stats,
       totals,
       availablePlayers,
+      accountId,
+      onAddGuestPlayer,
       onCreateStat,
       onUpdateStat,
       onDeleteStat,
@@ -316,6 +321,7 @@ const PitchingStatsEditableGrid = forwardRef<
     ref,
   ) => {
     const apiRef = useGridApiRef();
+    const [guestDialogOpen, setGuestDialogOpen] = useState(false);
     const originalRowsRef = useRef<Map<string, PitchingRow>>(new Map());
 
     const [rowsState, setRowsState] = useState<PitchingRow[]>(
@@ -845,22 +851,35 @@ const PitchingStatsEditableGrid = forwardRef<
                   event.stopPropagation();
                 }}
               >
-                <Autocomplete
-                  options={availablePlayers}
-                  getOptionLabel={(option) => option.playerName}
-                  value={selectedNewRowPlayer}
-                  onChange={(_event, option) =>
-                    setNewRow((prev) => ({
-                      ...prev,
-                      rosterSeasonId: option?.rosterSeasonId ?? '',
-                    }))
-                  }
-                  renderInput={(inputParams) => (
-                    <TextField {...inputParams} variant="standard" placeholder="Select player" />
-                  )}
-                  size="small"
-                  fullWidth
-                />
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  <Autocomplete
+                    options={availablePlayers}
+                    getOptionLabel={(option) =>
+                      option.isSubstitute ? `${option.playerName} (Guest)` : option.playerName
+                    }
+                    value={selectedNewRowPlayer}
+                    onChange={(_event, option) =>
+                      setNewRow((prev) => ({
+                        ...prev,
+                        rosterSeasonId: option?.rosterSeasonId ?? '',
+                      }))
+                    }
+                    renderInput={(inputParams) => (
+                      <TextField {...inputParams} variant="standard" placeholder="Select player" />
+                    )}
+                    size="small"
+                    fullWidth
+                  />
+                  <Tooltip title="Add guest player">
+                    <IconButton
+                      size="small"
+                      aria-label="Add guest player"
+                      onClick={() => setGuestDialogOpen(true)}
+                    >
+                      <PersonAddAlt1 fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
               </Box>
             );
           }
@@ -1215,6 +1234,18 @@ const PitchingStatsEditableGrid = forwardRef<
             '& .MuiDataGrid-cell': { outline: 'none !important' },
           }}
         />
+
+        {guestDialogOpen && (
+          <GuestPlayerDialog
+            accountId={accountId}
+            open
+            onClose={() => setGuestDialogOpen(false)}
+            onAdd={async (contactId) => {
+              const summary = await onAddGuestPlayer(contactId);
+              setNewRow((prev) => ({ ...prev, rosterSeasonId: summary.rosterSeasonId }));
+            }}
+          />
+        )}
       </Box>
     );
   },

--- a/draco-nodejs/frontend-next/components/team-stats-entry/PitchingStatsSection.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/PitchingStatsSection.tsx
@@ -26,6 +26,8 @@ interface PitchingStatsSectionProps {
   stats: GamePitchingStatsType | null;
   totals: GamePitchingStatsType['totals'] | null;
   availablePlayers: TeamStatsPlayerSummaryType[];
+  accountId: string;
+  onAddGuestPlayer: (contactId: string) => Promise<TeamStatsPlayerSummaryType>;
   onCreateStat?: (payload: CreateGamePitchingStatType) => Promise<void>;
   onUpdateStat?: (statId: string, payload: UpdateGamePitchingStatType) => Promise<void>;
   onDeleteStat?: (stat: GamePitchingStatLineType) => void;
@@ -43,6 +45,8 @@ const PitchingStatsSection: React.FC<PitchingStatsSectionProps> = ({
   stats,
   totals,
   availablePlayers,
+  accountId,
+  onAddGuestPlayer,
   onCreateStat,
   onUpdateStat,
   onDeleteStat,
@@ -69,6 +73,8 @@ const PitchingStatsSection: React.FC<PitchingStatsSectionProps> = ({
         stats={stats}
         totals={totals ?? null}
         availablePlayers={availablePlayers}
+        accountId={accountId}
+        onAddGuestPlayer={onAddGuestPlayer}
         onCreateStat={onCreateStat}
         onUpdateStat={onUpdateStat}
         onDeleteStat={onDeleteStat}

--- a/draco-nodejs/frontend-next/components/team-stats-entry/StatsTabsCard.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/StatsTabsCard.tsx
@@ -41,6 +41,7 @@ interface StatsTabsCardProps {
   tab: TabKey;
   onTabChange: (tab: TabKey) => void;
   canManageStats: boolean;
+  accountId: string;
   teamSeasonId: string;
   canManageAllTeams: boolean;
   enableAttendanceTracking: boolean;
@@ -53,6 +54,7 @@ interface StatsTabsCardProps {
   pitchingTotals: GamePitchingStatsType['totals'] | null;
   availableBatters: TeamStatsPlayerSummaryType[];
   availablePitchers: TeamStatsPlayerSummaryType[];
+  onAddGuestPlayer: (contactId: string) => Promise<TeamStatsPlayerSummaryType>;
   onCreateBattingStat: (payload: CreateGameBattingStatType) => Promise<void>;
   onUpdateBattingStat: (statId: string, payload: UpdateGameBattingStatType) => Promise<void>;
   onDeleteBattingStat: (stat: GameBattingStatLineType) => void;
@@ -91,6 +93,7 @@ const StatsTabsCard = forwardRef<StatsTabsCardHandle, StatsTabsCardProps>(
       tab,
       onTabChange,
       canManageStats,
+      accountId,
       teamSeasonId,
       canManageAllTeams,
       enableAttendanceTracking,
@@ -102,6 +105,7 @@ const StatsTabsCard = forwardRef<StatsTabsCardHandle, StatsTabsCardProps>(
       pitchingTotals,
       availableBatters,
       availablePitchers,
+      onAddGuestPlayer,
       onCreateBattingStat,
       onUpdateBattingStat,
       onDeleteBattingStat,
@@ -511,6 +515,8 @@ const StatsTabsCard = forwardRef<StatsTabsCardHandle, StatsTabsCardProps>(
                         stats={battingStats}
                         totals={battingTotals}
                         availablePlayers={availableBatters}
+                        accountId={accountId}
+                        onAddGuestPlayer={onAddGuestPlayer}
                         onCreateStat={onCreateBattingStat}
                         onUpdateStat={onUpdateBattingStat}
                         onDeleteStat={onDeleteBattingStat}
@@ -529,6 +535,8 @@ const StatsTabsCard = forwardRef<StatsTabsCardHandle, StatsTabsCardProps>(
                         stats={pitchingStats}
                         totals={pitchingTotals}
                         availablePlayers={availablePitchers}
+                        accountId={accountId}
+                        onAddGuestPlayer={onAddGuestPlayer}
                         onCreateStat={onCreatePitchingStat}
                         onUpdateStat={onUpdatePitchingStat}
                         onDeleteStat={onDeletePitchingStat}

--- a/draco-nodejs/frontend-next/components/team-stats-entry/__tests__/StatsTabsCard.test.tsx
+++ b/draco-nodejs/frontend-next/components/team-stats-entry/__tests__/StatsTabsCard.test.tsx
@@ -21,6 +21,15 @@ const noop = () => {};
 const asyncNoop = async () => {};
 
 const emptyPlayers: TeamStatsPlayerSummaryType[] = [];
+const addGuestNoop = async (): Promise<TeamStatsPlayerSummaryType> => ({
+  rosterSeasonId: 'guest-1',
+  playerId: 'player-guest',
+  contactId: 'contact-guest',
+  playerName: 'Guest Player',
+  playerNumber: null,
+  photoUrl: null,
+  isSubstitute: true,
+});
 
 const nullBatting = null as GameBattingStatsType | null;
 const nullPitching = null as GamePitchingStatsType | null;
@@ -215,6 +224,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}
@@ -266,6 +277,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}
@@ -319,6 +332,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}
@@ -373,6 +388,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}
@@ -427,6 +444,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}
@@ -481,6 +500,8 @@ describe('StatsTabsCard', () => {
         recapError={null}
         onRecapSave={asyncNoop}
         teamSeasonId="1"
+        accountId="1"
+        onAddGuestPlayer={addGuestNoop}
         canManageAllTeams={false}
         lineScoreData={null}
         lineScoreLoading={false}

--- a/draco-nodejs/frontend-next/services/teamStatsEntryService.ts
+++ b/draco-nodejs/frontend-next/services/teamStatsEntryService.ts
@@ -10,6 +10,7 @@ import {
   deleteApiAccountsByAccountIdSeasonsBySeasonIdTeamsByTeamSeasonIdStatEntryGamesByGameIdPitchingByStatId as apiDeleteGamePitchingStat,
   getApiAccountsByAccountIdSeasonsBySeasonIdTeamsByTeamSeasonIdStatEntryGamesByGameIdAttendance as apiGetGameAttendance,
   putApiAccountsByAccountIdSeasonsBySeasonIdTeamsByTeamSeasonIdStatEntryGamesByGameIdAttendance as apiUpdateGameAttendance,
+  postApiAccountsByAccountIdSeasonsBySeasonIdTeamsByTeamSeasonIdStatEntryGuests as apiAddGuestPlayer,
   listTeamSeasonBattingStats as apiListTeamSeasonBattingStats,
   listTeamSeasonPitchingStats as apiListTeamSeasonPitchingStats,
   getGameLineScore as apiGetGameLineScore,
@@ -30,6 +31,7 @@ import type {
   PlayerPitchingStatsType,
   LineScoreType,
   UpsertLineScoreType,
+  TeamStatsPlayerSummaryType,
 } from '@draco/shared-schemas';
 
 import { createApiClient } from '../lib/apiClientFactory';
@@ -228,6 +230,22 @@ export class TeamStatsEntryService {
     });
 
     assertNoApiError(result, 'Failed to delete pitching stat');
+  }
+
+  async addGuestPlayer(
+    accountId: string,
+    seasonId: string,
+    teamSeasonId: string,
+    contactId: string,
+  ): Promise<TeamStatsPlayerSummaryType> {
+    const result = await apiAddGuestPlayer({
+      client: this.client,
+      path: { accountId, seasonId, teamSeasonId },
+      body: { contactId },
+      throwOnError: false,
+    });
+
+    return unwrapApiResult(result, 'Failed to add guest player');
   }
 
   async getGameLineScore(

--- a/draco-nodejs/shared/shared-schemas/statistics.ts
+++ b/draco-nodejs/shared/shared-schemas/statistics.ts
@@ -261,7 +261,7 @@ export const TeamStatsPlayerSummarySchema = z.object({
 });
 
 export const AddGuestPlayerSchema = z.object({
-  contactId: z.string(),
+  contactId: bigintToStringSchema,
 });
 
 export const GameBattingStatInputSchema = z.object({

--- a/draco-nodejs/shared/shared-schemas/statistics.ts
+++ b/draco-nodejs/shared/shared-schemas/statistics.ts
@@ -257,6 +257,11 @@ export const TeamStatsPlayerSummarySchema = z.object({
   playerName: nameSchema,
   playerNumber: z.string().nullable(),
   photoUrl: z.string().url().nullable().optional(),
+  isSubstitute: z.boolean().optional(),
+});
+
+export const AddGuestPlayerSchema = z.object({
+  contactId: z.string(),
 });
 
 export const GameBattingStatInputSchema = z.object({
@@ -435,6 +440,7 @@ export const UpdateGameAttendanceSchema = z.object({
 });
 
 export type TeamStatsPlayerSummaryType = z.infer<typeof TeamStatsPlayerSummarySchema>;
+export type AddGuestPlayerType = z.infer<typeof AddGuestPlayerSchema>;
 export type GameBattingStatLineType = z.infer<typeof GameBattingStatLineSchema>;
 export type GameBattingTotalsType = z.infer<typeof GameBattingTotalsSchema>;
 export type GameBattingStatsType = z.infer<typeof GameBattingStatsSchema>;


### PR DESCRIPTION
Add support for one-time guest (substitute) players so their stats can be recorded without modifying their primary roster. Changes include:

- Database: add substitute BOOLEAN to rosterseason and provide a migration SQL.
- Prisma: add substitute field to schema.prisma.
- Backend API: new POST /stat-entry/guests endpoint with AddGuestPlayer schema in OpenAPI/OpenAPI types and path registration.
- Repository/service: add createSubstituteRosterSeasonEntry to IRosterRepository/PrismaRosterRepository and RosterService.addSubstitutePlayer; filter substitutes out of standard roster listings and prevent release/activate actions on substitute rows.
- StatsEntryService: include substitutes when listing available players, allow creating batting/pitching stats for substitutes, and surface isSubstitute in player summaries.
- Routes: implement route handler to add guest players.
- Frontend: add GuestPlayerDialog component, UI affordances to add guest players from batting/pitching editable grids, integrate handler in TeamStatEntryPage, and show guests in selection lists.
- Tests: add/update unit tests for roster and stats entry behaviors to cover substitute logic.

Migration SQL and all necessary type/serializer updates are included.