### PR TITLE
Adjust widget spacing, ordering, and rendering

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -789,6 +789,7 @@ const BaseballAccountHome: React.FC = () => {
               flexDirection: 'column',
               gap: 4,
               minWidth: 0,
+              '& > *:empty': { display: 'none' },
             }}
           >
             {shouldShowJoinLeagueNearSponsors ? null : (
@@ -796,7 +797,7 @@ const BaseballAccountHome: React.FC = () => {
             )}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 3 }, minWidth: 0, '&:empty': { display: 'none' } }}>
+              <Box sx={{ order: { xs: 3 }, minWidth: 0 }}>
                 <GameRecapsWidget accountId={accountIdStr} seasonId={currentSeason.id} />
               </Box>
             ) : null}
@@ -839,7 +840,7 @@ const BaseballAccountHome: React.FC = () => {
                 onAlbumChange={handleAlbumTabChange}
                 totalCountOverride={seasonFilteredPhotos.length}
                 teamAlbumHierarchy={teamAlbumHierarchy}
-                sx={{ height: '100%' }}
+                sx={{ height: '100%', mb: 0 }}
               />
             </Box>
 
@@ -869,7 +870,7 @@ const BaseballAccountHome: React.FC = () => {
             {shouldShowPendingPanel ? (
               <Box sx={{ order: { xs: 11 }, minWidth: 0 }}>
                 <PendingPhotoSubmissionsPanel
-                  containerSx={{ p: 3, mb: 2 }}
+                  containerSx={{ p: 3, mb: 0 }}
                   contextLabel={accountDisplayName}
                   submissions={pendingSubmissions}
                   loading={pendingLoading}
@@ -920,6 +921,7 @@ const BaseballAccountHome: React.FC = () => {
               flexDirection: 'column',
               gap: 3,
               minWidth: 0,
+              '& > *:empty': { display: 'none' },
             }}
           >
             {user && userTeams.length > 0 ? (
@@ -930,7 +932,7 @@ const BaseballAccountHome: React.FC = () => {
                   timeZone={accountTimeZone}
                   onViewTeam={handleViewTeam}
                   title="Your Teams"
-                  sx={{ width: '100%' }}
+                  sx={{ width: '100%', mb: 0 }}
                 />
               </Box>
             ) : null}
@@ -942,7 +944,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 2 }, minWidth: 0, '&:empty': { display: 'none' } }}>
+              <Box sx={{ order: { xs: 2 }, minWidth: 0 }}>
                 <TodayScoreboard
                   accountId={accountIdStr}
                   layout="vertical"
@@ -957,7 +959,7 @@ const BaseballAccountHome: React.FC = () => {
             ) : null}
 
             {currentSeason && !scheduleHidden ? (
-              <Box sx={{ order: { xs: 4 }, minWidth: 0, '&:empty': { display: 'none' } }}>
+              <Box sx={{ order: { xs: 4 }, minWidth: 0 }}>
                 <YesterdayScoreboard
                   accountId={accountIdStr}
                   layout="vertical"

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -658,6 +658,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
               flexDirection: 'column',
               gap: 4,
               minWidth: 0,
+              '& > *:empty': { display: 'none' },
             }}
           >
             {(canManageTeamSponsors || canManageTeamPhotos || isAccountMember) && (
@@ -702,7 +703,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
               </Box>
             )}
 
-            <Box sx={{ order: { xs: 5 }, minWidth: 0 }}>
+            <Box sx={{ order: { xs: 18 }, minWidth: 0 }}>
               <TeamManagersWidget
                 accountId={accountId}
                 seasonId={seasonId}
@@ -840,7 +841,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
               </Box>
             ) : null}
 
-            <Box sx={{ order: { xs: 6 }, minWidth: 0 }}>
+            <Box sx={{ order: { xs: 19 }, minWidth: 0 }}>
               <TeamRosterWidget
                 accountId={accountId}
                 seasonId={seasonId}
@@ -849,16 +850,6 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                 canEditPhotos={canEditPlayerPhotos}
               />
             </Box>
-
-            {shouldShowTeamSponsors ? (
-              <Box sx={{ order: { xs: 15 }, minWidth: 0 }}>
-                <SponsorCard
-                  sponsors={teamSponsors}
-                  title="Team Sponsors"
-                  emptyMessage={teamSponsorError ?? undefined}
-                />
-              </Box>
-            ) : null}
 
             {teamData?.teamId && teamData?.youtubeUserId ? (
               <Box sx={{ order: { xs: 16 }, minWidth: 0 }}>
@@ -882,6 +873,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
               flexDirection: 'column',
               gap: 3,
               minWidth: 0,
+              '& > *:empty': { display: 'none' },
             }}
           >
             {!loading ? (
@@ -952,6 +944,16 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                 />
               </AccountOptional>
             </Box>
+
+            {shouldShowTeamSponsors ? (
+              <Box sx={{ order: { xs: 20 }, minWidth: 0 }}>
+                <SponsorCard
+                  sponsors={teamSponsors}
+                  title="Team Sponsors"
+                  emptyMessage={teamSponsorError ?? undefined}
+                />
+              </Box>
+            ) : null}
           </Box>
         </Box>
       </Container>

--- a/draco-nodejs/frontend-next/components/hall-of-fame/HofNominationWidget.tsx
+++ b/draco-nodejs/frontend-next/components/hall-of-fame/HofNominationWidget.tsx
@@ -91,7 +91,6 @@ const HofNominationWidget: React.FC<HofNominationWidgetProps> = ({ accountId }) 
         }
         accent="secondary"
         sx={{
-          mt: 3,
           width: { xs: '100%', md: 'fit-content' },
           maxWidth: 520,
         }}

--- a/draco-nodejs/frontend-next/components/join-league/JoinLeagueDashboard.tsx
+++ b/draco-nodejs/frontend-next/components/join-league/JoinLeagueDashboard.tsx
@@ -38,7 +38,6 @@ const JoinLeagueDashboard: React.FC<JoinLeagueDashboardProps> = ({
       }
       accent="primary"
       sx={{
-        mb: 3,
         display: 'flex',
         flexDirection: 'column',
         width: '100%',

--- a/draco-nodejs/frontend-next/components/sponsors/TeamAdminPanel.tsx
+++ b/draco-nodejs/frontend-next/components/sponsors/TeamAdminPanel.tsx
@@ -297,9 +297,6 @@ const TeamAdminPanel: React.FC<TeamAdminPanelProps> = ({
       title="Team Management"
       subtitle="Manage the resources for your team."
       accent="info"
-      sx={{
-        mb: 4,
-      }}
     >
       {isHistoricalSeason ? (
         <Typography variant="body2" color="text.secondary">

--- a/draco-nodejs/frontend-next/components/team/TeamForumWidget.tsx
+++ b/draco-nodejs/frontend-next/components/team/TeamForumWidget.tsx
@@ -170,6 +170,10 @@ const TeamForumWidget: React.FC<TeamForumWidgetProps> = ({
     window.open(permalink, '_blank', 'noopener,noreferrer');
   };
 
+  if (!loading && !membershipLoading && !error && !channel) {
+    return null;
+  }
+
   return (
     <WidgetShell
       title={
@@ -180,11 +184,7 @@ const TeamForumWidget: React.FC<TeamForumWidgetProps> = ({
           </Typography>
         </Stack>
       }
-      subtitle={
-        channel
-          ? `Latest updates from the ${teamName ?? 'team'} Discord forum`
-          : 'Enable Discord team forums in account settings to surface conversations here.'
-      }
+      subtitle={channel ? `Latest updates from the ${teamName ?? 'team'} Discord forum` : undefined}
       accent="info"
     >
       {loading || membershipLoading ? (
@@ -193,12 +193,7 @@ const TeamForumWidget: React.FC<TeamForumWidgetProps> = ({
         </Box>
       ) : error ? (
         <Alert severity="error">{error}</Alert>
-      ) : !channel ? (
-        <Alert severity="info">
-          No Discord forum is active for this team yet. Ask your administrator to enable Discord
-          team forums in Account Settings.
-        </Alert>
-      ) : (
+      ) : !channel ? null : (
         <Stack spacing={2}>
           <Stack
             direction={{ xs: 'column', sm: 'row' }}

--- a/draco-nodejs/frontend-next/components/team/TeamForumWidget.tsx
+++ b/draco-nodejs/frontend-next/components/team/TeamForumWidget.tsx
@@ -170,86 +170,98 @@ const TeamForumWidget: React.FC<TeamForumWidgetProps> = ({
     window.open(permalink, '_blank', 'noopener,noreferrer');
   };
 
-  if (!loading && !membershipLoading && !error && !channel) {
+  const titleNode = (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <ForumIcon fontSize="small" color="primary" />{' '}
+      <Typography component="span" variant="h6">
+        Team Forum
+      </Typography>
+    </Stack>
+  );
+
+  if (loading || membershipLoading) {
+    return (
+      <WidgetShell title={titleNode} accent="info">
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      </WidgetShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <WidgetShell title={titleNode} accent="info">
+        <Alert severity="error">{error}</Alert>
+      </WidgetShell>
+    );
+  }
+
+  if (!channel) {
     return null;
   }
 
   return (
     <WidgetShell
-      title={
-        <Stack direction="row" spacing={1} alignItems="center">
-          <ForumIcon fontSize="small" color="primary" />{' '}
-          <Typography component="span" variant="h6">
-            Team Forum
-          </Typography>
-        </Stack>
-      }
-      subtitle={channel ? `Latest updates from the ${teamName ?? 'team'} Discord forum` : undefined}
+      title={titleNode}
+      subtitle={`Latest updates from the ${teamName ?? 'team'} Discord forum`}
       accent="info"
     >
-      {loading || membershipLoading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <CircularProgress size={24} />
-        </Box>
-      ) : error ? (
-        <Alert severity="error">{error}</Alert>
-      ) : !channel ? null : (
-        <Stack spacing={2}>
-          <Stack
-            direction={{ xs: 'column', sm: 'row' }}
-            spacing={1}
-            alignItems={{ xs: 'stretch', sm: 'center' }}
-            justifyContent="space-between"
-          >
-            <Box>
-              <Typography variant="subtitle1">{channel.label ?? channel.name}</Typography>
-            </Box>
-          </Stack>
+      <Stack spacing={2}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          justifyContent="space-between"
+        >
+          <Box>
+            <Typography variant="subtitle1">{channel.label ?? channel.name}</Typography>
+          </Box>
+        </Stack>
 
-          {messages.length === 0 ? (
-            <Alert severity="info">No recent messages yet.</Alert>
-          ) : (
-            <Stack spacing={2}>
-              {messages.map((message) => (
-                <Box
-                  key={message.id}
-                  sx={{ borderBottom: '1px solid', borderColor: 'divider', pb: 2 }}
-                >
-                  <MessagePreview message={message} onOpen={handleOpenMessage} />
-                </Box>
-              ))}
-            </Stack>
-          )}
-          <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-start">
-            {channel.url ? (
-              <Button
-                size="small"
-                variant="text"
-                startIcon={<OpenInNewIcon fontSize="inherit" />}
-                onClick={handleOpenDiscord}
-                disabled={!isTeamMember}
+        {messages.length === 0 ? (
+          <Alert severity="info">No recent messages yet.</Alert>
+        ) : (
+          <Stack spacing={2}>
+            {messages.map((message) => (
+              <Box
+                key={message.id}
+                sx={{ borderBottom: '1px solid', borderColor: 'divider', pb: 2 }}
               >
-                Open Discord
-              </Button>
-            ) : null}
+                <MessagePreview message={message} onOpen={handleOpenMessage} />
+              </Box>
+            ))}
+          </Stack>
+        )}
+        <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-start">
+          {channel.url ? (
             <Button
               size="small"
               variant="text"
-              component={NextLink}
-              href={`/account/${accountId}/social-hub/community`}
-              startIcon={<ForumIcon fontSize="inherit" />}
+              startIcon={<OpenInNewIcon fontSize="inherit" />}
+              onClick={handleOpenDiscord}
+              disabled={!isTeamMember}
             >
-              View all messages
+              Open Discord
             </Button>
-          </Stack>
-          {!isTeamMember ? (
-            <Alert severity="info">
-              You need team access to participate in Discord discussions. Contact your coach or
-              admin if you should be added.
-            </Alert>
           ) : null}
+          <Button
+            size="small"
+            variant="text"
+            component={NextLink}
+            href={`/account/${accountId}/social-hub/community`}
+            startIcon={<ForumIcon fontSize="inherit" />}
+          >
+            View all messages
+          </Button>
         </Stack>
-      )}
+        {!isTeamMember ? (
+          <Alert severity="info">
+            You need team access to participate in Discord discussions. Contact your coach or admin
+            if you should be added.
+          </Alert>
+        ) : null}
+      </Stack>
     </WidgetShell>
   );
 };


### PR DESCRIPTION
Tidy up dashboard and team page layouts: hide empty child elements via '& > *:empty', remove redundant per-box empty selectors, and reduce bottom margins on several widgets (BaseballAccountHome, HofNominationWidget, JoinLeagueDashboard, TeamAdminPanel). Reorder team page sections and move the SponsorCard to the end of the content column (TeamPage). Simplify TeamForumWidget rendering to return null when no channel (instead of showing an informational alert) and only show error or the forum content. These changes standardize spacing, prevent empty placeholders from taking space, and move sponsors lower in the visual order.