### PR TITLE
Highlight and auto-select user's teams

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -258,8 +258,9 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
           'Failed to load your teams',
         );
         setSeasonMyTeamIds(buildSeasonMembershipIdSet(memberships));
-      } catch {
+      } catch (err) {
         if (controller.signal.aborted) return;
+        console.error('Error loading your teams:', err);
         setSeasonMyTeamIds(new Set());
       } finally {
         if (!controller.signal.aborted) {
@@ -641,7 +642,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
               disabled={loading.teams}
             >
               {myTeamsList.map((team) => renderTeamMenuItem(team, true))}
-              {myTeamsList.length > 0 && otherTeamsList.length > 0 && <Divider />}
+              {myTeamsList.length > 0 && otherTeamsList.length > 0 && <Divider component="li" />}
               {otherTeamsList.map((team) => renderTeamMenuItem(team, false))}
             </Select>
           </FormControl>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -16,7 +16,9 @@ import {
   Tab,
   Paper,
   Alert,
+  Divider,
 } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
 import StatisticsTable from '../../../../components/statistics/StatisticsTable';
 import GameListCard, { type SortOrder } from '@/components/team-stats-entry/GameListCard';
 import BattingStatsViewTable from '@/components/team-stats-entry/BattingStatsViewTable';
@@ -24,9 +26,12 @@ import PitchingStatsViewTable from '@/components/team-stats-entry/PitchingStatsV
 import { TeamStatsEntryService } from '@/services/teamStatsEntryService';
 import { Team } from '@/types/schedule';
 import { useApiClient } from '@/hooks/useApiClient';
+import { useUserTeams } from '@/hooks/useUserTeams';
+import { useAuth } from '@/context/AuthContext';
 import { unwrapApiResult } from '@/utils/apiResult';
 import {
   listSeasonTeams as apiListSeasonTeams,
+  listMyTeamSeasons as apiListMyTeamSeasons,
   listTeamSeasonBattingStats as apiListTeamSeasonBattingStats,
   listTeamSeasonPitchingStats as apiListTeamSeasonPitchingStats,
   listAllTimeTeams as apiListAllTimeTeams,
@@ -44,6 +49,7 @@ import type {
   GamePitchingStatsType,
   PlayerBattingStatsType,
   PlayerPitchingStatsType,
+  RosterSeasonMembershipListType,
   TeamCompletedGameType,
 } from '@draco/shared-schemas';
 
@@ -102,8 +108,21 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
   } | null>(null);
   const [gameStatsError, setGameStatsError] = useState<string | null>(null);
   const apiClient = useApiClient();
+  const { token } = useAuth();
+  const { teams: userTeams, initialized: userTeamsInitialized } = useUserTeams(accountId);
+  const [seasonMyTeamIds, setSeasonMyTeamIds] = useState<Set<string>>(new Set());
+  const [seasonMyTeamsInitialized, setSeasonMyTeamsInitialized] = useState(false);
 
   const isAllTime = seasonId === '0';
+
+  const myOverallTeamIds = new Set(
+    userTeams.map((team) => team.team?.id).filter((id): id is string => Boolean(id)),
+  );
+
+  const isMyTeam = (team: Team): boolean =>
+    isAllTime
+      ? Boolean(team.overallTeamId && myOverallTeamIds.has(team.overallTeamId))
+      : Boolean(team.teamId && seasonMyTeamIds.has(team.teamId));
 
   useEffect(() => {
     setSelectedTeamId('');
@@ -151,6 +170,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
               return {
                 id: team.teamId,
                 teamId: team.teamId,
+                overallTeamId: team.teamId,
                 name: displayNames,
                 teamName: displayNames,
                 logoUrl: team.logoUrl ?? undefined,
@@ -179,6 +199,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
             return {
               id: teamSeason.id,
               teamId: teamSeason.id,
+              overallTeamId: teamSeason.team?.id,
               name: displayName,
               teamName: displayName,
               logoUrl: teamSeason.team?.logoUrl ?? undefined,
@@ -189,10 +210,6 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
         }
 
         setTeams(teamsData);
-
-        if (teamsData.length > 0 && teamsData[0].teamId) {
-          setSelectedTeamId(teamsData[0].teamId);
-        }
       } catch (err) {
         if (controller.signal.aborted) return;
         console.error('Error loading teams:', err);
@@ -209,6 +226,79 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
       controller.abort();
     };
   }, [accountId, seasonId, isAllTime, apiClient]);
+
+  useEffect(() => {
+    setSeasonMyTeamIds(new Set());
+    setSeasonMyTeamsInitialized(false);
+
+    if (isAllTime || !seasonId || !token) {
+      setSeasonMyTeamsInitialized(true);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const loadMyTeams = async () => {
+      try {
+        const result = await apiListMyTeamSeasons({
+          client: apiClient,
+          path: { accountId, seasonId },
+          signal: controller.signal,
+          throwOnError: false,
+        });
+
+        if (controller.signal.aborted) return;
+
+        const memberships = unwrapApiResult<RosterSeasonMembershipListType>(
+          result,
+          'Failed to load your teams',
+        );
+        setSeasonMyTeamIds(new Set(memberships.map((membership) => membership.teamSeasonId)));
+      } catch {
+        if (controller.signal.aborted) return;
+        setSeasonMyTeamIds(new Set());
+      } finally {
+        if (!controller.signal.aborted) {
+          setSeasonMyTeamsInitialized(true);
+        }
+      }
+    };
+
+    void loadMyTeams();
+
+    return () => {
+      controller.abort();
+    };
+  }, [accountId, seasonId, isAllTime, token, apiClient]);
+
+  useEffect(() => {
+    if (selectedTeamId || teams.length === 0) return;
+
+    const ready = isAllTime ? userTeamsInitialized : seasonMyTeamsInitialized;
+    if (!ready) return;
+
+    const overallIds = new Set(
+      userTeams.map((team) => team.team?.id).filter((id): id is string => Boolean(id)),
+    );
+    const myTeam = teams.find((team) =>
+      isAllTime
+        ? Boolean(team.overallTeamId && overallIds.has(team.overallTeamId))
+        : Boolean(team.teamId && seasonMyTeamIds.has(team.teamId)),
+    );
+    const target = myTeam ?? teams[0];
+
+    if (target?.teamId) {
+      setSelectedTeamId(target.teamId);
+    }
+  }, [
+    teams,
+    selectedTeamId,
+    isAllTime,
+    userTeamsInitialized,
+    seasonMyTeamsInitialized,
+    userTeams,
+    seasonMyTeamIds,
+  ]);
 
   useEffect(() => {
     if (!selectedTeamId || !seasonId) return;
@@ -505,6 +595,23 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
 
   const showGameList = !isAllTime;
 
+  const myTeamsList = Array.isArray(teams) ? teams.filter(isMyTeam) : [];
+  const otherTeamsList = Array.isArray(teams) ? teams.filter((team) => !isMyTeam(team)) : [];
+
+  const renderTeamMenuItem = (team: Team) => (
+    <MenuItem key={team.teamId} value={team.teamId}>
+      {isAllTime
+        ? `${team.leagueName} [${team.teamName}] [${team.divisionName}]`
+        : `${team.teamName} (${team.leagueName} - ${team.divisionName})`}
+      {isMyTeam(team) && (
+        <StarIcon
+          fontSize="small"
+          sx={{ ml: 0.5, color: 'warning.main', verticalAlign: 'text-bottom' }}
+        />
+      )}
+    </MenuItem>
+  );
+
   if (error) {
     return (
       <Box p={3}>
@@ -531,15 +638,9 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
               onChange={handleTeamChange}
               disabled={loading.teams}
             >
-              {Array.isArray(teams)
-                ? teams.map((team) => (
-                    <MenuItem key={team.teamId} value={team.teamId}>
-                      {isAllTime
-                        ? `${team.leagueName} [${team.teamName}] [${team.divisionName}]`
-                        : `${team.teamName} (${team.leagueName} - ${team.divisionName})`}
-                    </MenuItem>
-                  ))
-                : null}
+              {myTeamsList.map(renderTeamMenuItem)}
+              {myTeamsList.length > 0 && otherTeamsList.length > 0 && <Divider />}
+              {otherTeamsList.map(renderTeamMenuItem)}
             </Select>
           </FormControl>
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/TeamStatistics.tsx
@@ -28,6 +28,13 @@ import { Team } from '@/types/schedule';
 import { useApiClient } from '@/hooks/useApiClient';
 import { useUserTeams } from '@/hooks/useUserTeams';
 import { useAuth } from '@/context/AuthContext';
+import {
+  buildOverallTeamIdSet,
+  buildSeasonMembershipIdSet,
+  partitionMyTeams,
+  pickDefaultTeam,
+  type MyTeamMatch,
+} from './teamSelection';
 import { unwrapApiResult } from '@/utils/apiResult';
 import {
   listSeasonTeams as apiListSeasonTeams,
@@ -115,14 +122,11 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
 
   const isAllTime = seasonId === '0';
 
-  const myOverallTeamIds = new Set(
-    userTeams.map((team) => team.team?.id).filter((id): id is string => Boolean(id)),
-  );
-
-  const isMyTeam = (team: Team): boolean =>
-    isAllTime
-      ? Boolean(team.overallTeamId && myOverallTeamIds.has(team.overallTeamId))
-      : Boolean(team.teamId && seasonMyTeamIds.has(team.teamId));
+  const myTeamMatch: MyTeamMatch = {
+    isAllTime,
+    overallTeamIds: buildOverallTeamIdSet(userTeams),
+    seasonTeamIds: seasonMyTeamIds,
+  };
 
   useEffect(() => {
     setSelectedTeamId('');
@@ -253,7 +257,7 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
           result,
           'Failed to load your teams',
         );
-        setSeasonMyTeamIds(new Set(memberships.map((membership) => membership.teamSeasonId)));
+        setSeasonMyTeamIds(buildSeasonMembershipIdSet(memberships));
       } catch {
         if (controller.signal.aborted) return;
         setSeasonMyTeamIds(new Set());
@@ -277,15 +281,11 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
     const ready = isAllTime ? userTeamsInitialized : seasonMyTeamsInitialized;
     if (!ready) return;
 
-    const overallIds = new Set(
-      userTeams.map((team) => team.team?.id).filter((id): id is string => Boolean(id)),
-    );
-    const myTeam = teams.find((team) =>
-      isAllTime
-        ? Boolean(team.overallTeamId && overallIds.has(team.overallTeamId))
-        : Boolean(team.teamId && seasonMyTeamIds.has(team.teamId)),
-    );
-    const target = myTeam ?? teams[0];
+    const target = pickDefaultTeam(teams, {
+      isAllTime,
+      overallTeamIds: buildOverallTeamIdSet(userTeams),
+      seasonTeamIds: seasonMyTeamIds,
+    });
 
     if (target?.teamId) {
       setSelectedTeamId(target.teamId);
@@ -595,15 +595,17 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
 
   const showGameList = !isAllTime;
 
-  const myTeamsList = Array.isArray(teams) ? teams.filter(isMyTeam) : [];
-  const otherTeamsList = Array.isArray(teams) ? teams.filter((team) => !isMyTeam(team)) : [];
+  const { myTeams: myTeamsList, otherTeams: otherTeamsList } = partitionMyTeams(
+    Array.isArray(teams) ? teams : [],
+    myTeamMatch,
+  );
 
-  const renderTeamMenuItem = (team: Team) => (
+  const renderTeamMenuItem = (team: Team, mine: boolean) => (
     <MenuItem key={team.teamId} value={team.teamId}>
       {isAllTime
         ? `${team.leagueName} [${team.teamName}] [${team.divisionName}]`
         : `${team.teamName} (${team.leagueName} - ${team.divisionName})`}
-      {isMyTeam(team) && (
+      {mine && (
         <StarIcon
           fontSize="small"
           sx={{ ml: 0.5, color: 'warning.main', verticalAlign: 'text-bottom' }}
@@ -638,9 +640,9 @@ export default function TeamStatistics({ accountId, seasonId }: TeamStatisticsPr
               onChange={handleTeamChange}
               disabled={loading.teams}
             >
-              {myTeamsList.map(renderTeamMenuItem)}
+              {myTeamsList.map((team) => renderTeamMenuItem(team, true))}
               {myTeamsList.length > 0 && otherTeamsList.length > 0 && <Divider />}
-              {otherTeamsList.map(renderTeamMenuItem)}
+              {otherTeamsList.map((team) => renderTeamMenuItem(team, false))}
             </Select>
           </FormControl>
 

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/__tests__/teamSelection.test.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/__tests__/teamSelection.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import type { RosterSeasonMembershipListType, TeamSeasonType } from '@draco/shared-schemas';
+import type { Team } from '@/types/schedule';
+import {
+  buildOverallTeamIdSet,
+  buildSeasonMembershipIdSet,
+  isMyTeam,
+  partitionMyTeams,
+  pickDefaultTeam,
+  type MyTeamMatch,
+} from '../teamSelection';
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 'ts-1',
+  teamId: 'ts-1',
+  overallTeamId: 'team-1',
+  name: 'Tigers',
+  teamName: 'Tigers',
+  leagueName: 'MSBL',
+  divisionName: 'A',
+  ...overrides,
+});
+
+const makeUserTeam = (teamSeasonId: string, overallId: string): TeamSeasonType => ({
+  id: teamSeasonId,
+  team: { id: overallId },
+});
+
+const makeMembership = (teamSeasonId: string): RosterSeasonMembershipListType[number] => ({
+  teamSeasonId,
+  teamName: 'Tigers',
+  leagueSeasonId: 'ls-1',
+  leagueName: 'MSBL',
+  divisionSeasonId: null,
+  divisionName: null,
+  jerseyNumber: null,
+});
+
+const seasonMatch = (seasonTeamIds: string[]): MyTeamMatch => ({
+  isAllTime: false,
+  overallTeamIds: new Set<string>(),
+  seasonTeamIds: new Set(seasonTeamIds),
+});
+
+const allTimeMatch = (overallTeamIds: string[]): MyTeamMatch => ({
+  isAllTime: true,
+  overallTeamIds: new Set(overallTeamIds),
+  seasonTeamIds: new Set<string>(),
+});
+
+describe('buildOverallTeamIdSet', () => {
+  it('extracts the season-agnostic team id from each membership', () => {
+    const set = buildOverallTeamIdSet([
+      makeUserTeam('ts-9', 'team-9'),
+      makeUserTeam('ts-3', 'team-3'),
+    ]);
+    expect(set).toEqual(new Set(['team-9', 'team-3']));
+  });
+
+  it('skips entries missing a team id', () => {
+    const set = buildOverallTeamIdSet([
+      makeUserTeam('ts-1', 'team-1'),
+      { id: 'ts-2', team: { id: '' } },
+    ]);
+    expect(set).toEqual(new Set(['team-1']));
+  });
+});
+
+describe('buildSeasonMembershipIdSet', () => {
+  it('keys on the season-bound teamSeasonId', () => {
+    const set = buildSeasonMembershipIdSet([makeMembership('ts-7'), makeMembership('ts-8')]);
+    expect(set).toEqual(new Set(['ts-7', 'ts-8']));
+  });
+});
+
+describe('isMyTeam', () => {
+  it('season mode matches on teamSeasonId, ignoring overallTeamId', () => {
+    const team = makeTeam({ teamId: 'ts-5', overallTeamId: 'team-5' });
+    expect(isMyTeam(team, seasonMatch(['ts-5']))).toBe(true);
+    // overall id present in nothing — proves season mode does not consult overallTeamIds
+    expect(isMyTeam(team, seasonMatch(['ts-other']))).toBe(false);
+    expect(isMyTeam(team, allTimeMatch(['team-5']))).toBe(true);
+  });
+
+  it('all-time mode matches on overallTeamId, ignoring teamSeasonId', () => {
+    const team = makeTeam({ teamId: 'ts-5', overallTeamId: 'team-5' });
+    // teamSeasonId is in the season set, but all-time mode must ignore it
+    expect(
+      isMyTeam(team, {
+        isAllTime: true,
+        overallTeamIds: new Set<string>(),
+        seasonTeamIds: new Set(['ts-5']),
+      }),
+    ).toBe(false);
+    expect(isMyTeam(team, allTimeMatch(['team-5']))).toBe(true);
+  });
+
+  it('returns false when the team has no matchable id', () => {
+    expect(isMyTeam(makeTeam({ teamId: undefined }), seasonMatch(['ts-1']))).toBe(false);
+    expect(isMyTeam(makeTeam({ overallTeamId: undefined }), allTimeMatch(['team-1']))).toBe(false);
+  });
+});
+
+describe('pickDefaultTeam', () => {
+  const teams = [
+    makeTeam({ teamId: 'ts-1', overallTeamId: 'team-1', teamName: 'Aces' }),
+    makeTeam({ teamId: 'ts-2', overallTeamId: 'team-2', teamName: 'Bears' }),
+    makeTeam({ teamId: 'ts-3', overallTeamId: 'team-3', teamName: 'Cubs' }),
+  ];
+
+  it('prefers the user team in the season over the first team', () => {
+    const target = pickDefaultTeam(teams, seasonMatch(['ts-2']));
+    expect(target?.teamId).toBe('ts-2');
+  });
+
+  it('falls back to the first team when the user has none that season', () => {
+    const target = pickDefaultTeam(teams, seasonMatch(['ts-absent']));
+    expect(target?.teamId).toBe('ts-1');
+  });
+
+  it('picks the first listed team when the user belongs to several', () => {
+    const target = pickDefaultTeam(teams, seasonMatch(['ts-2', 'ts-3']));
+    expect(target?.teamId).toBe('ts-2');
+  });
+
+  it('matches all-time teams by overall id', () => {
+    const target = pickDefaultTeam(teams, allTimeMatch(['team-3']));
+    expect(target?.teamId).toBe('ts-3');
+  });
+
+  it('returns undefined for an empty team list', () => {
+    expect(pickDefaultTeam([], seasonMatch(['ts-1']))).toBeUndefined();
+  });
+
+  it('does not flag the fallback first team as the user team when none match', () => {
+    // Regression guard: historical season where the user was on no team — the
+    // first team must be selected but must NOT be treated as "mine".
+    const match = seasonMatch(['ts-absent']);
+    const target = pickDefaultTeam(teams, match);
+    expect(target?.teamId).toBe('ts-1');
+    expect(isMyTeam(target as Team, match)).toBe(false);
+  });
+});
+
+describe('partitionMyTeams', () => {
+  const teams = [
+    makeTeam({ teamId: 'ts-1', overallTeamId: 'team-1', teamName: 'Aces' }),
+    makeTeam({ teamId: 'ts-2', overallTeamId: 'team-2', teamName: 'Bears' }),
+    makeTeam({ teamId: 'ts-3', overallTeamId: 'team-3', teamName: 'Cubs' }),
+  ];
+
+  it('splits user teams from the rest, preserving input order within each group', () => {
+    const { myTeams, otherTeams } = partitionMyTeams(teams, seasonMatch(['ts-3', 'ts-1']));
+    expect(myTeams.map((t) => t.teamId)).toEqual(['ts-1', 'ts-3']);
+    expect(otherTeams.map((t) => t.teamId)).toEqual(['ts-2']);
+  });
+
+  it('returns all teams as others when the user has none', () => {
+    const { myTeams, otherTeams } = partitionMyTeams(teams, seasonMatch([]));
+    expect(myTeams).toEqual([]);
+    expect(otherTeams).toHaveLength(3);
+  });
+});

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/__tests__/teamSelection.test.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/__tests__/teamSelection.test.ts
@@ -77,14 +77,12 @@ describe('isMyTeam', () => {
   it('season mode matches on teamSeasonId, ignoring overallTeamId', () => {
     const team = makeTeam({ teamId: 'ts-5', overallTeamId: 'team-5' });
     expect(isMyTeam(team, seasonMatch(['ts-5']))).toBe(true);
-    // overall id present in nothing — proves season mode does not consult overallTeamIds
     expect(isMyTeam(team, seasonMatch(['ts-other']))).toBe(false);
     expect(isMyTeam(team, allTimeMatch(['team-5']))).toBe(true);
   });
 
   it('all-time mode matches on overallTeamId, ignoring teamSeasonId', () => {
     const team = makeTeam({ teamId: 'ts-5', overallTeamId: 'team-5' });
-    // teamSeasonId is in the season set, but all-time mode must ignore it
     expect(
       isMyTeam(team, {
         isAllTime: true,
@@ -133,8 +131,6 @@ describe('pickDefaultTeam', () => {
   });
 
   it('does not flag the fallback first team as the user team when none match', () => {
-    // Regression guard: historical season where the user was on no team — the
-    // first team must be selected but must NOT be treated as "mine".
     const match = seasonMatch(['ts-absent']);
     const target = pickDefaultTeam(teams, match);
     expect(target?.teamId).toBe('ts-1');

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/teamSelection.ts
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/teamSelection.ts
@@ -1,0 +1,41 @@
+import type { RosterSeasonMembershipListType, TeamSeasonType } from '@draco/shared-schemas';
+import type { Team } from '@/types/schedule';
+
+export interface MyTeamMatch {
+  isAllTime: boolean;
+  overallTeamIds: Set<string>;
+  seasonTeamIds: Set<string>;
+}
+
+export const buildOverallTeamIdSet = (userTeams: TeamSeasonType[]): Set<string> =>
+  new Set(userTeams.map((team) => team.team?.id).filter((id): id is string => Boolean(id)));
+
+export const buildSeasonMembershipIdSet = (
+  memberships: RosterSeasonMembershipListType,
+): Set<string> => new Set(memberships.map((membership) => membership.teamSeasonId));
+
+export const isMyTeam = (team: Team, match: MyTeamMatch): boolean =>
+  match.isAllTime
+    ? Boolean(team.overallTeamId && match.overallTeamIds.has(team.overallTeamId))
+    : Boolean(team.teamId && match.seasonTeamIds.has(team.teamId));
+
+export const pickDefaultTeam = (teams: Team[], match: MyTeamMatch): Team | undefined => {
+  if (teams.length === 0) return undefined;
+  return teams.find((team) => isMyTeam(team, match)) ?? teams[0];
+};
+
+export const partitionMyTeams = (
+  teams: Team[],
+  match: MyTeamMatch,
+): { myTeams: Team[]; otherTeams: Team[] } => {
+  const myTeams: Team[] = [];
+  const otherTeams: Team[] = [];
+  for (const team of teams) {
+    if (isMyTeam(team, match)) {
+      myTeams.push(team);
+    } else {
+      otherTeams.push(team);
+    }
+  }
+  return { myTeams, otherTeams };
+};

--- a/draco-nodejs/frontend-next/types/schedule.ts
+++ b/draco-nodejs/frontend-next/types/schedule.ts
@@ -48,6 +48,7 @@ export interface Game {
 export interface Team {
   id: string;
   teamId?: string;
+  overallTeamId?: string;
   name: string;
   teamName?: string;
   logoUrl?: string;


### PR DESCRIPTION
Mark teams belonging to the current user in TeamStatistics, show them at the top of the team selector with a star icon, and separate other teams with a divider. Added logic to fetch the user's season memberships (listMyTeamSeasons) and overall user teams, track season-specific and overall team IDs, and auto-select a user's team when none is selected. Also added a StarIcon and Divider to the UI, and introduced overallTeamId to the Team type to support all-time team matching.