### PR TITLE
Tweak gallery overlays and add submit progress

### DIFF
--- a/draco-nodejs/frontend-next/components/photo-gallery/PhotoGalleryHero.tsx
+++ b/draco-nodejs/frontend-next/components/photo-gallery/PhotoGalleryHero.tsx
@@ -182,7 +182,7 @@ const PhotoGalleryHero: React.FC<PhotoGalleryHeroProps> = ({
                     position: 'absolute',
                     inset: 0,
                     background:
-                      'linear-gradient(190deg, rgba(15,23,42,0.05) 0%, rgba(15,23,42,0.65) 60%, rgba(15,23,42,0.9) 100%)',
+                      'linear-gradient(180deg, rgba(15,23,42,0) 0%, rgba(15,23,42,0) 55%, rgba(15,23,42,0.55) 80%, rgba(15,23,42,0.85) 100%)',
                   }}
                 />
                 {isActive ? (

--- a/draco-nodejs/frontend-next/components/photo-gallery/PhotoGalleryLightbox.tsx
+++ b/draco-nodejs/frontend-next/components/photo-gallery/PhotoGalleryLightbox.tsx
@@ -87,16 +87,6 @@ const PhotoGalleryLightbox: React.FC<PhotoGalleryLightboxProps> = ({
           color: 'common.white',
         }}
       >
-        <Box
-          sx={{
-            position: 'absolute',
-            inset: 0,
-            background:
-              'linear-gradient(180deg, rgba(10,16,37,0.9) 0%, rgba(10,16,37,0.45) 40%, rgba(10,16,37,0.9) 100%)',
-            pointerEvents: 'none',
-          }}
-        />
-
         <IconButton
           onClick={onClose}
           aria-label="Close gallery"

--- a/draco-nodejs/frontend-next/components/photo-gallery/admin/PhotoGalleryAdminPhotoDialog.tsx
+++ b/draco-nodejs/frontend-next/components/photo-gallery/admin/PhotoGalleryAdminPhotoDialog.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   FormControl,
   InputLabel,
+  LinearProgress,
   ListSubheader,
   MenuItem,
   Select,
@@ -248,6 +250,7 @@ export const PhotoGalleryAdminPhotoDialog: React.FC<PhotoGalleryAdminPhotoDialog
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>{dialogTitle}</DialogTitle>
+      {submitting ? <LinearProgress /> : null}
       <DialogContent dividers>
         <Box
           component="form"
@@ -388,8 +391,19 @@ export const PhotoGalleryAdminPhotoDialog: React.FC<PhotoGalleryAdminPhotoDialog
         <Button onClick={onClose} disabled={submitting}>
           Cancel
         </Button>
-        <Button onClick={handleSubmit} variant="contained" disabled={submitting}>
-          {mode === 'create' ? 'Add Photo' : 'Save Changes'}
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={submitting}
+          startIcon={submitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+        >
+          {submitting
+            ? mode === 'create'
+              ? 'Uploading…'
+              : 'Saving…'
+            : mode === 'create'
+              ? 'Add Photo'
+              : 'Save Changes'}
         </Button>
       </DialogActions>
       <ImageCropDialog


### PR DESCRIPTION
Refines gallery overlay styling and improves admin dialog submit feedback.

- PhotoGalleryHero: adjust hero gradient to reduce top darkening and create a smoother fade.
- PhotoGalleryLightbox: remove the full-screen dark overlay so images are less obscured.
- PhotoGalleryAdminPhotoDialog: show a LinearProgress bar when submitting, add a CircularProgress icon on the submit button, and update button labels to 'Uploading…'/'Saving…' while submitting for clearer UX.