### PR TITLE
Unify widget spacing on team and account home pages

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/BaseballAccountHome.tsx
@@ -787,7 +787,7 @@ const BaseballAccountHome: React.FC = () => {
             sx={{
               display: { xs: 'contents', lg: 'flex' },
               flexDirection: 'column',
-              gap: 4,
+              gap: 3,
               minWidth: 0,
               '& > *:empty': { display: 'none' },
             }}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -92,7 +92,6 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
   } | null>(null);
   const [teamSponsors, setTeamSponsors] = React.useState<SponsorType[]>([]);
   const [teamSponsorError, setTeamSponsorError] = React.useState<string | null>(null);
-  const [informationWidgetVisible, setInformationWidgetVisible] = React.useState(true);
   const [playersWantedDialogOpen, setPlayersWantedDialogOpen] = React.useState(false);
   const [playersWantedInitialData, setPlayersWantedInitialData] = React.useState<
     UpsertPlayersWantedClassifiedType | undefined
@@ -656,7 +655,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
             sx={{
               display: { xs: 'contents', lg: 'flex' },
               flexDirection: 'column',
-              gap: 4,
+              gap: 3,
               minWidth: 0,
               '& > *:empty': { display: 'none' },
             }}
@@ -751,18 +750,15 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
 
             {showInformationWidget ? (
               <Box sx={{ order: { xs: 10 }, minWidth: 0 }}>
-                <Box sx={{ display: informationWidgetVisible ? 'contents' : 'none' }}>
-                  <InformationWidget
-                    accountId={accountId}
-                    teamId={resolvedTeamId ?? undefined}
-                    teamSeasonId={teamSeasonId}
-                    showAccountMessages={false}
-                    showTeamMessages={Boolean(resolvedTeamId)}
-                    hideWhenEmpty
-                    onVisibilityChange={setInformationWidgetVisible}
-                    title="Information Center"
-                  />
-                </Box>
+                <InformationWidget
+                  accountId={accountId}
+                  teamId={resolvedTeamId ?? undefined}
+                  teamSeasonId={teamSeasonId}
+                  showAccountMessages={false}
+                  showTeamMessages={Boolean(resolvedTeamId)}
+                  hideWhenEmpty
+                  title="Information Center"
+                />
               </Box>
             ) : null}
 
@@ -796,7 +792,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                   emptyMessage="No team photos have been published yet."
                   accent="team"
                   totalCountOverride={teamGalleryPhotos.length}
-                  sx={{ height: '100%' }}
+                  sx={{ height: '100%', mb: 0 }}
                 />
               </Box>
             ) : null}

--- a/draco-nodejs/frontend-next/components/GameListDisplay.tsx
+++ b/draco-nodejs/frontend-next/components/GameListDisplay.tsx
@@ -113,7 +113,6 @@ const GameListDisplay: React.FC<GameListDisplayProps> = ({
       accent={accent}
       disablePadding
       sx={{
-        mb: 2,
         minWidth: 0,
       }}
     >


### PR DESCRIPTION
- Collapse empty InformationWidget wrapper via :empty instead of a nested visibility box, removing a phantom flex gap
- Drop GameListDisplay's legacy root mb so spacing is owned by the column gap (fixes oversized gap below scoreboards/completed games)
- Use gap: 3 for both left and right columns on TeamPage and BaseballAccountHome for consistent vertical rhythm