### PR TITLE
Serve uploads via configurable storage provider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 node_modules
+**/node_modules
+.next
+**/.next
 .git
 .env
 .env.*

--- a/draco-nodejs/backend/src/app.ts
+++ b/draco-nodejs/backend/src/app.ts
@@ -74,7 +74,7 @@ import oauthRouter from './routes/oauth.js';
 import { ServiceFactory } from './services/serviceFactory.js';
 import { socialIngestionConfig } from './config/socialIngestion.js';
 import { assetsDir as stoplightAssetsDir } from '@draco/stoplight-assets';
-import { resolveUploadsRoot } from './utils/uploadsPath.js';
+import { createUploadsHandler } from './middleware/serveUploads.js';
 import { OriginAllowList } from './utils/originAllowList.js';
 import { createFrontendBaseUrlMiddleware } from './middleware/frontendBaseUrlMiddleware.js';
 
@@ -185,8 +185,8 @@ app.use(bigIntSerializer);
 app.use(queryLoggerMiddleware);
 app.use(databaseHealthCheck);
 
-// Serve static files from uploads directory
-app.use('/uploads', express.static(resolveUploadsRoot()));
+// Serve uploaded files from disk (local) or the configured object store (s3/r2)
+app.use('/uploads', createUploadsHandler());
 
 // Health check endpoint with enhanced monitoring
 app.get('/health', (req: express.Request, res: express.Response) => {

--- a/draco-nodejs/backend/src/middleware/serveUploads.ts
+++ b/draco-nodejs/backend/src/middleware/serveUploads.ts
@@ -1,0 +1,39 @@
+import express, { type RequestHandler } from 'express';
+import { resolveUploadsRoot } from '../utils/uploadsPath.js';
+import { ServiceFactory } from '../services/serviceFactory.js';
+import { contentTypeForKey } from '../utils/mimeTypes.js';
+
+export const createUploadsHandler = (): RequestHandler => {
+  const provider = (process.env.STORAGE_PROVIDER || 'local').toLowerCase();
+
+  if (provider === 'local') {
+    return express.static(resolveUploadsRoot());
+  }
+
+  return (req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      next();
+      return;
+    }
+
+    const key = decodeURIComponent(req.path.replace(/^\/+/, ''));
+    if (!key || key.includes('..')) {
+      res.status(400).end();
+      return;
+    }
+
+    ServiceFactory.getStorageService()
+      .getObject(key)
+      .then((buffer) => {
+        if (!buffer) {
+          res.status(404).end();
+          return;
+        }
+
+        res.setHeader('Content-Type', contentTypeForKey(key));
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        res.end(buffer);
+      })
+      .catch(next);
+  };
+};

--- a/draco-nodejs/backend/src/middleware/serveUploads.ts
+++ b/draco-nodejs/backend/src/middleware/serveUploads.ts
@@ -16,8 +16,16 @@ export const createUploadsHandler = (): RequestHandler => {
       return;
     }
 
-    const key = decodeURIComponent(req.path.replace(/^\/+/, ''));
-    if (!key || key.includes('..')) {
+    let key: string;
+    try {
+      key = decodeURIComponent(req.path.replace(/^\/+/, ''));
+    } catch {
+      res.status(400).end();
+      return;
+    }
+
+    const segments = key.split('/');
+    if (!key || segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
       res.status(400).end();
       return;
     }
@@ -32,6 +40,13 @@ export const createUploadsHandler = (): RequestHandler => {
 
         res.setHeader('Content-Type', contentTypeForKey(key));
         res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        res.setHeader('Content-Length', buffer.length);
+
+        if (req.method === 'HEAD') {
+          res.end();
+          return;
+        }
+
         res.end(buffer);
       })
       .catch(next);

--- a/draco-nodejs/backend/src/middleware/serveUploads.ts
+++ b/draco-nodejs/backend/src/middleware/serveUploads.ts
@@ -1,7 +1,6 @@
 import express, { type RequestHandler } from 'express';
 import { resolveUploadsRoot } from '../utils/uploadsPath.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
-import { contentTypeForKey } from '../utils/mimeTypes.js';
 
 export const createUploadsHandler = (): RequestHandler => {
   const provider = (process.env.STORAGE_PROVIDER || 'local').toLowerCase();
@@ -32,22 +31,22 @@ export const createUploadsHandler = (): RequestHandler => {
 
     ServiceFactory.getStorageService()
       .getObject(key)
-      .then((buffer) => {
-        if (!buffer) {
+      .then((stored) => {
+        if (!stored) {
           res.status(404).end();
           return;
         }
 
-        res.setHeader('Content-Type', contentTypeForKey(key));
+        res.setHeader('Content-Type', stored.contentType);
         res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-        res.setHeader('Content-Length', buffer.length);
+        res.setHeader('Content-Length', stored.buffer.length);
 
         if (req.method === 'HEAD') {
           res.end();
           return;
         }
 
-        res.end(buffer);
+        res.end(stored.buffer);
       })
       .catch(next);
   };

--- a/draco-nodejs/backend/src/middleware/serveUploads.ts
+++ b/draco-nodejs/backend/src/middleware/serveUploads.ts
@@ -2,10 +2,12 @@ import express, { type RequestHandler } from 'express';
 import { resolveUploadsRoot } from '../utils/uploadsPath.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 
+const OBJECT_STORE_PROVIDERS = new Set(['r2', 's3']);
+
 export const createUploadsHandler = (): RequestHandler => {
   const provider = (process.env.STORAGE_PROVIDER || 'local').toLowerCase();
 
-  if (provider === 'local') {
+  if (!OBJECT_STORE_PROVIDERS.has(provider)) {
     return express.static(resolveUploadsRoot());
   }
 

--- a/draco-nodejs/backend/src/services/__tests__/inMemoryStorage.ts
+++ b/draco-nodejs/backend/src/services/__tests__/inMemoryStorage.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+import type { StorageService } from '../baseStorageService.js';
+
+export class InMemoryStorage implements StorageService {
+  readonly objects = new Map<string, { buffer: Buffer; contentType: string }>();
+
+  readonly saveObject = vi.fn(async (key: string, buffer: Buffer, contentType: string) => {
+    this.objects.set(key, { buffer, contentType });
+  });
+
+  readonly getObject = vi.fn(async (key: string): Promise<Buffer | null> => {
+    return this.objects.get(key)?.buffer ?? null;
+  });
+
+  readonly deleteObject = vi.fn(async (key: string) => {
+    this.objects.delete(key);
+  });
+
+  private notImplemented(): never {
+    throw new Error('not implemented');
+  }
+
+  saveLogo = this.notImplemented;
+  getLogo = this.notImplemented;
+  deleteLogo = this.notImplemented;
+  saveAccountLogo = this.notImplemented;
+  getAccountLogo = this.notImplemented;
+  deleteAccountLogo = this.notImplemented;
+  saveContactPhoto = this.notImplemented;
+  getContactPhoto = this.notImplemented;
+  deleteContactPhoto = this.notImplemented;
+  saveSponsorPhoto = this.notImplemented;
+  getSponsorPhoto = this.notImplemented;
+  deleteSponsorPhoto = this.notImplemented;
+  saveAttachment = this.notImplemented;
+  getAttachment = this.notImplemented;
+  deleteAttachment = this.notImplemented;
+  deleteAllAttachments = this.notImplemented;
+  saveHandout = this.notImplemented;
+  getHandout = this.notImplemented;
+  deleteHandout = this.notImplemented;
+}

--- a/draco-nodejs/backend/src/services/__tests__/inMemoryStorage.ts
+++ b/draco-nodejs/backend/src/services/__tests__/inMemoryStorage.ts
@@ -1,15 +1,15 @@
 import { vi } from 'vitest';
-import type { StorageService } from '../baseStorageService.js';
+import type { StorageService, StoredObject } from '../baseStorageService.js';
 
 export class InMemoryStorage implements StorageService {
-  readonly objects = new Map<string, { buffer: Buffer; contentType: string }>();
+  readonly objects = new Map<string, StoredObject>();
 
   readonly saveObject = vi.fn(async (key: string, buffer: Buffer, contentType: string) => {
     this.objects.set(key, { buffer, contentType });
   });
 
-  readonly getObject = vi.fn(async (key: string): Promise<Buffer | null> => {
-    return this.objects.get(key)?.buffer ?? null;
+  readonly getObject = vi.fn(async (key: string): Promise<StoredObject | null> => {
+    return this.objects.get(key) ?? null;
   });
 
   readonly deleteObject = vi.fn(async (key: string) => {

--- a/draco-nodejs/backend/src/services/__tests__/photoGalleryAssetService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/photoGalleryAssetService.test.ts
@@ -1,45 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import sharp from 'sharp';
 import { PhotoGalleryAssetService } from '../photoGalleryAssetService.js';
-import type { StorageService } from '../baseStorageService.js';
-
-class InMemoryStorage implements StorageService {
-  readonly objects = new Map<string, { buffer: Buffer; contentType: string }>();
-  readonly saveObject = vi.fn(async (key: string, buffer: Buffer, contentType: string) => {
-    this.objects.set(key, { buffer, contentType });
-  });
-  readonly deleteObject = vi.fn(async (key: string) => {
-    this.objects.delete(key);
-  });
-
-  async getObject(key: string): Promise<Buffer | null> {
-    return this.objects.get(key)?.buffer ?? null;
-  }
-
-  private notImplemented(): never {
-    throw new Error('not implemented');
-  }
-
-  saveLogo = this.notImplemented;
-  getLogo = this.notImplemented;
-  deleteLogo = this.notImplemented;
-  saveAccountLogo = this.notImplemented;
-  getAccountLogo = this.notImplemented;
-  deleteAccountLogo = this.notImplemented;
-  saveContactPhoto = this.notImplemented;
-  getContactPhoto = this.notImplemented;
-  deleteContactPhoto = this.notImplemented;
-  saveSponsorPhoto = this.notImplemented;
-  getSponsorPhoto = this.notImplemented;
-  deleteSponsorPhoto = this.notImplemented;
-  saveAttachment = this.notImplemented;
-  getAttachment = this.notImplemented;
-  deleteAttachment = this.notImplemented;
-  deleteAllAttachments = this.notImplemented;
-  saveHandout = this.notImplemented;
-  getHandout = this.notImplemented;
-  deleteHandout = this.notImplemented;
-}
+import { InMemoryStorage } from './inMemoryStorage.js';
 
 const createSourceImage = (): Promise<Buffer> =>
   sharp({

--- a/draco-nodejs/backend/src/services/__tests__/photoGalleryAssetService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/photoGalleryAssetService.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import sharp from 'sharp';
+import { PhotoGalleryAssetService } from '../photoGalleryAssetService.js';
+import type { StorageService } from '../baseStorageService.js';
+
+class InMemoryStorage implements StorageService {
+  readonly objects = new Map<string, { buffer: Buffer; contentType: string }>();
+  readonly saveObject = vi.fn(async (key: string, buffer: Buffer, contentType: string) => {
+    this.objects.set(key, { buffer, contentType });
+  });
+  readonly deleteObject = vi.fn(async (key: string) => {
+    this.objects.delete(key);
+  });
+
+  async getObject(key: string): Promise<Buffer | null> {
+    return this.objects.get(key)?.buffer ?? null;
+  }
+
+  private notImplemented(): never {
+    throw new Error('not implemented');
+  }
+
+  saveLogo = this.notImplemented;
+  getLogo = this.notImplemented;
+  deleteLogo = this.notImplemented;
+  saveAccountLogo = this.notImplemented;
+  getAccountLogo = this.notImplemented;
+  deleteAccountLogo = this.notImplemented;
+  saveContactPhoto = this.notImplemented;
+  getContactPhoto = this.notImplemented;
+  deleteContactPhoto = this.notImplemented;
+  saveSponsorPhoto = this.notImplemented;
+  getSponsorPhoto = this.notImplemented;
+  deleteSponsorPhoto = this.notImplemented;
+  saveAttachment = this.notImplemented;
+  getAttachment = this.notImplemented;
+  deleteAttachment = this.notImplemented;
+  deleteAllAttachments = this.notImplemented;
+  saveHandout = this.notImplemented;
+  getHandout = this.notImplemented;
+  deleteHandout = this.notImplemented;
+}
+
+const createSourceImage = (): Promise<Buffer> =>
+  sharp({
+    create: { width: 1200, height: 800, channels: 3, background: { r: 10, g: 120, b: 200 } },
+  })
+    .png()
+    .toBuffer();
+
+describe('PhotoGalleryAssetService', () => {
+  let storage: InMemoryStorage;
+  let service: PhotoGalleryAssetService;
+
+  beforeEach(() => {
+    storage = new InMemoryStorage();
+    service = new PhotoGalleryAssetService(storage);
+  });
+
+  it('stores resized primary and thumbnail JPEGs under the gallery keys', async () => {
+    const source = await createSourceImage();
+
+    await service.saveGalleryAssets(1n, 25n, source);
+
+    const primary = storage.objects.get('1/photo-gallery/25/photo.jpg');
+    const thumbnail = storage.objects.get('1/photo-gallery/25/photo-thumb.jpg');
+
+    expect(primary?.contentType).toBe('image/jpeg');
+    expect(thumbnail?.contentType).toBe('image/jpeg');
+
+    const primaryMeta = await sharp(primary!.buffer).metadata();
+    expect(primaryMeta.format).toBe('jpeg');
+    expect(primaryMeta.width).toBe(800);
+    expect(primaryMeta.height).toBe(450);
+
+    const thumbnailMeta = await sharp(thumbnail!.buffer).metadata();
+    expect(thumbnailMeta.width).toBe(160);
+    expect(thumbnailMeta.height).toBe(90);
+  });
+
+  it('removes both gallery keys on delete', async () => {
+    const source = await createSourceImage();
+    await service.saveGalleryAssets(1n, 25n, source);
+
+    await service.deleteGalleryAssets(1n, 25n);
+
+    expect(storage.objects.has('1/photo-gallery/25/photo.jpg')).toBe(false);
+    expect(storage.objects.has('1/photo-gallery/25/photo-thumb.jpg')).toBe(false);
+  });
+
+  it('cleans up partial writes when storage fails mid-save', async () => {
+    const source = await createSourceImage();
+    storage.saveObject.mockImplementationOnce(async (key, buffer, contentType) => {
+      storage.objects.set(key, { buffer, contentType });
+    });
+    storage.saveObject.mockImplementationOnce(async () => {
+      throw new Error('R2 unavailable');
+    });
+
+    await expect(service.saveGalleryAssets(1n, 25n, source)).rejects.toThrow('R2 unavailable');
+
+    expect(storage.deleteObject).toHaveBeenCalledWith('1/photo-gallery/25/photo.jpg');
+    expect(storage.deleteObject).toHaveBeenCalledWith('1/photo-gallery/25/photo-thumb.jpg');
+    expect(storage.objects.size).toBe(0);
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/photoSubmissionAssetService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/photoSubmissionAssetService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import sharp from 'sharp';
 import type { PhotoSubmissionRecordType } from '@draco/shared-schemas';
 import { PhotoSubmissionAssetService } from '../photoSubmissionAssetService.js';
 import { InMemoryStorage } from './inMemoryStorage.js';
@@ -61,5 +62,52 @@ describe('PhotoSubmissionAssetService.promoteSubmissionAssets', () => {
     expect(storage.getObject).not.toHaveBeenCalledWith(submission.originalFilePath);
     expect(storage.getObject).toHaveBeenCalledTimes(2);
     expect(storage.saveObject).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the stored content type when promoting a .bmp-keyed JPEG derivative', async () => {
+    const bmpSubmission: PhotoSubmissionRecordType = {
+      ...submission,
+      originalFilePath: '1/photo-submissions/key/original.bmp',
+      primaryImagePath: '1/photo-submissions/key/primary.bmp',
+      thumbnailImagePath: '1/photo-submissions/key/thumbnail.bmp',
+    };
+    storage.objects.set(bmpSubmission.primaryImagePath, {
+      buffer: Buffer.from('jpeg-bytes'),
+      contentType: 'image/jpeg',
+    });
+    storage.objects.set(bmpSubmission.thumbnailImagePath, {
+      buffer: Buffer.from('jpeg-thumb'),
+      contentType: 'image/jpeg',
+    });
+
+    await service.promoteSubmissionAssets(bmpSubmission, 25n);
+
+    const photo = storage.objects.get('1/photo-gallery/25/photo.bmp');
+    expect(photo?.contentType).toBe('image/jpeg');
+  });
+});
+
+describe('PhotoSubmissionAssetService.stageSubmissionAssets', () => {
+  const bmpSubmission: PhotoSubmissionRecordType = {
+    ...submission,
+    originalFilePath: '1/photo-submissions/key/original.bmp',
+    primaryImagePath: '1/photo-submissions/key/primary.bmp',
+    thumbnailImagePath: '1/photo-submissions/key/thumbnail.bmp',
+  };
+
+  it('stores the original as image/bmp and transcoded derivatives as image/jpeg', async () => {
+    const storage = new InMemoryStorage();
+    const service = new PhotoSubmissionAssetService(storage);
+    const source = await sharp({
+      create: { width: 1200, height: 800, channels: 3, background: { r: 5, g: 90, b: 180 } },
+    })
+      .png()
+      .toBuffer();
+
+    await service.stageSubmissionAssets(bmpSubmission, source);
+
+    expect(storage.objects.get(bmpSubmission.originalFilePath)?.contentType).toBe('image/bmp');
+    expect(storage.objects.get(bmpSubmission.primaryImagePath)?.contentType).toBe('image/jpeg');
+    expect(storage.objects.get(bmpSubmission.thumbnailImagePath)?.contentType).toBe('image/jpeg');
   });
 });

--- a/draco-nodejs/backend/src/services/__tests__/photoSubmissionAssetService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/photoSubmissionAssetService.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { PhotoSubmissionRecordType } from '@draco/shared-schemas';
+import { PhotoSubmissionAssetService } from '../photoSubmissionAssetService.js';
+import { InMemoryStorage } from './inMemoryStorage.js';
+
+const submission: PhotoSubmissionRecordType = {
+  id: '10',
+  accountId: '1',
+  teamId: null,
+  albumId: null,
+  submitterContactId: '5',
+  moderatedByContactId: null,
+  approvedPhotoId: null,
+  title: 'Summer Tournament',
+  caption: null,
+  originalFileName: 'photo.jpg',
+  originalFilePath: '1/photo-submissions/key/original.jpg',
+  primaryImagePath: '1/photo-submissions/key/primary.jpg',
+  thumbnailImagePath: '1/photo-submissions/key/thumbnail.jpg',
+  status: 'Approved',
+  denialReason: null,
+  submittedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+  updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+  moderatedAt: null,
+};
+
+describe('PhotoSubmissionAssetService.promoteSubmissionAssets', () => {
+  let storage: InMemoryStorage;
+  let service: PhotoSubmissionAssetService;
+
+  beforeEach(() => {
+    storage = new InMemoryStorage();
+    service = new PhotoSubmissionAssetService(storage);
+    storage.objects.set(submission.originalFilePath, {
+      buffer: Buffer.from('original'),
+      contentType: 'image/jpeg',
+    });
+    storage.objects.set(submission.primaryImagePath, {
+      buffer: Buffer.from('primary'),
+      contentType: 'image/jpeg',
+    });
+    storage.objects.set(submission.thumbnailImagePath, {
+      buffer: Buffer.from('thumbnail'),
+      contentType: 'image/jpeg',
+    });
+  });
+
+  it('promotes the primary into the gallery photo key and the thumbnail into the thumb key', async () => {
+    await service.promoteSubmissionAssets(submission, 25n);
+
+    const photo = storage.objects.get('1/photo-gallery/25/photo.jpg');
+    const thumb = storage.objects.get('1/photo-gallery/25/photo-thumb.jpg');
+
+    expect(photo?.buffer.toString()).toBe('primary');
+    expect(thumb?.buffer.toString()).toBe('thumbnail');
+  });
+
+  it('does not redundantly read or copy the submission original', async () => {
+    await service.promoteSubmissionAssets(submission, 25n);
+
+    expect(storage.getObject).not.toHaveBeenCalledWith(submission.originalFilePath);
+    expect(storage.getObject).toHaveBeenCalledTimes(2);
+    expect(storage.saveObject).toHaveBeenCalledTimes(2);
+  });
+});

--- a/draco-nodejs/backend/src/services/baseStorageService.ts
+++ b/draco-nodejs/backend/src/services/baseStorageService.ts
@@ -42,6 +42,9 @@ export interface StorageService {
     filename: string,
     teamId?: string,
   ): Promise<void>;
+  saveObject(key: string, buffer: Buffer, contentType: string): Promise<void>;
+  getObject(key: string): Promise<Buffer | null>;
+  deleteObject(key: string): Promise<void>;
 }
 
 export abstract class BaseStorageService implements StorageService {
@@ -152,4 +155,7 @@ export abstract class BaseStorageService implements StorageService {
     filename: string,
     teamId?: string,
   ): Promise<void>;
+  abstract saveObject(key: string, buffer: Buffer, contentType: string): Promise<void>;
+  abstract getObject(key: string): Promise<Buffer | null>;
+  abstract deleteObject(key: string): Promise<void>;
 }

--- a/draco-nodejs/backend/src/services/baseStorageService.ts
+++ b/draco-nodejs/backend/src/services/baseStorageService.ts
@@ -1,5 +1,10 @@
 import { ImageProcessor } from '../utils/imageProcessor.js';
 
+export interface StoredObject {
+  buffer: Buffer;
+  contentType: string;
+}
+
 export interface StorageService {
   saveLogo(accountId: string, teamId: string, buffer: Buffer): Promise<void>;
   getLogo(accountId: string, teamId: string): Promise<Buffer | null>;
@@ -43,7 +48,7 @@ export interface StorageService {
     teamId?: string,
   ): Promise<void>;
   saveObject(key: string, buffer: Buffer, contentType: string): Promise<void>;
-  getObject(key: string): Promise<Buffer | null>;
+  getObject(key: string): Promise<StoredObject | null>;
   deleteObject(key: string): Promise<void>;
 }
 
@@ -156,6 +161,6 @@ export abstract class BaseStorageService implements StorageService {
     teamId?: string,
   ): Promise<void>;
   abstract saveObject(key: string, buffer: Buffer, contentType: string): Promise<void>;
-  abstract getObject(key: string): Promise<Buffer | null>;
+  abstract getObject(key: string): Promise<StoredObject | null>;
   abstract deleteObject(key: string): Promise<void>;
 }

--- a/draco-nodejs/backend/src/services/photoGalleryAssetService.ts
+++ b/draco-nodejs/backend/src/services/photoGalleryAssetService.ts
@@ -1,25 +1,18 @@
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import sharp from 'sharp';
-import {
-  buildGalleryAssetPaths,
-  resolveGalleryAssetAbsolutePath,
-} from '../utils/photoSubmissionPaths.js';
+import { buildGalleryAssetPaths } from '../utils/photoSubmissionPaths.js';
+import { contentTypeForKey } from '../utils/mimeTypes.js';
+import { ServiceFactory } from './serviceFactory.js';
+import type { StorageService } from './baseStorageService.js';
 
 const PRIMARY_DIMENSIONS = { width: 800, height: 450 } as const;
 const THUMBNAIL_DIMENSIONS = { width: 160, height: 90 } as const;
 const GALLERY_EXTENSION = '.jpg';
 
-const ensureDirectory = async (targetPath: string): Promise<void> => {
-  await fs.mkdir(targetPath, { recursive: true });
-};
-
-const writeJpeg = async (
+const toJpeg = async (
   buffer: Buffer,
-  destination: string,
   dimensions?: { width: number; height: number },
   options: { withoutEnlargement?: boolean } = {},
-): Promise<void> => {
+): Promise<Buffer> => {
   let image = sharp(buffer);
 
   if (dimensions) {
@@ -30,35 +23,39 @@ const writeJpeg = async (
     });
   }
 
-  await ensureDirectory(path.dirname(destination));
-  await image.jpeg({ quality: 90 }).toFile(destination);
+  return image.jpeg({ quality: 90 }).toBuffer();
 };
 
 export class PhotoGalleryAssetService {
+  constructor(private readonly storage: StorageService = ServiceFactory.getStorageService()) {}
+
   async saveGalleryAssets(accountId: bigint, photoId: bigint, buffer: Buffer): Promise<void> {
     const galleryPaths = buildGalleryAssetPaths(accountId, photoId, GALLERY_EXTENSION);
 
-    const originalPath = resolveGalleryAssetAbsolutePath(galleryPaths.originalFilePath);
-    const primaryPath = resolveGalleryAssetAbsolutePath(galleryPaths.primaryImagePath);
-    const thumbnailPath = resolveGalleryAssetAbsolutePath(galleryPaths.thumbnailImagePath);
-
     try {
-      await writeJpeg(buffer, originalPath);
-      await writeJpeg(buffer, primaryPath, PRIMARY_DIMENSIONS, { withoutEnlargement: true });
-      await writeJpeg(buffer, thumbnailPath, THUMBNAIL_DIMENSIONS);
+      const primary = await toJpeg(buffer, PRIMARY_DIMENSIONS, { withoutEnlargement: true });
+      const thumbnail = await toJpeg(buffer, THUMBNAIL_DIMENSIONS);
+
+      await this.storage.saveObject(
+        galleryPaths.primaryImagePath,
+        primary,
+        contentTypeForKey(galleryPaths.primaryImagePath),
+      );
+      await this.storage.saveObject(
+        galleryPaths.thumbnailImagePath,
+        thumbnail,
+        contentTypeForKey(galleryPaths.thumbnailImagePath),
+      );
     } catch (error) {
-      await fs
-        .rm(path.dirname(originalPath), { recursive: true, force: true })
-        .catch(() => undefined);
+      await this.deleteGalleryAssets(accountId, photoId).catch(() => undefined);
       throw error;
     }
   }
 
   async deleteGalleryAssets(accountId: bigint, photoId: bigint): Promise<void> {
     const galleryPaths = buildGalleryAssetPaths(accountId, photoId, GALLERY_EXTENSION);
-    const originalPath = resolveGalleryAssetAbsolutePath(galleryPaths.originalFilePath);
-    const directory = path.dirname(originalPath);
 
-    await fs.rm(directory, { recursive: true, force: true });
+    await this.storage.deleteObject(galleryPaths.primaryImagePath);
+    await this.storage.deleteObject(galleryPaths.thumbnailImagePath);
   }
 }

--- a/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
+++ b/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
@@ -109,7 +109,6 @@ export class PhotoSubmissionAssetService {
     const accountId = BigInt(submission.accountId);
     const galleryAssets = buildGalleryAssetPaths(accountId, approvedPhotoId, extension);
 
-    await this.copyObject(submission.originalFilePath, galleryAssets.originalFilePath);
     await this.copyObject(submission.primaryImagePath, galleryAssets.primaryImagePath);
     await this.copyObject(submission.thumbnailImagePath, galleryAssets.thumbnailImagePath);
   }

--- a/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
+++ b/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
@@ -1,12 +1,10 @@
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import sharp, { FormatEnum, type Metadata } from 'sharp';
 import type { PhotoSubmissionRecordType } from '@draco/shared-schemas';
-import {
-  buildGalleryAssetPaths,
-  resolveGalleryAssetAbsolutePath,
-  resolveSubmissionAssetAbsolutePath,
-} from '../utils/photoSubmissionPaths.js';
+import { buildGalleryAssetPaths } from '../utils/photoSubmissionPaths.js';
+import { contentTypeForKey } from '../utils/mimeTypes.js';
+import { ServiceFactory } from './serviceFactory.js';
+import type { StorageService } from './baseStorageService.js';
 
 const PRIMARY_DIMENSIONS = { width: 800, height: 450 } as const;
 const THUMBNAIL_DIMENSIONS = { width: 160, height: 90 } as const;
@@ -17,10 +15,6 @@ const SUPPORTED_FORMATS: Record<string, keyof FormatEnum> = {
   '.png': 'png',
   '.gif': 'gif',
   '.bmp': 'jpeg',
-};
-
-const ensureDirectory = async (targetPath: string): Promise<void> => {
-  await fs.mkdir(targetPath, { recursive: true });
 };
 
 const getExtension = (filePath: string): string => path.extname(filePath).toLowerCase();
@@ -41,70 +35,70 @@ const matchesTargetDimensions = (
   return metadata.width === dimensions.width && metadata.height === dimensions.height;
 };
 
-const processImage = async (
+const resizeToBuffer = async (
   buffer: Buffer,
-  destination: string,
   format: keyof FormatEnum,
   dimensions: { width: number; height: number },
   options: { withoutEnlargement?: boolean } = {},
-): Promise<void> => {
-  await sharp(buffer)
+): Promise<Buffer> => {
+  return sharp(buffer)
     .resize(dimensions.width, dimensions.height, {
       fit: 'cover',
       position: 'centre',
       withoutEnlargement: options.withoutEnlargement ?? false,
     })
     .toFormat(format)
-    .toFile(destination);
-};
-
-const copyFile = async (source: string, destination: string): Promise<void> => {
-  await ensureDirectory(path.dirname(destination));
-  await fs.copyFile(source, destination);
+    .toBuffer();
 };
 
 export class PhotoSubmissionAssetService {
+  constructor(private readonly storage: StorageService = ServiceFactory.getStorageService()) {}
+
   async stageSubmissionAssets(
     submission: PhotoSubmissionRecordType,
     fileBuffer: Buffer,
   ): Promise<void> {
-    const originalPath = resolveSubmissionAssetAbsolutePath(submission.originalFilePath);
-    const primaryPath = resolveSubmissionAssetAbsolutePath(submission.primaryImagePath);
-    const thumbnailPath = resolveSubmissionAssetAbsolutePath(submission.thumbnailImagePath);
-    const directory = path.dirname(originalPath);
     const extension = getExtension(submission.originalFilePath);
     const format = getSharpFormat(extension);
 
     try {
-      await ensureDirectory(directory);
-      await fs.writeFile(originalPath, fileBuffer);
+      await this.storage.saveObject(
+        submission.originalFilePath,
+        fileBuffer,
+        contentTypeForKey(submission.originalFilePath),
+      );
 
       const metadata = await sharp(fileBuffer).metadata();
 
-      await ensureDirectory(path.dirname(primaryPath));
-      if (matchesTargetDimensions(metadata, PRIMARY_DIMENSIONS)) {
-        await fs.writeFile(primaryPath, fileBuffer);
-      } else {
-        await processImage(fileBuffer, primaryPath, format, PRIMARY_DIMENSIONS, {
-          withoutEnlargement: true,
-        });
-      }
+      const primaryBuffer = matchesTargetDimensions(metadata, PRIMARY_DIMENSIONS)
+        ? fileBuffer
+        : await resizeToBuffer(fileBuffer, format, PRIMARY_DIMENSIONS, {
+            withoutEnlargement: true,
+          });
+      await this.storage.saveObject(
+        submission.primaryImagePath,
+        primaryBuffer,
+        contentTypeForKey(submission.primaryImagePath),
+      );
 
-      await ensureDirectory(path.dirname(thumbnailPath));
-      if (matchesTargetDimensions(metadata, THUMBNAIL_DIMENSIONS)) {
-        await fs.writeFile(thumbnailPath, fileBuffer);
-      } else {
-        await processImage(fileBuffer, thumbnailPath, format, THUMBNAIL_DIMENSIONS);
-      }
+      const thumbnailBuffer = matchesTargetDimensions(metadata, THUMBNAIL_DIMENSIONS)
+        ? fileBuffer
+        : await resizeToBuffer(fileBuffer, format, THUMBNAIL_DIMENSIONS);
+      await this.storage.saveObject(
+        submission.thumbnailImagePath,
+        thumbnailBuffer,
+        contentTypeForKey(submission.thumbnailImagePath),
+      );
     } catch (error) {
-      await fs.rm(directory, { recursive: true, force: true }).catch(() => undefined);
+      await this.deleteSubmissionAssets(submission).catch(() => undefined);
       throw error;
     }
   }
 
   async deleteSubmissionAssets(submission: PhotoSubmissionRecordType): Promise<void> {
-    const directory = path.dirname(resolveSubmissionAssetAbsolutePath(submission.originalFilePath));
-    await fs.rm(directory, { recursive: true, force: true });
+    await this.storage.deleteObject(submission.originalFilePath);
+    await this.storage.deleteObject(submission.primaryImagePath);
+    await this.storage.deleteObject(submission.thumbnailImagePath);
   }
 
   async promoteSubmissionAssets(
@@ -115,17 +109,9 @@ export class PhotoSubmissionAssetService {
     const accountId = BigInt(submission.accountId);
     const galleryAssets = buildGalleryAssetPaths(accountId, approvedPhotoId, extension);
 
-    const sourceOriginal = resolveSubmissionAssetAbsolutePath(submission.originalFilePath);
-    const sourcePrimary = resolveSubmissionAssetAbsolutePath(submission.primaryImagePath);
-    const sourceThumbnail = resolveSubmissionAssetAbsolutePath(submission.thumbnailImagePath);
-
-    const destinationOriginal = resolveGalleryAssetAbsolutePath(galleryAssets.originalFilePath);
-    const destinationPrimary = resolveGalleryAssetAbsolutePath(galleryAssets.primaryImagePath);
-    const destinationThumbnail = resolveGalleryAssetAbsolutePath(galleryAssets.thumbnailImagePath);
-
-    await copyFile(sourceOriginal, destinationOriginal);
-    await copyFile(sourcePrimary, destinationPrimary);
-    await copyFile(sourceThumbnail, destinationThumbnail);
+    await this.copyObject(submission.originalFilePath, galleryAssets.originalFilePath);
+    await this.copyObject(submission.primaryImagePath, galleryAssets.primaryImagePath);
+    await this.copyObject(submission.thumbnailImagePath, galleryAssets.thumbnailImagePath);
   }
 
   async deleteGalleryAssets(
@@ -136,9 +122,16 @@ export class PhotoSubmissionAssetService {
     const accountId = BigInt(submission.accountId);
     const galleryAssets = buildGalleryAssetPaths(accountId, approvedPhotoId, extension);
 
-    const destinationOriginal = resolveGalleryAssetAbsolutePath(galleryAssets.originalFilePath);
-    const directory = path.dirname(destinationOriginal);
+    await this.storage.deleteObject(galleryAssets.primaryImagePath);
+    await this.storage.deleteObject(galleryAssets.thumbnailImagePath);
+  }
 
-    await fs.rm(directory, { recursive: true, force: true });
+  private async copyObject(sourceKey: string, destinationKey: string): Promise<void> {
+    const buffer = await this.storage.getObject(sourceKey);
+    if (!buffer) {
+      throw new Error(`Source asset not found: ${sourceKey}`);
+    }
+
+    await this.storage.saveObject(destinationKey, buffer, contentTypeForKey(destinationKey));
   }
 }

--- a/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
+++ b/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
@@ -63,10 +63,10 @@ export class PhotoSubmissionAssetService {
     const originalContentType = contentTypeForKey(submission.originalFilePath);
     const encodedContentType = contentTypeForImageFormat(format);
 
+    const metadata = await sharp(fileBuffer).metadata();
+
     try {
       await this.storage.saveObject(submission.originalFilePath, fileBuffer, originalContentType);
-
-      const metadata = await sharp(fileBuffer).metadata();
 
       const primaryMatches = matchesTargetDimensions(metadata, PRIMARY_DIMENSIONS);
       const primaryBuffer = primaryMatches

--- a/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
+++ b/draco-nodejs/backend/src/services/photoSubmissionAssetService.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import sharp, { FormatEnum, type Metadata } from 'sharp';
 import type { PhotoSubmissionRecordType } from '@draco/shared-schemas';
 import { buildGalleryAssetPaths } from '../utils/photoSubmissionPaths.js';
-import { contentTypeForKey } from '../utils/mimeTypes.js';
+import { contentTypeForKey, contentTypeForImageFormat } from '../utils/mimeTypes.js';
 import { ServiceFactory } from './serviceFactory.js';
 import type { StorageService } from './baseStorageService.js';
 
@@ -60,17 +60,16 @@ export class PhotoSubmissionAssetService {
   ): Promise<void> {
     const extension = getExtension(submission.originalFilePath);
     const format = getSharpFormat(extension);
+    const originalContentType = contentTypeForKey(submission.originalFilePath);
+    const encodedContentType = contentTypeForImageFormat(format);
 
     try {
-      await this.storage.saveObject(
-        submission.originalFilePath,
-        fileBuffer,
-        contentTypeForKey(submission.originalFilePath),
-      );
+      await this.storage.saveObject(submission.originalFilePath, fileBuffer, originalContentType);
 
       const metadata = await sharp(fileBuffer).metadata();
 
-      const primaryBuffer = matchesTargetDimensions(metadata, PRIMARY_DIMENSIONS)
+      const primaryMatches = matchesTargetDimensions(metadata, PRIMARY_DIMENSIONS);
+      const primaryBuffer = primaryMatches
         ? fileBuffer
         : await resizeToBuffer(fileBuffer, format, PRIMARY_DIMENSIONS, {
             withoutEnlargement: true,
@@ -78,16 +77,17 @@ export class PhotoSubmissionAssetService {
       await this.storage.saveObject(
         submission.primaryImagePath,
         primaryBuffer,
-        contentTypeForKey(submission.primaryImagePath),
+        primaryMatches ? originalContentType : encodedContentType,
       );
 
-      const thumbnailBuffer = matchesTargetDimensions(metadata, THUMBNAIL_DIMENSIONS)
+      const thumbnailMatches = matchesTargetDimensions(metadata, THUMBNAIL_DIMENSIONS);
+      const thumbnailBuffer = thumbnailMatches
         ? fileBuffer
         : await resizeToBuffer(fileBuffer, format, THUMBNAIL_DIMENSIONS);
       await this.storage.saveObject(
         submission.thumbnailImagePath,
         thumbnailBuffer,
-        contentTypeForKey(submission.thumbnailImagePath),
+        thumbnailMatches ? originalContentType : encodedContentType,
       );
     } catch (error) {
       await this.deleteSubmissionAssets(submission).catch(() => undefined);
@@ -126,11 +126,11 @@ export class PhotoSubmissionAssetService {
   }
 
   private async copyObject(sourceKey: string, destinationKey: string): Promise<void> {
-    const buffer = await this.storage.getObject(sourceKey);
-    if (!buffer) {
+    const stored = await this.storage.getObject(sourceKey);
+    if (!stored) {
       throw new Error(`Source asset not found: ${sourceKey}`);
     }
 
-    await this.storage.saveObject(destinationKey, buffer, contentTypeForKey(destinationKey));
+    await this.storage.saveObject(destinationKey, stored.buffer, stored.contentType);
   }
 }

--- a/draco-nodejs/backend/src/services/storageService.ts
+++ b/draco-nodejs/backend/src/services/storageService.ts
@@ -371,7 +371,7 @@ export class LocalStorageService extends BaseStorageService {
     }
   }
 
-  async saveObject(key: string, buffer: Buffer): Promise<void> {
+  async saveObject(key: string, buffer: Buffer, _contentType: string): Promise<void> {
     try {
       const filePath = path.join(this.uploadsDir, key);
       await fs.promises.mkdir(path.dirname(filePath), { recursive: true });

--- a/draco-nodejs/backend/src/services/storageService.ts
+++ b/draco-nodejs/backend/src/services/storageService.ts
@@ -9,8 +9,9 @@ import {
   HeadBucketCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { BaseStorageService, StorageService } from './baseStorageService.js';
+import { BaseStorageService, StorageService, StoredObject } from './baseStorageService.js';
 import { resolveUploadsRoot } from '../utils/uploadsPath.js';
+import { contentTypeForKey } from '../utils/mimeTypes.js';
 
 // AWS Error interface for better type safety
 interface AWSError extends Error {
@@ -381,16 +382,16 @@ export class LocalStorageService extends BaseStorageService {
     }
   }
 
-  async getObject(key: string): Promise<Buffer | null> {
+  async getObject(key: string): Promise<StoredObject | null> {
     try {
       const filePath = path.join(this.uploadsDir, key);
-      if (!fs.existsSync(filePath)) {
+      const buffer = await fs.promises.readFile(filePath);
+      return { buffer, contentType: contentTypeForKey(key) };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return null;
       }
-      return await fs.promises.readFile(filePath);
-    } catch (error) {
-      console.error('Error reading object from local storage:', error);
-      return null;
+      this.handleStorageError(error, 'read object from local storage');
     }
   }
 
@@ -1046,7 +1047,7 @@ export class S3StorageService extends BaseStorageService {
     }
   }
 
-  async getObject(key: string): Promise<Buffer | null> {
+  async getObject(key: string): Promise<StoredObject | null> {
     try {
       const command = new GetObjectCommand({ Bucket: this.bucketName, Key: key });
       const response = await this.s3Client.send(command);
@@ -1061,10 +1062,17 @@ export class S3StorageService extends BaseStorageService {
         chunks.push(Buffer.from(chunk));
       }
 
-      return Buffer.concat(chunks);
-    } catch (error) {
+      return {
+        buffer: Buffer.concat(chunks),
+        contentType: response.ContentType || contentTypeForKey(key),
+      };
+    } catch (error: unknown) {
+      const awsError = error as AWSError;
+      if (awsError.name === 'NoSuchKey' || awsError.$metadata?.httpStatusCode === 404) {
+        return null;
+      }
       console.error('Error retrieving object from S3:', error);
-      return null;
+      throw new Error('Failed to get object from S3');
     }
   }
 

--- a/draco-nodejs/backend/src/services/storageService.ts
+++ b/draco-nodejs/backend/src/services/storageService.ts
@@ -370,6 +370,38 @@ export class LocalStorageService extends BaseStorageService {
       this.handleStorageError(error, 'delete handout from local storage');
     }
   }
+
+  async saveObject(key: string, buffer: Buffer): Promise<void> {
+    try {
+      const filePath = path.join(this.uploadsDir, key);
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, buffer);
+    } catch (error) {
+      this.handleStorageError(error, 'save object to local storage');
+    }
+  }
+
+  async getObject(key: string): Promise<Buffer | null> {
+    try {
+      const filePath = path.join(this.uploadsDir, key);
+      if (!fs.existsSync(filePath)) {
+        return null;
+      }
+      return await fs.promises.readFile(filePath);
+    } catch (error) {
+      console.error('Error reading object from local storage:', error);
+      return null;
+    }
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    try {
+      const filePath = path.join(this.uploadsDir, key);
+      await fs.promises.rm(filePath, { force: true });
+    } catch (error) {
+      this.handleStorageError(error, 'delete object from local storage');
+    }
+  }
 }
 
 interface S3Config {
@@ -995,6 +1027,54 @@ export class S3StorageService extends BaseStorageService {
     } catch (error) {
       console.error('Error deleting handout from S3:', error);
       throw new Error('Failed to delete handout from S3');
+    }
+  }
+
+  async saveObject(key: string, buffer: Buffer, contentType: string): Promise<void> {
+    try {
+      const command = new PutObjectCommand({
+        Bucket: this.bucketName,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      });
+      await this.s3Client.send(command);
+    } catch (error) {
+      console.error('Error saving object to S3:', error);
+      throw new Error('Failed to save object to S3');
+    }
+  }
+
+  async getObject(key: string): Promise<Buffer | null> {
+    try {
+      const command = new GetObjectCommand({ Bucket: this.bucketName, Key: key });
+      const response = await this.s3Client.send(command);
+
+      if (!response.Body) {
+        return null;
+      }
+
+      const chunks: Buffer[] = [];
+      const stream = response.Body as NodeJS.ReadableStream;
+      for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk));
+      }
+
+      return Buffer.concat(chunks);
+    } catch (error) {
+      console.error('Error retrieving object from S3:', error);
+      return null;
+    }
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    try {
+      const command = new DeleteObjectCommand({ Bucket: this.bucketName, Key: key });
+      await this.s3Client.send(command);
+    } catch (error) {
+      console.error('Error deleting object from S3:', error);
+      throw new Error('Failed to delete object from S3');
     }
   }
 }

--- a/draco-nodejs/backend/src/utils/mimeTypes.ts
+++ b/draco-nodejs/backend/src/utils/mimeTypes.ts
@@ -4,6 +4,14 @@ const EXTENSION_CONTENT_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.gif': 'image/gif',
   '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+};
+
+const FORMAT_CONTENT_TYPES: Record<string, string> = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
 };
 
 export const contentTypeForKey = (key: string): string => {
@@ -14,4 +22,8 @@ export const contentTypeForKey = (key: string): string => {
 
   const extension = key.slice(lastDot).toLowerCase();
   return EXTENSION_CONTENT_TYPES[extension] ?? 'application/octet-stream';
+};
+
+export const contentTypeForImageFormat = (format: string): string => {
+  return FORMAT_CONTENT_TYPES[format] ?? 'application/octet-stream';
 };

--- a/draco-nodejs/backend/src/utils/mimeTypes.ts
+++ b/draco-nodejs/backend/src/utils/mimeTypes.ts
@@ -1,0 +1,17 @@
+const EXTENSION_CONTENT_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+export const contentTypeForKey = (key: string): string => {
+  const lastDot = key.lastIndexOf('.');
+  if (lastDot === -1) {
+    return 'application/octet-stream';
+  }
+
+  const extension = key.slice(lastDot).toLowerCase();
+  return EXTENSION_CONTENT_TYPES[extension] ?? 'application/octet-stream';
+};

--- a/draco-nodejs/backend/src/utils/photoSubmissionPaths.ts
+++ b/draco-nodejs/backend/src/utils/photoSubmissionPaths.ts
@@ -1,5 +1,4 @@
 import type { PhotoSubmissionAssetsType } from '@draco/shared-schemas';
-import { buildUploadsPath } from './uploadsPath.js';
 
 const ensureExtensionFormat = (extension: string): string => {
   if (!extension) {
@@ -26,10 +25,6 @@ export function buildSubmissionAssetPaths(
   };
 }
 
-export function resolveSubmissionAssetAbsolutePath(relativePath: string): string {
-  return buildUploadsPath(relativePath);
-}
-
 export function buildGalleryAssetPaths(
   accountId: bigint,
   photoId: bigint,
@@ -48,8 +43,4 @@ export function buildGalleryAssetPaths(
     primaryImagePath: `${basePath}/photo${normalizedExtension}`,
     thumbnailImagePath: `${basePath}/photo-thumb${normalizedExtension}`,
   };
-}
-
-export function resolveGalleryAssetAbsolutePath(relativePath: string): string {
-  return buildUploadsPath(relativePath);
 }

--- a/draco-nodejs/backend/src/utils/uploadsPath.ts
+++ b/draco-nodejs/backend/src/utils/uploadsPath.ts
@@ -13,10 +13,3 @@ export const resolveUploadsRoot = (): string => {
 
   return path.join(process.cwd(), 'uploads');
 };
-
-/**
- * Builds an absolute path inside the uploads directory.
- */
-export const buildUploadsPath = (...segments: string[]): string => {
-  return path.join(resolveUploadsRoot(), ...segments);
-};

--- a/draco-nodejs/frontend-next/instrumentation-node.ts
+++ b/draco-nodejs/frontend-next/instrumentation-node.ts
@@ -1,29 +1,18 @@
 export {};
 
-const globalWithGc = globalThis as typeof globalThis & { gc?: () => void };
-const runGc = typeof globalWithGc.gc === 'function' ? globalWithGc.gc.bind(globalWithGc) : null;
-
-const parsed = Number(process.env.GC_INTERVAL_MS);
+const parsed = Number(process.env.MEM_SAMPLE_INTERVAL_MS);
 const intervalMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60 * 1000;
 
 const toMb = (bytes: number) => Math.round(bytes / 1024 / 1024);
 
-const logMemory = (phase: string) => {
+const logMemory = () => {
   const usage = process.memoryUsage();
   console.log(
-    `[mem] phase=${phase} rss=${toMb(usage.rss)}MB heapUsed=${toMb(usage.heapUsed)}MB ` +
+    `[mem] phase=sample rss=${toMb(usage.rss)}MB heapUsed=${toMb(usage.heapUsed)}MB ` +
       `heapTotal=${toMb(usage.heapTotal)}MB external=${toMb(usage.external)}MB ` +
       `arrayBuffers=${toMb(usage.arrayBuffers)}MB`,
   );
 };
 
-const timer = setInterval(() => {
-  if (runGc) {
-    logMemory('pre-gc');
-    runGc();
-    logMemory('post-gc');
-  } else {
-    logMemory('sample');
-  }
-}, intervalMs);
+const timer = setInterval(logMemory, intervalMs);
 timer.unref();

--- a/draco-nodejs/frontend-next/instrumentation-node.ts
+++ b/draco-nodejs/frontend-next/instrumentation-node.ts
@@ -1,18 +1,20 @@
 export {};
 
 const parsed = Number(process.env.MEM_SAMPLE_INTERVAL_MS);
-const intervalMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60 * 1000;
+const intervalMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 
-const toMb = (bytes: number) => Math.round(bytes / 1024 / 1024);
+if (intervalMs > 0) {
+  const toMb = (bytes: number) => Math.round(bytes / 1024 / 1024);
 
-const logMemory = () => {
-  const usage = process.memoryUsage();
-  console.log(
-    `[mem] phase=sample rss=${toMb(usage.rss)}MB heapUsed=${toMb(usage.heapUsed)}MB ` +
-      `heapTotal=${toMb(usage.heapTotal)}MB external=${toMb(usage.external)}MB ` +
-      `arrayBuffers=${toMb(usage.arrayBuffers)}MB`,
-  );
-};
+  const logMemory = () => {
+    const usage = process.memoryUsage();
+    console.log(
+      `[mem] phase=sample rss=${toMb(usage.rss)}MB heapUsed=${toMb(usage.heapUsed)}MB ` +
+        `heapTotal=${toMb(usage.heapTotal)}MB external=${toMb(usage.external)}MB ` +
+        `arrayBuffers=${toMb(usage.arrayBuffers)}MB`,
+    );
+  };
 
-const timer = setInterval(logMemory, intervalMs);
-timer.unref();
+  const timer = setInterval(logMemory, intervalMs);
+  timer.unref();
+}


### PR DESCRIPTION
Introduce middleware to serve uploaded files from either local disk or an object store (S3/R2) and refactor storage/asset code to use the storage service API.

- Add createUploadsHandler middleware to route /uploads requests to local static files or to fetch objects from the configured storage provider.
- Extend BaseStorageService interface with saveObject/getObject/deleteObject and implement these in LocalStorageService and S3StorageService (R2 inherits behavior).
- Refactor PhotoGalleryAssetService and PhotoSubmissionAssetService to use the storage API and content-type helper instead of writing/reading files on disk; add copyObject helper and ensure cleanup on failures.
- Add a small mimeTypes util (contentTypeForKey) used when saving objects.
- Add unit tests for PhotoGalleryAssetService (in-memory storage) covering save, delete, and partial-failure cleanup.
- Update uploads path utilities and remove direct buildUploadsPath usage where no longer needed.
- Misc: broaden .dockerignore entries and simplify frontend memory instrumentation env var/logging.