### PR TITLE
Add async scheduler run API and worker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts",
         "hashed_secret": "64f5667353b1de8440882280b88e4429fa061e50",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 107
       }
     ],
     "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts": [
@@ -157,42 +157,42 @@
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "64f5667353b1de8440882280b88e4429fa061e50",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 110
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "376c762c1b28f927595010e98e4ee82d6bc63de3",
         "is_verified": false,
-        "line_number": 1029
+        "line_number": 1031
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "fec13f7a36bfaae0ba315a85c7f01c2e65934c25",
         "is_verified": false,
-        "line_number": 1137
+        "line_number": 1139
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1196
+        "line_number": 1198
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "f2e1e6be297417e5f12d1d5c127632646dd186a6",
         "is_verified": false,
-        "line_number": 1270
+        "line_number": 1272
       },
       {
         "type": "Secret Keyword",
         "filename": "draco-nodejs/backend/src/__tests__/oauth.integration.test.ts",
         "hashed_secret": "6a9640567ceb83c0ef56e09b9dede0d9bc22a2db",
         "is_verified": false,
-        "line_number": 1296
+        "line_number": 1298
       }
     ],
     "draco-nodejs/backend/src/__tests__/services/oauthService.test.ts": [
@@ -433,5 +433,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-21T04:36:37Z"
+  "generated_at": "2026-06-22T15:37:36Z"
 }

--- a/docs/scheduler-async-job-proposal.md
+++ b/docs/scheduler-async-job-proposal.md
@@ -1,0 +1,152 @@
+# Proposal: Asynchronous Schedule Generation (background job)
+
+**Status:** ✅ Implemented (approved). See "Implementation notes" below for the as-built deviations.
+**Scope flagged as approval-gated:** introduces a new persistence table (Prisma migration) and
+new **shared-schema** types (restricted per `draco-nodejs/shared/AGENTS.md`) — both approved.
+
+## Implementation notes (as built)
+
+- **Additive endpoints, not a replacement.** Rather than turning `POST .../scheduler/solve` into an
+  enqueue, the async flow is exposed as new endpoints `POST .../scheduler/runs` (202 + `runId`) and
+  `GET .../scheduler/runs/:runId`. The synchronous `/solve` endpoint is left intact for backward
+  compatibility and can be removed in a follow-up once the async path is fully validated.
+- **Status enum naming.** A `SchedulerRunStatus` enum already existed for the *solve outcome*
+  (`completed|partial|infeasible|failed`). The job lifecycle uses a distinct
+  `SchedulerRunLifecycleStatus` (`queued|running|completed|failed`) to avoid the collision.
+- **Engine.** `solve()` was refactored into shared `prepareSolve`/`placeGameAt`/`finalizeSolve`
+  helpers; a new `solveAsync()` reuses them, yields every N games, and reports `onProgress`.
+- **Worker.** In-process (`setImmediate`), idempotent by deterministic `runId`, persists progress
+  (throttled), result, or error to the `schedulerrun` table. Multi-instance caveat below still
+  applies.
+- **Frontend.** `SeasonSchedulerWidget` enqueues then polls `GET .../runs/:runId` every ~1s with an
+  `AbortController`, shows a determinate `LinearProgress`, then loads the proposal. localStorage
+  behavior unchanged.
+- **DB migration** `20260621000000_add_schedulerrun` must be applied (`pnpm exec prisma migrate
+  deploy`); Railway applies it automatically on deploy.
+
+## Problem
+
+`POST /api/accounts/:accountId/seasons/:seasonId/scheduler/solve` runs the solve **synchronously**
+inside the request handler. For large inputs the solve can take long enough that the Next.js dev
+proxy resets the connection (`socket hang up` / `ECONNRESET`) before the backend responds, with no
+useful error surfaced to the user. The synchronous solve also blocks the Node event loop for the
+duration.
+
+The diagnostics + saturation early-out shipped alongside this proposal make the *current* failure
+mode fast and observable, but they do not change the fundamental shape: a single request both does
+the work and waits for it. This proposal moves generation to a background job so the request returns
+immediately and the client tracks progress.
+
+## Goals
+
+- The Generate Schedule request returns immediately (no long-held connection, no socket hang up).
+- The user sees real progress (a progress bar) and a clear terminal state (completed / failed).
+- The solve no longer blocks the event loop for other requests.
+- Idempotency is preserved (re-submitting the same problem reuses the existing run).
+
+## Non-goals
+
+- Distributed/cross-instance job processing (see "Multi-instance caveat").
+- Changing the scheduling algorithm or its results.
+
+## Proposed design
+
+### 1. Enqueue endpoint
+
+`POST .../scheduler/solve` becomes an **enqueue**:
+
+1. Validate the request (as today).
+2. Build a deterministic `runId` (reuse `buildDeterministicRunId` from `schedulerEngineService`).
+3. Upsert a run row in `status: 'queued'` (return the existing row if the `runId`/idempotency key is
+   already present — preserves current idempotency behavior).
+4. Kick off background processing (see §3) and return **`202 Accepted`** with
+   `{ runId, status }` immediately.
+
+### 2. Status + result endpoints
+
+- `GET .../scheduler/runs/:runId` → `{ runId, status, progress: { processed, total }, result?, error? }`.
+  - `status`: `queued | running | completed | failed`.
+  - `result` is the existing `SchedulerSolveResult` when `status === 'completed'`.
+- Optionally `GET .../scheduler/runs` for a recent-runs list (not required for v1).
+
+### 3. Background worker
+
+- A simple in-process job runner (a module-level queue drained on `setImmediate`) runs
+  `buildProblemSpecForSolve` + `solve` for each queued run.
+- **Make the solve yield.** Refactor `SchedulerEngineService.solve` to optionally accept a
+  `{ onProgress?(processed, total): void; yieldEveryN?: number }` option and `await` a microtask
+  (`await new Promise((r) => setImmediate(r))`) every N games. This keeps the event loop responsive
+  and lets the worker persist progress. The existing synchronous call path can remain for unit tests
+  by defaulting to no yielding.
+- On completion/failure, persist `status`, `result`/`error`, and timestamps.
+
+### 4. Frontend
+
+In `SeasonSchedulerWidget`:
+
+- `handleGenerateMatchups` calls `generateMatchups` (unchanged), then the new enqueue endpoint,
+  stores `runId`, and renders a progress bar driven by the status endpoint.
+- **Notification:** reuse the existing SSE infrastructure (as used by alerts) to push a
+  "run updated/completed" event; fall back to polling `GET .../runs/:runId` on an interval if SSE is
+  unavailable. All polling uses `AbortController` per the frontend guide.
+- On `completed`, load the proposal into the existing review UI; on `failed`, show the error.
+- Persisted-proposal localStorage behavior is unchanged once the result is loaded.
+
+## Data model (new table — migration required)
+
+`schedulerrun` (illustrative):
+
+| column        | type          | notes                                            |
+| ------------- | ------------- | ------------------------------------------------ |
+| `runid`       | text PK       | deterministic run id                             |
+| `accountid`   | bigint        | FK → accounts (cascade)                          |
+| `seasonid`    | bigint        | FK → season (cascade)                            |
+| `status`      | text          | queued / running / completed / failed            |
+| `processed`   | int           | progress numerator                               |
+| `total`       | int           | progress denominator                             |
+| `result`      | jsonb (null)  | `SchedulerSolveResult` when completed            |
+| `error`       | text (null)   | message when failed                              |
+| `createdat`   | timestamptz   | default now()                                    |
+| `updatedat`   | timestamptz   | `@updatedAt`                                     |
+
+Migrations are authored as raw SQL under `backend/prisma/migrations/` and applied with
+`pnpm exec prisma migrate deploy` (per project convention); Railway runs migrate on deploy.
+
+## Shared-schema additions (restricted — needs approval)
+
+New types in `@draco/shared-schemas` (then `pnpm sync:api`):
+
+- `SchedulerRunStatus` enum.
+- `SchedulerRunProgress` `{ processed, total }`.
+- `SchedulerRunState` `{ runId, status, progress, result?, error? }` — response for the enqueue and
+  status endpoints.
+
+No change to `SchedulerSolveResult` itself (it becomes the `result` payload).
+
+## Multi-instance caveat (Railway)
+
+An in-process queue does not survive a restart and does not span instances. Acceptable for the
+current single-backend-instance deployment, but document the limitation. If horizontal scaling is
+introduced later, options are:
+
+- DB-backed claim/lease (a worker polls for `queued` rows and claims them transactionally), or
+- `worker_threads` for CPU isolation within an instance, or
+- an external queue (out of scope here).
+
+The DB-backed status table above is the foundation for any of these — only the *drainer* changes.
+
+## Rollout
+
+1. Land the table + shared-schema types (approved separately).
+2. Add enqueue/status endpoints + in-process worker with the yielding solve.
+3. Switch the frontend to enqueue + progress; keep the synchronous endpoint temporarily behind the
+   same route or a feature flag until the async path is verified.
+4. Remove the synchronous path once the async path is confirmed in production.
+
+## Testing
+
+- Backend: worker transitions (queued → running → completed/failed); progress callback invoked;
+  idempotent enqueue returns the existing run; yielding solve produces identical results to the
+  synchronous solve for the same input.
+- Frontend: enqueue → progress → completed renders the proposal; failed surfaces the error; polling
+  aborts on unmount.

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -25469,6 +25469,206 @@
           "unscheduled": []
         }
       },
+      "SchedulerRunState": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "running",
+              "completed",
+              "failed"
+            ],
+            "title": "SchedulerRunLifecycleStatus",
+            "description": "Lifecycle state of an asynchronous schedule-generation run."
+          },
+          "progress": {
+            "type": "object",
+            "properties": {
+              "processed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "processed",
+              "total"
+            ],
+            "title": "SchedulerRunProgress"
+          },
+          "result": {
+            "type": "object",
+            "properties": {
+              "runId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "completed",
+                  "partial",
+                  "infeasible",
+                  "failed"
+                ],
+                "title": "SchedulerRunStatus"
+              },
+              "metrics": {
+                "type": "object",
+                "properties": {
+                  "totalGames": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "scheduledGames": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "unscheduledGames": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "objectiveValue": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "totalGames",
+                  "scheduledGames",
+                  "unscheduledGames"
+                ],
+                "title": "SchedulerMetrics"
+              },
+              "assignments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "gameId": {
+                      "type": "string",
+                      "minLength": 1,
+                      "example": "123"
+                    },
+                    "fieldId": {
+                      "type": "string",
+                      "minLength": 1,
+                      "example": "123"
+                    },
+                    "startTime": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2024-03-01T18:30:00Z",
+                      "description": "ISO 8601 timestamp string with timezone offset."
+                    },
+                    "endTime": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2024-03-01T18:30:00Z",
+                      "description": "ISO 8601 timestamp string with timezone offset."
+                    },
+                    "umpireIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "example": "123"
+                      }
+                    }
+                  },
+                  "required": [
+                    "gameId",
+                    "fieldId",
+                    "startTime",
+                    "endTime",
+                    "umpireIds"
+                  ],
+                  "title": "SchedulerAssignment"
+                }
+              },
+              "unscheduled": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "gameId": {
+                      "type": "string",
+                      "minLength": 1,
+                      "example": "123"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "gameId",
+                    "reason"
+                  ],
+                  "title": "SchedulerUnscheduledReason"
+                }
+              }
+            },
+            "required": [
+              "runId",
+              "status",
+              "metrics",
+              "assignments",
+              "unscheduled"
+            ],
+            "title": "SchedulerSolveResult",
+            "description": "Proposal-only solve output. Persisting assignments is handled by a follow-up apply endpoint.",
+            "example": {
+              "runId": "sched_account_42_ab12cd34ef56gh78",
+              "status": "completed",
+              "metrics": {
+                "totalGames": 1,
+                "scheduledGames": 1,
+                "unscheduledGames": 0,
+                "objectiveValue": 1
+              },
+              "assignments": [
+                {
+                  "gameId": "game-1",
+                  "fieldId": "field-1",
+                  "startTime": "2026-04-05T09:00:00Z",
+                  "endTime": "2026-04-05T10:30:00Z",
+                  "umpireIds": [
+                    "ump-1"
+                  ]
+                }
+              ],
+              "unscheduled": []
+            }
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "status",
+          "progress"
+        ],
+        "title": "SchedulerRunState",
+        "description": "Status of an asynchronous schedule-generation run, including progress and the final result when completed.",
+        "example": {
+          "runId": "sched_account_42_ab12cd34ef56gh78",
+          "status": "running",
+          "progress": {
+            "processed": 120,
+            "total": 480
+          }
+        }
+      },
       "SchedulerApplyRequest": {
         "type": "object",
         "properties": {
@@ -71155,6 +71355,209 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs": {
+      "post": {
+        "operationId": "enqueueSeasonScheduleRun",
+        "summary": "Queue an asynchronous schedule-generation run",
+        "description": "Builds the problem spec from database state and queues an asynchronous solve. Returns immediately with a run id; poll GET .../scheduler/runs/{runId} for progress and the final result. Provide an Idempotency-Key header to reuse an existing run.",
+        "tags": [
+          "Scheduler"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": "Optional client-provided key used to derive a stable runId so callers can safely retry without enqueuing duplicate runs."
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchedulerSeasonSolveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Run accepted and queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulerRunState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions to generate schedules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs/{runId}": {
+      "get": {
+        "operationId": "getSeasonScheduleRun",
+        "summary": "Get the status of an asynchronous schedule-generation run",
+        "description": "Returns the lifecycle status and progress of a queued run, including the solve result once completed.",
+        "tags": [
+          "Scheduler"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulerRunState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions to view schedule runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
                 }
               }
             }

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -18446,7 +18446,7 @@ components:
               minItems: 1
               description: League-season IDs selected for scheduling. When omitted, the
                 frontend should treat this as "all leagues".
-              example: &a1
+              example: &a2
                 - "55"
                 - "56"
             umpiresPerGame:
@@ -19197,7 +19197,7 @@ components:
       title: SchedulerSolveResult
       description: Proposal-only solve output. Persisting assignments is handled by a
         follow-up apply endpoint.
-      example:
+      example: &a1
         runId: sched_account_42_ab12cd34ef56gh78
         status: completed
         metrics:
@@ -19213,6 +19213,144 @@ components:
             umpireIds:
               - ump-1
         unscheduled: []
+    SchedulerRunState:
+      type: object
+      properties:
+        runId:
+          type: string
+          minLength: 1
+        status:
+          type: string
+          enum:
+            - queued
+            - running
+            - completed
+            - failed
+          title: SchedulerRunLifecycleStatus
+          description: Lifecycle state of an asynchronous schedule-generation run.
+        progress:
+          type: object
+          properties:
+            processed:
+              type: integer
+              minimum: 0
+            total:
+              type: integer
+              minimum: 0
+          required:
+            - processed
+            - total
+          title: SchedulerRunProgress
+        result:
+          type: object
+          properties:
+            runId:
+              type: string
+              minLength: 1
+            status:
+              type: string
+              enum:
+                - completed
+                - partial
+                - infeasible
+                - failed
+              title: SchedulerRunStatus
+            metrics:
+              type: object
+              properties:
+                totalGames:
+                  type: integer
+                  minimum: 0
+                scheduledGames:
+                  type: integer
+                  minimum: 0
+                unscheduledGames:
+                  type: integer
+                  minimum: 0
+                objectiveValue:
+                  type: number
+              required:
+                - totalGames
+                - scheduledGames
+                - unscheduledGames
+              title: SchedulerMetrics
+            assignments:
+              type: array
+              items:
+                type: object
+                properties:
+                  gameId:
+                    type: string
+                    minLength: 1
+                    example: "123"
+                  fieldId:
+                    type: string
+                    minLength: 1
+                    example: "123"
+                  startTime:
+                    type: string
+                    format: date-time
+                    example: 2024-03-01T18:30:00Z
+                    description: ISO 8601 timestamp string with timezone offset.
+                  endTime:
+                    type: string
+                    format: date-time
+                    example: 2024-03-01T18:30:00Z
+                    description: ISO 8601 timestamp string with timezone offset.
+                  umpireIds:
+                    type: array
+                    items:
+                      type: string
+                      minLength: 1
+                      example: "123"
+                required:
+                  - gameId
+                  - fieldId
+                  - startTime
+                  - endTime
+                  - umpireIds
+                title: SchedulerAssignment
+            unscheduled:
+              type: array
+              items:
+                type: object
+                properties:
+                  gameId:
+                    type: string
+                    minLength: 1
+                    example: "123"
+                  reason:
+                    type: string
+                    minLength: 1
+                required:
+                  - gameId
+                  - reason
+                title: SchedulerUnscheduledReason
+          required:
+            - runId
+            - status
+            - metrics
+            - assignments
+            - unscheduled
+          title: SchedulerSolveResult
+          description: Proposal-only solve output. Persisting assignments is handled by a
+            follow-up apply endpoint.
+          example: *a1
+        error:
+          type: string
+      required:
+        - runId
+        - status
+        - progress
+      title: SchedulerRunState
+      description: Status of an asynchronous schedule-generation run, including
+        progress and the final result when completed.
+      example:
+        runId: sched_account_42_ab12cd34ef56gh78
+        status: running
+        progress:
+          processed: 120
+          total: 480
     SchedulerApplyRequest:
       type: object
       properties:
@@ -19444,7 +19582,7 @@ components:
           minItems: 1
           description: League-season IDs selected for scheduling. When omitted, the
             frontend should treat this as "all leagues".
-          example: *a1
+          example: *a2
         umpiresPerGame:
           type: integer
           minimum: 1
@@ -19491,7 +19629,7 @@ components:
           minItems: 1
           description: League-season IDs selected for scheduling. When omitted, the
             frontend should treat this as "all leagues".
-          example: *a1
+          example: *a2
         umpiresPerGame:
           type: integer
           minimum: 1
@@ -26640,14 +26778,14 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a2
+        - &a3
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a3
+        - &a4
           name: teamId
           in: path
           required: true
@@ -26694,9 +26832,9 @@ paths:
         - Photo Gallery
       security:
         - bearerAuth: []
-      parameters: &a4
-        - *a2
+      parameters: &a5
         - *a3
+        - *a4
       requestBody:
         content:
           multipart/form-data:
@@ -26740,8 +26878,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a2
         - *a3
+        - *a4
         - name: photoId
           in: path
           required: true
@@ -26788,8 +26926,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a2
         - *a3
+        - *a4
         - name: photoId
           in: path
           required: true
@@ -26821,7 +26959,7 @@ paths:
         - Photo Gallery
       security:
         - bearerAuth: []
-      parameters: *a4
+      parameters: *a5
       responses:
         "200":
           description: Team gallery albums available for administrative management.
@@ -26848,7 +26986,7 @@ paths:
         - Photo Gallery
       security:
         - bearerAuth: []
-      parameters: *a4
+      parameters: *a5
       requestBody:
         content:
           application/json:
@@ -26906,8 +27044,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a2
         - *a3
+        - *a4
         - name: albumId
           in: path
           required: true
@@ -26969,8 +27107,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a2
         - *a3
+        - *a4
         - name: albumId
           in: path
           required: true
@@ -30760,7 +30898,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: &a5
+            enum: &a6
               - announcements
               - gameResults
               - workouts
@@ -30801,7 +30939,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: *a5
+            enum: *a6
       requestBody:
         required: true
         content:
@@ -31661,7 +31799,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a6
+        - &a7
           name: alertId
           in: path
           required: true
@@ -31708,7 +31846,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a6
+        - *a7
       requestBody:
         content:
           application/json:
@@ -31760,7 +31898,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a6
+        - *a7
       responses:
         "204":
           description: Alert deleted successfully.
@@ -31797,14 +31935,14 @@ paths:
       tags:
         - Announcements
       parameters:
-        - &a7
+        - &a8
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a9
+        - &a10
           name: limit
           in: query
           required: false
@@ -31813,7 +31951,7 @@ paths:
             minimum: 1
             maximum: 25
           description: Maximum number of announcement summaries to return (default 10).
-        - &a10
+        - &a11
           name: includeSpecialOnly
           in: query
           required: false
@@ -31841,7 +31979,7 @@ paths:
       tags:
         - Announcements
       parameters:
-        - *a7
+        - *a8
       responses:
         "200":
           description: Announcements published for the account.
@@ -31865,7 +32003,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
+        - *a8
       requestBody:
         content:
           application/json:
@@ -31910,8 +32048,8 @@ paths:
       tags:
         - Announcements
       parameters:
-        - *a7
-        - &a8
+        - *a8
+        - &a9
           name: announcementId
           in: path
           required: true
@@ -31946,8 +32084,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
         - *a8
+        - *a9
       requestBody:
         content:
           application/json:
@@ -31999,8 +32137,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
         - *a8
+        - *a9
       responses:
         "204":
           description: Announcement deleted.
@@ -32037,16 +32175,16 @@ paths:
       tags:
         - Announcements
       parameters:
-        - *a7
-        - &a11
+        - *a8
+        - &a12
           name: teamId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - *a9
         - *a10
+        - *a11
       responses:
         "200":
           description: Team announcement summaries for the specified account.
@@ -32075,8 +32213,8 @@ paths:
       tags:
         - Announcements
       parameters:
-        - *a7
-        - *a11
+        - *a8
+        - *a12
       responses:
         "200":
           description: Team announcements for the specified account.
@@ -32105,8 +32243,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
-        - *a11
+        - *a8
+        - *a12
       requestBody:
         content:
           application/json:
@@ -32157,9 +32295,9 @@ paths:
       tags:
         - Announcements
       parameters:
-        - *a7
-        - *a11
         - *a8
+        - *a12
+        - *a9
       responses:
         "200":
           description: Team announcement.
@@ -32188,9 +32326,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
-        - *a11
         - *a8
+        - *a12
+        - *a9
       requestBody:
         content:
           application/json:
@@ -32242,9 +32380,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a7
-        - *a11
         - *a8
+        - *a12
+        - *a9
       responses:
         "204":
           description: Team announcement deleted.
@@ -32608,14 +32746,14 @@ paths:
         - Baseball Live Scoring
       security: []
       parameters:
-        - &a12
+        - &a13
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a13
+        - &a14
           name: gameId
           in: path
           required: true
@@ -32645,8 +32783,8 @@ paths:
         - Baseball Live Scoring
       security: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       responses:
         "200":
           description: Current baseball live scoring state
@@ -32676,8 +32814,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -32718,8 +32856,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -32772,8 +32910,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -32826,8 +32964,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -32890,8 +33028,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -32947,8 +33085,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a12
         - *a13
+        - *a14
       requestBody:
         content:
           application/json:
@@ -33004,7 +33142,7 @@ paths:
         - Baseball Live Scoring
       security: []
       parameters:
-        - *a12
+        - *a13
       responses:
         "200":
           description: List of active sessions
@@ -35451,14 +35589,14 @@ paths:
       tags:
         - Exports
       parameters:
-        - &a14
+        - &a15
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a15
+        - &a16
           name: seasonId
           in: path
           required: true
@@ -35475,7 +35613,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: &a16
+            text/csv: &a17
               schema:
                 type: string
                 format: binary
@@ -35514,8 +35652,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: leagueSeasonId
           in: path
           required: true
@@ -35526,7 +35664,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35561,8 +35699,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: teamSeasonId
           in: path
           required: true
@@ -35573,7 +35711,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35609,8 +35747,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: leagueSeasonId
           in: path
           required: true
@@ -35621,7 +35759,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35656,8 +35794,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: teamSeasonId
           in: path
           required: true
@@ -35668,7 +35806,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35703,8 +35841,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: leagueSeasonId
           in: path
           required: true
@@ -35715,7 +35853,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35750,8 +35888,8 @@ paths:
       tags:
         - Exports
       parameters:
-        - *a14
         - *a15
+        - *a16
         - name: leagueSeasonId
           in: path
           required: true
@@ -35762,7 +35900,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35796,14 +35934,14 @@ paths:
         - bearerAuth: []
       tags:
         - Exports
-      parameters: &a17
-        - *a14
+      parameters: &a18
         - *a15
+        - *a16
       responses:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35837,12 +35975,12 @@ paths:
         - bearerAuth: []
       tags:
         - Exports
-      parameters: *a17
+      parameters: *a18
       responses:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -35945,7 +36083,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a16
+            text/csv: *a17
         "401":
           description: Authentication required
           content:
@@ -41825,7 +41963,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a18
+        - &a19
           name: accountId
           in: path
           required: true
@@ -41861,7 +41999,7 @@ paths:
         - Individual Live Scoring
       security: []
       parameters:
-        - *a18
+        - *a19
       responses:
         "200":
           description: Current individual live scoring state
@@ -41891,7 +42029,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       responses:
         "201":
           description: SSE connection ticket
@@ -41927,7 +42065,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       requestBody:
         content:
           application/json:
@@ -41980,7 +42118,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       requestBody:
         content:
           application/json:
@@ -42033,7 +42171,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       requestBody:
         content:
           application/json:
@@ -42082,7 +42220,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       responses:
         "204":
           description: Session finalized successfully
@@ -42120,7 +42258,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a18
+        - *a19
       responses:
         "204":
           description: Session stopped successfully
@@ -42157,7 +42295,7 @@ paths:
       tags:
         - League FAQ
       parameters:
-        - &a19
+        - &a20
           name: accountId
           in: path
           required: true
@@ -42186,7 +42324,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a19
+        - *a20
       requestBody:
         content:
           application/json:
@@ -42232,8 +42370,8 @@ paths:
       tags:
         - League FAQ
       parameters:
-        - *a19
-        - &a20
+        - *a20
+        - &a21
           name: faqId
           in: path
           required: true
@@ -42268,8 +42406,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a19
         - *a20
+        - *a21
       requestBody:
         content:
           application/json:
@@ -42321,8 +42459,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a19
         - *a20
+        - *a21
       responses:
         "204":
           description: League FAQ entry deleted
@@ -43640,14 +43778,14 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a21
+        - &a22
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a22
+        - &a23
           name: matchId
           in: path
           required: true
@@ -43683,8 +43821,8 @@ paths:
         - Live Scoring
       security: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       responses:
         "200":
           description: Current live scoring state
@@ -43714,8 +43852,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -43756,8 +43894,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -43810,8 +43948,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -43864,8 +44002,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -43927,8 +44065,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -43984,8 +44122,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a21
         - *a22
+        - *a23
       requestBody:
         content:
           application/json:
@@ -44041,7 +44179,7 @@ paths:
         - Live Scoring
       security: []
       parameters:
-        - *a21
+        - *a22
       responses:
         "200":
           description: List of active sessions
@@ -44334,7 +44472,7 @@ paths:
       tags:
         - Member Businesses
       parameters:
-        - &a23
+        - &a24
           name: accountId
           in: path
           required: true
@@ -44385,7 +44523,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a23
+        - *a24
       requestBody:
         content:
           application/json:
@@ -44442,8 +44580,8 @@ paths:
       tags:
         - Member Businesses
       parameters:
-        - *a23
-        - &a24
+        - *a24
+        - &a25
           name: memberBusinessId
           in: path
           required: true
@@ -44478,8 +44616,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a23
         - *a24
+        - *a25
       requestBody:
         content:
           application/json:
@@ -44537,8 +44675,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a23
         - *a24
+        - *a25
       responses:
         "204":
           description: Member business entry deleted
@@ -45533,7 +45671,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a25
+        - &a26
           name: accountId
           in: path
           required: true
@@ -45577,7 +45715,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
+        - *a26
       requestBody:
         content:
           application/json:
@@ -45624,8 +45762,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
-        - &a26
+        - *a26
+        - &a27
           name: categoryId
           in: path
           required: true
@@ -45684,8 +45822,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
         - *a26
+        - *a27
       responses:
         "204":
           description: Survey category deleted successfully.
@@ -45724,8 +45862,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
         - *a26
+        - *a27
       requestBody:
         content:
           application/json:
@@ -45778,8 +45916,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
-        - &a27
+        - *a26
+        - &a28
           name: questionId
           in: path
           required: true
@@ -45837,8 +45975,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
-        - *a27
+        - *a26
+        - *a28
       responses:
         "204":
           description: Survey question deleted successfully.
@@ -45875,7 +46013,7 @@ paths:
       tags:
         - Player Surveys
       parameters:
-        - *a25
+        - *a26
         - schema:
             type: integer
             minimum: 1
@@ -45926,8 +46064,8 @@ paths:
       tags:
         - Player Surveys
       parameters:
-        - *a25
-        - &a28
+        - *a26
+        - &a29
           name: playerId
           in: path
           required: true
@@ -45965,9 +46103,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
+        - *a26
+        - *a29
         - *a28
-        - *a27
       requestBody:
         content:
           application/json:
@@ -46020,9 +46158,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a25
+        - *a26
+        - *a29
         - *a28
-        - *a27
       responses:
         "204":
           description: Survey answer deleted successfully.
@@ -46059,7 +46197,7 @@ paths:
       tags:
         - Player Surveys
       parameters:
-        - *a25
+        - *a26
       responses:
         "200":
           description: Player survey spotlight result.
@@ -46088,7 +46226,7 @@ paths:
       tags:
         - Player Surveys
       parameters:
-        - *a25
+        - *a26
         - name: teamSeasonId
           in: path
           required: true
@@ -48371,6 +48509,136 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs:
+    post:
+      operationId: enqueueSeasonScheduleRun
+      summary: Queue an asynchronous schedule-generation run
+      description: Builds the problem spec from database state and queues an
+        asynchronous solve. Returns immediately with a run id; poll GET
+        .../scheduler/runs/{runId} for progress and the final result. Provide an
+        Idempotency-Key header to reuse an existing run.
+      tags:
+        - Scheduler
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            minLength: 1
+          description: Optional client-provided key used to derive a stable runId so
+            callers can safely retry without enqueuing duplicate runs.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SchedulerSeasonSolveRequest"
+      responses:
+        "202":
+          description: Run accepted and queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SchedulerRunState"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Insufficient permissions to generate schedules
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs/{runId}:
+    get:
+      operationId: getSeasonScheduleRun
+      summary: Get the status of an asynchronous schedule-generation run
+      description: Returns the lifecycle status and progress of a queued run,
+        including the solve result once completed.
+      tags:
+        - Scheduler
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        "200":
+          description: Run status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SchedulerRunState"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Insufficient permissions to view schedule runs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
   /api/accounts/{accountId}/seasons/{seasonId}/scheduler/apply:
     post:
       operationId: applySeasonSchedule
@@ -49360,21 +49628,21 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a29
+        - &a30
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a30
+        - &a31
           name: seasonId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a31
+        - &a32
           name: leagueSeasonId
           in: path
           required: true
@@ -49419,9 +49687,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a29
         - *a30
         - *a31
+        - *a32
       requestBody:
         content:
           application/json:
@@ -49474,9 +49742,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a29
         - *a30
         - *a31
+        - *a32
       requestBody:
         content:
           application/json:
@@ -49529,10 +49797,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a29
         - *a30
         - *a31
-        - &a32
+        - *a32
+        - &a33
           name: subId
           in: path
           required: true
@@ -49578,10 +49846,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a29
         - *a30
         - *a31
         - *a32
+        - *a33
       responses:
         "204":
           description: Substitute deleted
@@ -49864,14 +50132,14 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a33
+        - &a34
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a34
+        - &a35
           name: seasonId
           in: path
           required: true
@@ -49977,8 +50245,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - name: feedItemId
           in: path
           required: true
@@ -50021,8 +50289,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - name: feedItemId
           in: path
           required: true
@@ -50065,8 +50333,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - schema:
             type: string
             pattern: ^\d+$
@@ -50133,8 +50401,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - schema:
             type: string
             pattern: ^\d+$
@@ -50200,8 +50468,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - schema:
             type: string
             nullable: true
@@ -50245,8 +50513,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
         - schema:
             type: string
             pattern: ^\d+$
@@ -50313,8 +50581,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
+        - *a35
       requestBody:
         content:
           application/json:
@@ -50367,9 +50635,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
-        - &a35
+        - *a35
+        - &a36
           name: liveEventId
           in: path
           required: true
@@ -50416,9 +50684,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
         - *a35
+        - *a36
       requestBody:
         content:
           application/json:
@@ -50470,9 +50738,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a33
         - *a34
         - *a35
+        - *a36
       responses:
         "204":
           description: Live event deleted.
@@ -52016,7 +52284,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: &a36
+            text/csv: &a37
               schema:
                 type: string
                 format: binary
@@ -52125,7 +52393,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52176,7 +52444,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52225,7 +52493,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52275,7 +52543,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52319,7 +52587,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52363,7 +52631,7 @@ paths:
         "200":
           description: CSV file export
           content:
-            text/csv: *a36
+            text/csv: *a37
         "400":
           description: Validation error
           content:
@@ -52392,22 +52660,22 @@ paths:
         - Team Emails
       security:
         - bearerAuth: []
-      parameters: &a37
-        - &a38
+      parameters: &a38
+        - &a39
           name: accountId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a39
+        - &a40
           name: seasonId
           in: path
           required: true
           schema:
             type: string
             format: number
-        - &a40
+        - &a41
           name: teamSeasonId
           in: path
           required: true
@@ -52476,7 +52744,7 @@ paths:
         - Team Emails
       security:
         - bearerAuth: []
-      parameters: *a37
+      parameters: *a38
       responses:
         "200":
           description: List of roster contacts
@@ -52548,9 +52816,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a38
         - *a39
         - *a40
+        - *a41
         - name: page
           in: query
           required: false
@@ -52626,9 +52894,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a38
         - *a39
         - *a40
+        - *a41
         - name: emailId
           in: path
           required: true
@@ -52681,23 +52949,23 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - &a42
+        - &a43
           name: accountId
           in: path
           required: true
-          schema: &a41
+          schema: &a42
             type: string
             format: number
-        - &a43
+        - &a44
           name: seasonId
           in: path
           required: true
-          schema: *a41
-        - &a44
+          schema: *a42
+        - &a45
           name: teamSeasonId
           in: path
           required: true
-          schema: *a41
+          schema: *a42
       responses:
         "200":
           description: Completed games retrieved.
@@ -52746,9 +53014,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
+        - *a45
       requestBody:
         required: true
         content:
@@ -52806,14 +53074,14 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
-        - &a45
+        - *a45
+        - &a46
           name: gameId
           in: path
           required: true
-          schema: *a41
+          schema: *a42
       responses:
         "200":
           description: Batting stats retrieved.
@@ -52858,10 +53126,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
+        - *a46
       requestBody:
         required: true
         content:
@@ -52919,15 +53187,15 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
-        - &a46
+        - *a46
+        - &a47
           name: statId
           in: path
           required: true
-          schema: *a41
+          schema: *a42
       requestBody:
         required: true
         content:
@@ -52978,11 +53246,11 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
         - *a46
+        - *a47
       responses:
         "204":
           description: Batting stat deleted.
@@ -53024,10 +53292,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
+        - *a46
       responses:
         "200":
           description: Pitching stats retrieved.
@@ -53072,10 +53340,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
+        - *a46
       requestBody:
         required: true
         content:
@@ -53133,11 +53401,11 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
         - *a46
+        - *a47
       requestBody:
         required: true
         content:
@@ -53188,11 +53456,11 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
         - *a46
+        - *a47
       responses:
         "204":
           description: Pitching stat deleted.
@@ -53234,10 +53502,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
+        - *a46
       responses:
         "200":
           description: Attendance retrieved.
@@ -53282,10 +53550,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a42
         - *a43
         - *a44
         - *a45
+        - *a46
       requestBody:
         required: true
         content:
@@ -54635,7 +54903,7 @@ paths:
       tags:
         - Accounts
       parameters:
-        - &a47
+        - &a48
           name: accountId
           in: path
           required: true
@@ -54660,7 +54928,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
+        - *a48
       requestBody:
         content:
           application/json:
@@ -54699,8 +54967,8 @@ paths:
       tags:
         - Accounts
       parameters:
-        - *a47
-        - &a48
+        - *a48
+        - &a49
           name: messageId
           in: path
           required: true
@@ -54729,8 +54997,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
         - *a48
+        - *a49
       requestBody:
         content:
           application/json:
@@ -54776,8 +55044,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
         - *a48
+        - *a49
       responses:
         "204":
           description: Welcome message deleted successfully.
@@ -54808,8 +55076,8 @@ paths:
       tags:
         - Teams
       parameters:
-        - *a47
-        - &a49
+        - *a48
+        - &a50
           name: teamSeasonId
           in: path
           required: true
@@ -54838,8 +55106,8 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
-        - *a49
+        - *a48
+        - *a50
       requestBody:
         content:
           application/json:
@@ -54884,9 +55152,9 @@ paths:
       tags:
         - Teams
       parameters:
-        - *a47
-        - *a49
         - *a48
+        - *a50
+        - *a49
       responses:
         "200":
           description: Team welcome message retrieved successfully.
@@ -54909,9 +55177,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
-        - *a49
         - *a48
+        - *a50
+        - *a49
       requestBody:
         content:
           application/json:
@@ -54957,9 +55225,9 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - *a47
-        - *a49
         - *a48
+        - *a50
+        - *a49
       responses:
         "204":
           description: Team welcome message deleted successfully.

--- a/draco-nodejs/backend/prisma/migrations/20260621000000_add_schedulerrun/migration.sql
+++ b/draco-nodejs/backend/prisma/migrations/20260621000000_add_schedulerrun/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE schedulerrun (
+  runid VARCHAR(255) PRIMARY KEY,
+  accountid BIGINT NOT NULL,
+  seasonid BIGINT NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'queued',
+  processed INT NOT NULL DEFAULT 0,
+  total INT NOT NULL DEFAULT 0,
+  result JSONB,
+  error TEXT,
+  createdat TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updatedat TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT fk_schedulerrun_accounts
+    FOREIGN KEY (accountid) REFERENCES accounts(id) ON DELETE CASCADE,
+  CONSTRAINT fk_schedulerrun_season
+    FOREIGN KEY (seasonid) REFERENCES season(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_schedulerrun_account_season
+  ON schedulerrun(accountid, seasonid);

--- a/draco-nodejs/backend/prisma/schema.prisma
+++ b/draco-nodejs/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model accounts {
   schedulerleagueseasonexclusions schedulerleagueseasonexclusions[]
   schedulerumpireexclusions schedulerumpireexclusions[]
   schedulerapplyauditlog schedulerapplyauditlog[]
+  schedulerrun schedulerrun[]
   contactroles              contactroles[]
   contacts                  contacts[]
   currentseason             currentseason?
@@ -538,6 +539,24 @@ model schedulerapplyauditlog {
   season   season   @relation(fields: [seasonid], references: [id], onDelete: Cascade, map: "fk_schedulerapplyauditlog_season")
 
   @@index([accountid, seasonid], map: "idx_schedulerapplyauditlog_account_season")
+}
+
+model schedulerrun {
+  runid     String   @id @db.VarChar(255)
+  accountid BigInt
+  seasonid  BigInt
+  status    String   @default("queued") @db.VarChar(20)
+  processed Int      @default(0)
+  total     Int      @default(0)
+  result    Json?
+  error     String?
+  createdat DateTime @default(now()) @db.Timestamptz(6)
+  updatedat DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  accounts accounts @relation(fields: [accountid], references: [id], onDelete: Cascade, map: "fk_schedulerrun_accounts")
+  season   season   @relation(fields: [seasonid], references: [id], onDelete: Cascade, map: "fk_schedulerrun_season")
+
+  @@index([accountid, seasonid], map: "idx_schedulerrun_account_season")
 }
 
 model batstatsum {
@@ -1719,6 +1738,7 @@ model season {
   schedulerleagueseasonexclusions schedulerleagueseasonexclusions[]
   schedulerumpireexclusions schedulerumpireexclusions[]
   schedulerapplyauditlog schedulerapplyauditlog[]
+  schedulerrun schedulerrun[]
   accounts                    accounts                      @relation(fields: [accountid], references: [id], onDelete: Cascade, map: "fk_season_accounts")
 }
 

--- a/draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts
+++ b/draco-nodejs/backend/src/__tests__/accounts-contacts-my-teams.integration.test.ts
@@ -86,6 +86,8 @@ vi.mock('../repositories/repositoryFactory.js', () => ({
     getSchedulerLeagueSeasonExclusionsRepository: vi.fn(),
     getSchedulerUmpireExclusionsRepository: vi.fn(),
     getSchedulerMatchupRepository: vi.fn(),
+    getSchedulerApplyAuditLogRepository: vi.fn(),
+    getSchedulerRunRepository: vi.fn(),
     getGolfCourseRepository: vi.fn(),
     getGolferRepository: vi.fn(),
     getGolfScoreRepository: vi.fn(),

--- a/draco-nodejs/backend/src/__tests__/oauth.integration.test.ts
+++ b/draco-nodejs/backend/src/__tests__/oauth.integration.test.ts
@@ -89,6 +89,8 @@ vi.mock('../repositories/repositoryFactory.js', () => ({
     getSchedulerLeagueSeasonExclusionsRepository: vi.fn(),
     getSchedulerUmpireExclusionsRepository: vi.fn(),
     getSchedulerMatchupRepository: vi.fn(),
+    getSchedulerApplyAuditLogRepository: vi.fn(),
+    getSchedulerRunRepository: vi.fn(),
     getGolfCourseRepository: vi.fn(),
     getGolferRepository: vi.fn(),
     getGolfScoreRepository: vi.fn(),

--- a/draco-nodejs/backend/src/openapi/openapiTypes.ts
+++ b/draco-nodejs/backend/src/openapi/openapiTypes.ts
@@ -301,6 +301,7 @@ import {
   SchedulerGenerateMatchupsRequestSchema,
   SchedulerGenerateMatchupsResultSchema,
   SchedulerSolveResultSchema,
+  SchedulerRunStateSchema,
   SchedulerApplyRequestSchema,
   SchedulerApplyResultSchema,
   SchedulerSeasonWindowConfigSchema,
@@ -1338,6 +1339,10 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     'SchedulerSolveResult',
     SchedulerSolveResultSchema,
   );
+  const SchedulerRunStateSchemaRef = registry.register(
+    'SchedulerRunState',
+    SchedulerRunStateSchema,
+  );
   const SchedulerApplyRequestSchemaRef = registry.register(
     'SchedulerApplyRequest',
     SchedulerApplyRequestSchema,
@@ -1995,6 +2000,7 @@ export const registerSchemaRefs = (registry: OpenAPIRegistry) => {
     SchedulerGenerateMatchupsRequestSchemaRef,
     SchedulerGenerateMatchupsResultSchemaRef,
     SchedulerSolveResultSchemaRef,
+    SchedulerRunStateSchemaRef,
     SchedulerApplyRequestSchemaRef,
     SchedulerApplyResultSchemaRef,
     SchedulerSeasonWindowConfigSchemaRef,

--- a/draco-nodejs/backend/src/openapi/paths/scheduler/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/scheduler/index.ts
@@ -14,6 +14,7 @@ export const registerSchedulerEndpoints = ({ registry, schemaRefs }: RegisterCon
     SchedulerGenerateMatchupsRequestSchemaRef,
     SchedulerGenerateMatchupsResultSchemaRef,
     SchedulerSolveResultSchemaRef,
+    SchedulerRunStateSchemaRef,
     SchedulerApplyRequestSchemaRef,
     SchedulerApplyResultSchemaRef,
     SchedulerSeasonWindowConfigSchemaRef,
@@ -1194,6 +1195,124 @@ export const registerSchedulerEndpoints = ({ registry, schemaRefs }: RegisterCon
       403: {
         description: 'Insufficient permissions to generate schedules',
         content: { 'application/json': { schema: AuthorizationErrorSchemaRef } },
+      },
+      500: {
+        description: 'Internal server error',
+        content: { 'application/json': { schema: InternalServerErrorSchemaRef } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs',
+    operationId: 'enqueueSeasonScheduleRun',
+    summary: 'Queue an asynchronous schedule-generation run',
+    description:
+      'Builds the problem spec from database state and queues an asynchronous solve. Returns immediately with a run id; poll GET .../scheduler/runs/{runId} for progress and the final result. Provide an Idempotency-Key header to reuse an existing run.',
+    tags: ['Scheduler'],
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+      {
+        name: 'Idempotency-Key',
+        in: 'header',
+        required: false,
+        schema: { type: 'string', minLength: 1 },
+        description:
+          'Optional client-provided key used to derive a stable runId so callers can safely retry without enqueuing duplicate runs.',
+      },
+    ],
+    request: {
+      body: {
+        required: false,
+        content: {
+          'application/json': {
+            schema: SchedulerSeasonSolveRequestSchemaRef,
+          },
+        },
+      },
+    },
+    responses: {
+      202: {
+        description: 'Run accepted and queued',
+        content: { 'application/json': { schema: SchedulerRunStateSchemaRef } },
+      },
+      400: {
+        description: 'Validation error',
+        content: { 'application/json': { schema: ValidationErrorSchemaRef } },
+      },
+      401: {
+        description: 'Authentication required',
+        content: { 'application/json': { schema: AuthenticationErrorSchemaRef } },
+      },
+      403: {
+        description: 'Insufficient permissions to generate schedules',
+        content: { 'application/json': { schema: AuthorizationErrorSchemaRef } },
+      },
+      500: {
+        description: 'Internal server error',
+        content: { 'application/json': { schema: InternalServerErrorSchemaRef } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/scheduler/runs/{runId}',
+    operationId: 'getSeasonScheduleRun',
+    summary: 'Get the status of an asynchronous schedule-generation run',
+    description:
+      'Returns the lifecycle status and progress of a queued run, including the solve result once completed.',
+    tags: ['Scheduler'],
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'number' },
+      },
+      {
+        name: 'runId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', minLength: 1 },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'Run status',
+        content: { 'application/json': { schema: SchedulerRunStateSchemaRef } },
+      },
+      401: {
+        description: 'Authentication required',
+        content: { 'application/json': { schema: AuthenticationErrorSchemaRef } },
+      },
+      403: {
+        description: 'Insufficient permissions to view schedule runs',
+        content: { 'application/json': { schema: AuthorizationErrorSchemaRef } },
+      },
+      404: {
+        description: 'Run not found',
+        content: { 'application/json': { schema: NotFoundErrorSchemaRef } },
       },
       500: {
         description: 'Internal server error',

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerProblemSpecRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerProblemSpecRepository.ts
@@ -55,6 +55,7 @@ export class PrismaSchedulerProblemSpecRepository implements ISchedulerProblemSp
   async listSeasonGames(seasonId: bigint): Promise<leagueschedule[]> {
     return this.prisma.leagueschedule.findMany({
       where: { leagueseason: { seasonid: seasonId } },
+      orderBy: [{ gamedate: 'asc' }, { id: 'asc' }],
     });
   }
 }

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerRunRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerRunRepository.ts
@@ -1,0 +1,37 @@
+import { PrismaClient, schedulerrun } from '#prisma/client';
+import type {
+  ISchedulerRunRepository,
+  SchedulerRunCreateData,
+  SchedulerRunProgressUpdate,
+} from '../interfaces/ISchedulerRunRepository.js';
+
+export class PrismaSchedulerRunRepository implements ISchedulerRunRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: SchedulerRunCreateData): Promise<schedulerrun> {
+    return this.prisma.schedulerrun.create({ data });
+  }
+
+  async findByRunId(
+    accountid: bigint,
+    seasonid: bigint,
+    runid: string,
+  ): Promise<schedulerrun | null> {
+    return this.prisma.schedulerrun.findFirst({
+      where: { runid, accountid, seasonid },
+    });
+  }
+
+  async update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun> {
+    return this.prisma.schedulerrun.update({
+      where: { runid },
+      data: {
+        ...(data.status !== undefined ? { status: data.status } : {}),
+        ...(data.processed !== undefined ? { processed: data.processed } : {}),
+        ...(data.total !== undefined ? { total: data.total } : {}),
+        ...(data.result !== undefined ? { result: data.result } : {}),
+        ...(data.error !== undefined ? { error: data.error === null ? null : data.error } : {}),
+      },
+    });
+  }
+}

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerRunRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaSchedulerRunRepository.ts
@@ -22,6 +22,14 @@ export class PrismaSchedulerRunRepository implements ISchedulerRunRepository {
     });
   }
 
+  async claimQueued(runid: string, total: number): Promise<boolean> {
+    const result = await this.prisma.schedulerrun.updateMany({
+      where: { runid, status: 'queued' },
+      data: { status: 'running', processed: 0, total },
+    });
+    return result.count === 1;
+  }
+
   async update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun> {
     return this.prisma.schedulerrun.update({
       where: { runid },

--- a/draco-nodejs/backend/src/repositories/implementations/index.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/index.ts
@@ -71,3 +71,4 @@ export * from './PrismaBaseballLiveScoringRepository.js';
 export * from './PrismaOauthRepository.js';
 export * from './PrismaSchedulerMatchupRepository.js';
 export * from './PrismaSchedulerApplyAuditLogRepository.js';
+export * from './PrismaSchedulerRunRepository.js';

--- a/draco-nodejs/backend/src/repositories/interfaces/ISchedulerRunRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/ISchedulerRunRepository.ts
@@ -20,4 +20,5 @@ export interface ISchedulerRunRepository {
   create(data: SchedulerRunCreateData): Promise<schedulerrun>;
   findByRunId(accountid: bigint, seasonid: bigint, runid: string): Promise<schedulerrun | null>;
   update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun>;
+  claimQueued(runid: string, total: number): Promise<boolean>;
 }

--- a/draco-nodejs/backend/src/repositories/interfaces/ISchedulerRunRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/ISchedulerRunRepository.ts
@@ -1,0 +1,23 @@
+import type { Prisma, schedulerrun } from '#prisma/client';
+
+export interface SchedulerRunCreateData {
+  runid: string;
+  accountid: bigint;
+  seasonid: bigint;
+  status: string;
+  total: number;
+}
+
+export interface SchedulerRunProgressUpdate {
+  status?: string;
+  processed?: number;
+  total?: number;
+  result?: Prisma.InputJsonValue;
+  error?: string | null;
+}
+
+export interface ISchedulerRunRepository {
+  create(data: SchedulerRunCreateData): Promise<schedulerrun>;
+  findByRunId(accountid: bigint, seasonid: bigint, runid: string): Promise<schedulerrun | null>;
+  update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun>;
+}

--- a/draco-nodejs/backend/src/repositories/interfaces/index.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/index.ts
@@ -72,3 +72,4 @@ export * from './IBaseballLiveScoringRepository.js';
 export * from './IOauthRepository.js';
 export * from './ISchedulerMatchupRepository.js';
 export * from './ISchedulerApplyAuditLogRepository.js';
+export * from './ISchedulerRunRepository.js';

--- a/draco-nodejs/backend/src/repositories/repositoryFactory.ts
+++ b/draco-nodejs/backend/src/repositories/repositoryFactory.ts
@@ -60,6 +60,7 @@ import {
   ISchedulerLeagueSeasonExclusionsRepository,
   ISchedulerUmpireExclusionsRepository,
   ISchedulerApplyAuditLogRepository,
+  ISchedulerRunRepository,
   IGolfCourseRepository,
   IGolfTeeRepository,
   IGolfLeagueRepository,
@@ -135,6 +136,7 @@ import {
   PrismaSchedulerLeagueSeasonExclusionsRepository,
   PrismaSchedulerUmpireExclusionsRepository,
   PrismaSchedulerApplyAuditLogRepository,
+  PrismaSchedulerRunRepository,
   PrismaGolfCourseRepository,
   PrismaGolfTeeRepository,
   PrismaGolfLeagueRepository,
@@ -217,6 +219,7 @@ export class RepositoryFactory {
   private static schedulerLeagueSeasonExclusionsRepository: ISchedulerLeagueSeasonExclusionsRepository;
   private static schedulerUmpireExclusionsRepository: ISchedulerUmpireExclusionsRepository;
   private static schedulerApplyAuditLogRepository: ISchedulerApplyAuditLogRepository;
+  private static schedulerRunRepository: ISchedulerRunRepository;
   private static golfCourseRepository: IGolfCourseRepository;
   private static golfTeeRepository: IGolfTeeRepository;
   private static golfLeagueRepository: IGolfLeagueRepository;
@@ -560,6 +563,13 @@ export class RepositoryFactory {
       this.schedulerApplyAuditLogRepository = new PrismaSchedulerApplyAuditLogRepository(prisma);
     }
     return this.schedulerApplyAuditLogRepository;
+  }
+
+  static getSchedulerRunRepository(): ISchedulerRunRepository {
+    if (!this.schedulerRunRepository) {
+      this.schedulerRunRepository = new PrismaSchedulerRunRepository(prisma);
+    }
+    return this.schedulerRunRepository;
   }
 
   static getUmpireRepository(): IUmpireRepository {

--- a/draco-nodejs/backend/src/responseFormatters/__tests__/schedulerRunResponseFormatter.test.ts
+++ b/draco-nodejs/backend/src/responseFormatters/__tests__/schedulerRunResponseFormatter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { schedulerrun } from '#prisma/client';
+import { SchedulerRunResponseFormatter } from '../schedulerRunResponseFormatter.js';
+
+const buildRow = (status: string): schedulerrun => ({
+  runid: 'r1',
+  accountid: 1n,
+  seasonid: 5n,
+  status,
+  processed: 0,
+  total: 0,
+  result: null,
+  error: null,
+  createdat: new Date('2026-06-21T00:00:00Z'),
+  updatedat: new Date('2026-06-21T00:00:00Z'),
+});
+
+describe('SchedulerRunResponseFormatter', () => {
+  it('passes known lifecycle statuses through unchanged', () => {
+    expect(SchedulerRunResponseFormatter.format(buildRow('queued')).status).toBe('queued');
+    expect(SchedulerRunResponseFormatter.format(buildRow('running')).status).toBe('running');
+    expect(SchedulerRunResponseFormatter.format(buildRow('completed')).status).toBe('completed');
+    expect(SchedulerRunResponseFormatter.format(buildRow('failed')).status).toBe('failed');
+  });
+
+  it('maps an unknown/corrupt status to failed rather than queued', () => {
+    expect(SchedulerRunResponseFormatter.format(buildRow('bogus')).status).toBe('failed');
+  });
+});

--- a/draco-nodejs/backend/src/responseFormatters/schedulerRunResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/schedulerRunResponseFormatter.ts
@@ -16,7 +16,7 @@ const LIFECYCLE_STATUSES: SchedulerRunLifecycleStatus[] = [
 const toLifecycleStatus = (value: string): SchedulerRunLifecycleStatus =>
   LIFECYCLE_STATUSES.includes(value as SchedulerRunLifecycleStatus)
     ? (value as SchedulerRunLifecycleStatus)
-    : 'queued';
+    : 'failed';
 
 export class SchedulerRunResponseFormatter {
   static format(run: schedulerrun): SchedulerRunState {

--- a/draco-nodejs/backend/src/responseFormatters/schedulerRunResponseFormatter.ts
+++ b/draco-nodejs/backend/src/responseFormatters/schedulerRunResponseFormatter.ts
@@ -1,0 +1,35 @@
+import type { Prisma, schedulerrun } from '#prisma/client';
+import {
+  SchedulerSolveResultSchema,
+  type SchedulerRunLifecycleStatus,
+  type SchedulerRunState,
+  type SchedulerSolveResult,
+} from '@draco/shared-schemas';
+
+const LIFECYCLE_STATUSES: SchedulerRunLifecycleStatus[] = [
+  'queued',
+  'running',
+  'completed',
+  'failed',
+];
+
+const toLifecycleStatus = (value: string): SchedulerRunLifecycleStatus =>
+  LIFECYCLE_STATUSES.includes(value as SchedulerRunLifecycleStatus)
+    ? (value as SchedulerRunLifecycleStatus)
+    : 'queued';
+
+export class SchedulerRunResponseFormatter {
+  static format(run: schedulerrun): SchedulerRunState {
+    return {
+      runId: run.runid,
+      status: toLifecycleStatus(run.status),
+      progress: { processed: run.processed, total: run.total },
+      result: run.result == null ? undefined : SchedulerSolveResultSchema.parse(run.result),
+      error: run.error ?? undefined,
+    };
+  }
+
+  static toStoredResult(result: SchedulerSolveResult): Prisma.InputJsonValue {
+    return result as Prisma.InputJsonValue;
+  }
+}

--- a/draco-nodejs/backend/src/routes/season-scheduler-field-availability.ts
+++ b/draco-nodejs/backend/src/routes/season-scheduler-field-availability.ts
@@ -3,6 +3,7 @@ import { authenticateToken } from '../middleware/authMiddleware.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { extractBigIntParams } from '../utils/paramExtraction.js';
+import { NotFoundError } from '../utils/customErrors.js';
 import {
   SchedulerSeasonWindowConfigUpsertSchema,
   SchedulerSeasonExclusionUpsertSchema,
@@ -27,6 +28,7 @@ const schedulerProblemSpecService = ServiceFactory.getSchedulerProblemSpecServic
 const schedulerEngineService = ServiceFactory.getSchedulerEngineService();
 const schedulerSeasonApplyService = ServiceFactory.getSchedulerSeasonApplyService();
 const schedulerMatchupGenerationService = ServiceFactory.getSchedulerMatchupGenerationService();
+const schedulerRunService = ServiceFactory.getSchedulerRunService();
 
 router.get(
   '/season-window-config',
@@ -381,17 +383,63 @@ router.post(
         ? rawIdempotencyKey.trim()
         : undefined;
 
-    const { problemSpec, timeZoneId } = await schedulerProblemSpecService.buildProblemSpecForSolve(
-      accountId,
-      seasonId,
-      request,
-    );
+    const logPrefix = `[scheduler:solve account=${accountId.toString()} season=${seasonId.toString()}]`;
+    const buildStart = Date.now();
+    const { problemSpec, timeZoneId, fieldGameLengthById } =
+      await schedulerProblemSpecService.buildProblemSpecForSolve(accountId, seasonId, request);
+    console.log(`${logPrefix} build complete in ${Date.now() - buildStart}ms`);
+
+    const solveStart = Date.now();
     const result = schedulerEngineService.solve(problemSpec, {
       accountId,
       idempotencyKey,
       timeZoneId,
+      fieldGameLengthById,
     });
+    console.log(
+      `${logPrefix} solve complete in ${Date.now() - solveStart}ms status=${result.status} ` +
+        `scheduled=${result.metrics.scheduledGames}/${result.metrics.totalGames}`,
+    );
     res.json(result);
+  }),
+);
+
+router.post(
+  '/runs',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('account.games.manage'),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId } = extractBigIntParams(req.params, 'accountId', 'seasonId');
+    const request = SchedulerSeasonSolveRequestSchema.parse(req.body ?? {});
+    const rawIdempotencyKey = req.header('Idempotency-Key') ?? req.header('X-Idempotency-Key');
+    const idempotencyKey =
+      typeof rawIdempotencyKey === 'string' && rawIdempotencyKey.trim().length > 0
+        ? rawIdempotencyKey.trim()
+        : undefined;
+
+    const run = await schedulerRunService.enqueue(accountId, seasonId, request, idempotencyKey);
+    res.status(202).json(run);
+  }),
+);
+
+router.get(
+  '/runs/:runId',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermission('account.games.manage'),
+  asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const { accountId, seasonId } = extractBigIntParams(req.params, 'accountId', 'seasonId');
+    const rawRunId = req.params.runId;
+    const runId = Array.isArray(rawRunId) ? rawRunId[0] : rawRunId;
+    if (!runId) {
+      throw new NotFoundError('Scheduler run not found');
+    }
+    const run = await schedulerRunService.getRun(accountId, seasonId, runId);
+    if (!run) {
+      throw new NotFoundError('Scheduler run not found');
+    }
+    res.json(run);
   }),
 );
 

--- a/draco-nodejs/backend/src/services/__tests__/schedulerEngineService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerEngineService.test.ts
@@ -2620,3 +2620,214 @@ describe('SchedulerEngineService — fixedGames occupancy seeding', () => {
     expect(result.assignments[0]?.umpireIds).toEqual(['ump-1']);
   });
 });
+
+describe('SchedulerEngineService — saturation early-out', () => {
+  const NO_CAPACITY_REASON = 'No field capacity remaining';
+
+  const makeGame = (
+    id: string,
+    homeTeamSeasonId: string,
+    visitorTeamSeasonId: string,
+  ): SchedulerProblemSpec['games'][number] => ({
+    id,
+    leagueSeasonId: 'leagueSeason-1',
+    homeTeamSeasonId,
+    visitorTeamSeasonId,
+    earliestStart: '2026-04-05T09:00:00Z',
+    latestEnd: '2026-04-05T23:00:00Z',
+    durationMinutes: 60,
+    requiredUmpires: 0,
+  });
+
+  const makeSlot = (
+    id: string,
+    startTime: string,
+    endTime: string,
+  ): SchedulerProblemSpec['fieldSlots'][number] => ({
+    id,
+    fieldId: 'field-1',
+    startTime,
+    endTime,
+  });
+
+  const buildSpec = (
+    overrides: Partial<SchedulerProblemSpec> & {
+      games: SchedulerProblemSpec['games'];
+      fieldSlots: SchedulerProblemSpec['fieldSlots'];
+    },
+  ): SchedulerProblemSpec => ({
+    season: {
+      id: 'spring-2026',
+      name: 'Spring 2026',
+      startDate: '2026-04-01',
+      endDate: '2026-08-31',
+    },
+    teams: [
+      { id: 'team-1', teamSeasonId: 'teamSeason-1', league: { id: 'league-1', name: 'Open' } },
+      { id: 'team-2', teamSeasonId: 'teamSeason-2', league: { id: 'league-1', name: 'Open' } },
+      { id: 'team-3', teamSeasonId: 'teamSeason-3', league: { id: 'league-1', name: 'Open' } },
+      { id: 'team-4', teamSeasonId: 'teamSeason-4', league: { id: 'league-1', name: 'Open' } },
+    ],
+    fields: [{ id: 'field-1', name: 'Field 1' }],
+    umpires: [],
+    teamBlackouts: [],
+    constraints: { hard: { respectFieldSlots: true } },
+    ...overrides,
+  });
+
+  it('stops scanning once all slot capacity is consumed and flags the remainder', () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      games: [
+        makeGame('game-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-2', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-3', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-4', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-5', 'teamSeason-1', 'teamSeason-2'),
+      ],
+      fieldSlots: [
+        makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T10:30:00Z'),
+        makeSlot('slot-2', '2026-04-05T11:00:00Z', '2026-04-05T12:30:00Z'),
+        makeSlot('slot-3', '2026-04-05T13:00:00Z', '2026-04-05T14:30:00Z'),
+      ],
+    });
+
+    const result = service.solve(spec);
+
+    expect(result.status).toBe('partial');
+    expect(result.assignments).toHaveLength(3);
+    expect(result.unscheduled).toHaveLength(2);
+    expect(result.unscheduled.every((u) => u.reason === NO_CAPACITY_REASON)).toBe(true);
+    expect(result.unscheduled.map((u) => u.gameId)).toEqual(['game-4', 'game-5']);
+  });
+
+  it('counts maxParallelGames toward placement capacity', () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      fields: [{ id: 'field-1', name: 'Field 1', properties: { maxParallelGames: 2 } }],
+      games: [
+        makeGame('game-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-2', 'teamSeason-3', 'teamSeason-4'),
+        makeGame('game-3', 'teamSeason-1', 'teamSeason-3'),
+        makeGame('game-4', 'teamSeason-2', 'teamSeason-4'),
+      ],
+      fieldSlots: [makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T11:00:00Z')],
+    });
+
+    const result = service.solve(spec);
+
+    expect(result.assignments).toHaveLength(2);
+    expect(result.unscheduled).toHaveLength(2);
+    expect(result.unscheduled.every((u) => u.reason === NO_CAPACITY_REASON)).toBe(true);
+  });
+
+  it('uses the field game length from context for the assigned duration', () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      games: [makeGame('game-1', 'teamSeason-1', 'teamSeason-2')],
+      fieldSlots: [makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T11:00:00Z')],
+    });
+
+    const withField = service.solve(spec, { fieldGameLengthById: { 'field-1': 90 } });
+    expect(withField.assignments[0]?.startTime).toBe('2026-04-05T09:00:00.000Z');
+    expect(withField.assignments[0]?.endTime).toBe('2026-04-05T10:30:00.000Z');
+
+    const withoutField = service.solve(spec);
+    expect(withoutField.assignments[0]?.endTime).toBe('2026-04-05T10:00:00.000Z');
+  });
+
+  it('preserves caller (round-major) order instead of regrouping repeats by id', () => {
+    const service = new SchedulerEngineService();
+    // Caller supplies round-major order: pairing A round 0, pairing B round 0,
+    // pairing A round 1, pairing B round 1. The ids would group A's together if
+    // the engine sorted by id; a stable sort must keep them interleaved.
+    const spec = buildSpec({
+      games: [
+        makeGame('m-a-0', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('m-b-0', 'teamSeason-3', 'teamSeason-4'),
+        makeGame('m-a-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('m-b-1', 'teamSeason-3', 'teamSeason-4'),
+      ],
+      fieldSlots: [
+        makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T10:30:00Z'),
+        makeSlot('slot-2', '2026-04-05T11:00:00Z', '2026-04-05T12:30:00Z'),
+        makeSlot('slot-3', '2026-04-05T13:00:00Z', '2026-04-05T14:30:00Z'),
+        makeSlot('slot-4', '2026-04-05T15:00:00Z', '2026-04-05T16:30:00Z'),
+      ],
+    });
+
+    const result = service.solve(spec);
+
+    expect(result.assignments.map((a) => a.gameId)).toEqual(['m-a-0', 'm-b-0', 'm-a-1', 'm-b-1']);
+  });
+
+  it('does not trigger when every game fits', () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      games: [
+        makeGame('game-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-2', 'teamSeason-1', 'teamSeason-2'),
+      ],
+      fieldSlots: [
+        makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T10:30:00Z'),
+        makeSlot('slot-2', '2026-04-05T11:00:00Z', '2026-04-05T12:30:00Z'),
+        makeSlot('slot-3', '2026-04-05T13:00:00Z', '2026-04-05T14:30:00Z'),
+      ],
+    });
+
+    const result = service.solve(spec);
+
+    expect(result.status).toBe('completed');
+    expect(result.assignments).toHaveLength(2);
+    expect(result.unscheduled).toHaveLength(0);
+  });
+
+  it('solveAsync produces the same result as solve and reports progress', async () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      games: [
+        makeGame('game-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-2', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-3', 'teamSeason-1', 'teamSeason-2'),
+      ],
+      fieldSlots: [
+        makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T10:30:00Z'),
+        makeSlot('slot-2', '2026-04-05T11:00:00Z', '2026-04-05T12:30:00Z'),
+      ],
+    });
+
+    const sync = service.solve(spec);
+    const progress: Array<{ processed: number; total: number }> = [];
+    const async = await service.solveAsync(spec, undefined, {
+      yieldEveryN: 1,
+      onProgress: (processed, total) => progress.push({ processed, total }),
+    });
+
+    expect(async.status).toBe(sync.status);
+    expect(async.assignments).toEqual(sync.assignments);
+    expect(async.unscheduled).toEqual(sync.unscheduled);
+    expect(progress.length).toBeGreaterThan(0);
+    expect(progress[progress.length - 1]).toEqual({ processed: 3, total: 3 });
+  });
+
+  it('solveAsync reports full progress when the early-out fires', async () => {
+    const service = new SchedulerEngineService();
+    const spec = buildSpec({
+      games: [
+        makeGame('game-1', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-2', 'teamSeason-1', 'teamSeason-2'),
+        makeGame('game-3', 'teamSeason-1', 'teamSeason-2'),
+      ],
+      fieldSlots: [makeSlot('slot-1', '2026-04-05T09:00:00Z', '2026-04-05T10:30:00Z')],
+    });
+
+    const progress: Array<{ processed: number; total: number }> = [];
+    const result = await service.solveAsync(spec, undefined, {
+      onProgress: (processed, total) => progress.push({ processed, total }),
+    });
+
+    expect(result.assignments).toHaveLength(1);
+    expect(result.unscheduled).toHaveLength(2);
+    expect(progress[progress.length - 1]).toEqual({ processed: 3, total: 3 });
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGenerationService.test.ts
@@ -44,8 +44,16 @@ describe('SchedulerMatchupGenerationService', () => {
 
     repo.listLeagueSeasonIdsBySeasonAndAccount.mockResolvedValue([BigInt(LEAGUE_SEASON_ID)]);
     repo.listLeagueTeamsWithDivision.mockResolvedValue([
-      { leagueseasonid: BigInt(LEAGUE_SEASON_ID), teamseasonid: BigInt(1), divisionseasonid: null },
-      { leagueseasonid: BigInt(LEAGUE_SEASON_ID), teamseasonid: BigInt(2), divisionseasonid: null },
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(1),
+        divisionseasonid: BigInt(50),
+      },
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(2),
+        divisionseasonid: BigInt(50),
+      },
     ]);
 
     service = new SchedulerMatchupGenerationService(repo, makeGeneratorStub(makeEmptyResult()));
@@ -76,13 +84,56 @@ describe('SchedulerMatchupGenerationService', () => {
       {
         leagueSeasonId: LEAGUE_SEASON_ID,
         teams: [
-          { teamSeasonId: '1', divisionSeasonId: null },
-          { teamSeasonId: '2', divisionSeasonId: null },
+          { teamSeasonId: '1', divisionSeasonId: '50' },
+          { teamSeasonId: '2', divisionSeasonId: '50' },
         ],
         inDivisionGameCount: 2,
         crossDivisionGameCount: 1,
       },
     ]);
+  });
+
+  it('excludes teams not assigned to a division (inactive teams)', async () => {
+    repo.listLeagueTeamsWithDivision.mockResolvedValue([
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(1),
+        divisionseasonid: BigInt(50),
+      },
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(2),
+        divisionseasonid: BigInt(50),
+      },
+      {
+        leagueseasonid: BigInt(LEAGUE_SEASON_ID),
+        teamseasonid: BigInt(3),
+        divisionseasonid: null,
+      },
+    ]);
+    const generatorStub = makeGeneratorStub(makeEmptyResult());
+    service = new SchedulerMatchupGenerationService(repo, generatorStub);
+
+    await service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest());
+
+    expect(generatorStub.generate).toHaveBeenCalledWith([
+      expect.objectContaining({
+        teams: [
+          { teamSeasonId: '1', divisionSeasonId: '50' },
+          { teamSeasonId: '2', divisionSeasonId: '50' },
+        ],
+      }),
+    ]);
+  });
+
+  it('throws ValidationError when a league has only teams without a division', async () => {
+    repo.listLeagueTeamsWithDivision.mockResolvedValue([
+      { leagueseasonid: BigInt(LEAGUE_SEASON_ID), teamseasonid: BigInt(1), divisionseasonid: null },
+    ]);
+
+    await expect(service.generateForSeason(ACCOUNT_ID, SEASON_ID, makeRequest())).rejects.toThrow(
+      ValidationError,
+    );
   });
 
   it('throws NotFoundError when a requested leagueSeasonId does not belong to the account/season', async () => {

--- a/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGeneratorService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerMatchupGeneratorService.test.ts
@@ -270,5 +270,64 @@ describe('SchedulerMatchupGeneratorService', () => {
         expect(['B1', 'B2']).toContain(m.visitorTeamSeasonId);
       }
     });
+
+    it('packs each league into rounds so a team is not scheduled twice before others play', () => {
+      const league = makeLeague({
+        leagueSeasonId: 'ls-rr',
+        teams: [
+          { teamSeasonId: 'T1', divisionSeasonId: null },
+          { teamSeasonId: 'T2', divisionSeasonId: null },
+          { teamSeasonId: 'T3', divisionSeasonId: null },
+          { teamSeasonId: 'T4', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 1,
+        crossDivisionGameCount: 0,
+      });
+
+      const result = service.generate([league]);
+
+      // 4 teams → a round is 2 games; the first round must cover all 4 distinct teams,
+      // i.e. no team appears twice before every team has played once.
+      const firstRound = result.matchups.slice(0, 2);
+      const teamsInFirstRound = new Set(
+        firstRound.flatMap((m) => [m.homeTeamSeasonId, m.visitorTeamSeasonId]),
+      );
+      expect(teamsInFirstRound.size).toBe(4);
+    });
+
+    it('interleaves leagues round-robin so no league claims the earliest slots', () => {
+      const leagueA = makeLeague({
+        leagueSeasonId: 'ls-A',
+        teams: [
+          { teamSeasonId: 'A1', divisionSeasonId: null },
+          { teamSeasonId: 'A2', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 3,
+        crossDivisionGameCount: 0,
+      });
+
+      const leagueB = makeLeague({
+        leagueSeasonId: 'ls-B',
+        teams: [
+          { teamSeasonId: 'B1', divisionSeasonId: null },
+          { teamSeasonId: 'B2', divisionSeasonId: null },
+        ],
+        inDivisionGameCount: 3,
+        crossDivisionGameCount: 0,
+      });
+
+      const result = service.generate([leagueA, leagueB]);
+
+      // Each league has one pairing repeated 3 times; merged by index the league ids
+      // must alternate rather than emitting all of ls-A before ls-B.
+      expect(result.matchups.map((m) => m.leagueSeasonId)).toEqual([
+        'ls-A',
+        'ls-B',
+        'ls-A',
+        'ls-B',
+        'ls-A',
+        'ls-B',
+      ]);
+    });
   });
 });

--- a/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
@@ -46,6 +46,15 @@ class FakeRunRepository implements ISchedulerRunRepository {
     return row && row.accountid === accountid && row.seasonid === seasonid ? row : null;
   }
 
+  async claimQueued(runid: string, total: number): Promise<boolean> {
+    const row = this.rows.get(runid);
+    if (!row || row.status !== 'queued') return false;
+    row.status = 'running';
+    row.processed = 0;
+    row.total = total;
+    return true;
+  }
+
   async update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun> {
     const row = this.rows.get(runid);
     if (!row) throw new Error(`run ${runid} not found`);
@@ -181,6 +190,29 @@ describe('SchedulerRunService', () => {
     const second = await service.enqueue(1n, 5n, request, 'key-1');
     expect(second.runId).toBe(first.runId);
     expect(repo.createCalls).toBe(1);
+
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+    expect(solveAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not double-process when concurrent retries resume a queued run', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+    const service = new SchedulerRunService(repo);
+
+    const first = await service.enqueue(1n, 5n, request, 'key-1');
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+    expect(solveAsync).toHaveBeenCalledTimes(1);
+
+    const stuck = repo.rows.get(first.runId);
+    if (!stuck) throw new Error('expected run row to exist');
+    stuck.status = 'queued';
+
+    await Promise.all([
+      service.enqueue(1n, 5n, request, 'key-1'),
+      service.enqueue(1n, 5n, request, 'key-1'),
+    ]);
 
     await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
     expect(solveAsync).toHaveBeenCalledTimes(2);

--- a/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
@@ -11,6 +11,8 @@ import type {
   SchedulerRunProgressUpdate,
 } from '../../repositories/interfaces/ISchedulerRunRepository.js';
 import { SchedulerRunService } from '../schedulerRunService.js';
+import type { SchedulerEngineService } from '../schedulerEngineService.js';
+import type { SchedulerProblemSpecService } from '../schedulerProblemSpecService.js';
 import { ServiceFactory } from '../serviceFactory.js';
 
 class FakeRunRepository implements ISchedulerRunRepository {
@@ -93,12 +95,20 @@ const stubServices = (problemSpec: SchedulerProblemSpec, solveResult: SchedulerS
     options?.onProgress?.(problemSpec.games.length, problemSpec.games.length);
     return solveResult;
   });
-  vi.spyOn(ServiceFactory, 'getSchedulerProblemSpecService').mockReturnValue({
-    buildProblemSpecForSolve: vi.fn(async () => ({ problemSpec, timeZoneId: 'UTC' })),
-  } as unknown as ReturnType<typeof ServiceFactory.getSchedulerProblemSpecService>);
-  vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue({
-    solveAsync,
-  } as unknown as ReturnType<typeof ServiceFactory.getSchedulerEngineService>);
+  const problemSpecService: Pick<SchedulerProblemSpecService, 'buildProblemSpecForSolve'> = {
+    buildProblemSpecForSolve: vi.fn(async () => ({
+      problemSpec,
+      timeZoneId: 'UTC',
+      fieldGameLengthById: {},
+    })),
+  };
+  const engineService: Pick<SchedulerEngineService, 'solveAsync'> = { solveAsync };
+  vi.spyOn(ServiceFactory, 'getSchedulerProblemSpecService').mockReturnValue(
+    problemSpecService as SchedulerProblemSpecService,
+  );
+  vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue(
+    engineService as SchedulerEngineService,
+  );
   return { solveAsync };
 };
 
@@ -176,6 +186,36 @@ describe('SchedulerRunService', () => {
     expect(solveAsync).toHaveBeenCalledTimes(2);
   });
 
+  it('returns the existing run when create races on the idempotency key (P2002)', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+
+    repo.create = async (data: SchedulerRunCreateData): Promise<schedulerrun> => {
+      const winner: schedulerrun = {
+        runid: data.runid,
+        accountid: data.accountid,
+        seasonid: data.seasonid,
+        status: 'queued',
+        processed: 0,
+        total: data.total,
+        result: null,
+        error: null,
+        createdat: new Date('2026-06-21T00:00:00Z'),
+        updatedat: new Date('2026-06-21T00:00:00Z'),
+      };
+      repo.rows.set(data.runid, winner);
+      throw Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    };
+
+    const service = new SchedulerRunService(repo);
+    const result = await service.enqueue(1n, 5n, request, 'key-race');
+
+    expect(result.status).toBe('queued');
+    await waitFor(() => repo.rows.get(result.runId)?.status === 'completed');
+    expect(solveAsync).toHaveBeenCalledTimes(1);
+  });
+
   it('starts a fresh run for each generate when no idempotency key is supplied', async () => {
     const repo = new FakeRunRepository();
     const problemSpec = buildProblemSpec(2);
@@ -197,11 +237,14 @@ describe('SchedulerRunService', () => {
     const repo = new FakeRunRepository();
     const problemSpec = buildProblemSpec(2);
     stubServices(problemSpec, buildResult());
-    vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue({
+    const failingEngine: Pick<SchedulerEngineService, 'solveAsync'> = {
       solveAsync: vi.fn(async () => {
         throw new Error('boom');
       }),
-    } as unknown as ReturnType<typeof ServiceFactory.getSchedulerEngineService>);
+    };
+    vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue(
+      failingEngine as SchedulerEngineService,
+    );
     const service = new SchedulerRunService(repo);
 
     const enqueued = await service.enqueue(1n, 5n, request);

--- a/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { schedulerrun } from '#prisma/client';
+import type {
+  SchedulerProblemSpec,
+  SchedulerSeasonSolveRequest,
+  SchedulerSolveResult,
+} from '@draco/shared-schemas';
+import type {
+  ISchedulerRunRepository,
+  SchedulerRunCreateData,
+  SchedulerRunProgressUpdate,
+} from '../../repositories/interfaces/ISchedulerRunRepository.js';
+import { SchedulerRunService } from '../schedulerRunService.js';
+import { ServiceFactory } from '../serviceFactory.js';
+
+class FakeRunRepository implements ISchedulerRunRepository {
+  rows = new Map<string, schedulerrun>();
+  createCalls = 0;
+
+  async create(data: SchedulerRunCreateData): Promise<schedulerrun> {
+    this.createCalls += 1;
+    const row: schedulerrun = {
+      runid: data.runid,
+      accountid: data.accountid,
+      seasonid: data.seasonid,
+      status: data.status,
+      processed: 0,
+      total: data.total,
+      result: null,
+      error: null,
+      createdat: new Date('2026-06-21T00:00:00Z'),
+      updatedat: new Date('2026-06-21T00:00:00Z'),
+    };
+    this.rows.set(data.runid, row);
+    return row;
+  }
+
+  async findByRunId(
+    accountid: bigint,
+    seasonid: bigint,
+    runid: string,
+  ): Promise<schedulerrun | null> {
+    const row = this.rows.get(runid);
+    return row && row.accountid === accountid && row.seasonid === seasonid ? row : null;
+  }
+
+  async update(runid: string, data: SchedulerRunProgressUpdate): Promise<schedulerrun> {
+    const row = this.rows.get(runid);
+    if (!row) throw new Error(`run ${runid} not found`);
+    if (data.status !== undefined) row.status = data.status;
+    if (data.processed !== undefined) row.processed = data.processed;
+    if (data.total !== undefined) row.total = data.total;
+    if (data.result !== undefined) row.result = data.result as schedulerrun['result'];
+    if (data.error !== undefined) row.error = data.error;
+    return row;
+  }
+}
+
+const buildProblemSpec = (gameCount: number): SchedulerProblemSpec => ({
+  season: { id: 's1', name: 'S1', startDate: '2026-04-01', endDate: '2026-08-31' },
+  teams: [
+    { id: 't1', teamSeasonId: 'ts1', league: { id: 'l1', name: 'Open' } },
+    { id: 't2', teamSeasonId: 'ts2', league: { id: 'l1', name: 'Open' } },
+  ],
+  fields: [{ id: 'f1', name: 'Field 1' }],
+  umpires: [],
+  games: Array.from({ length: gameCount }, (_, i) => ({
+    id: `game-${i + 1}`,
+    leagueSeasonId: 'l1',
+    homeTeamSeasonId: 'ts1',
+    visitorTeamSeasonId: 'ts2',
+  })),
+  fieldSlots: [
+    {
+      id: 'slot-1',
+      fieldId: 'f1',
+      startTime: '2026-04-05T09:00:00Z',
+      endTime: '2026-04-05T11:00:00Z',
+    },
+  ],
+});
+
+const buildResult = (): SchedulerSolveResult => ({
+  runId: 'placeholder',
+  status: 'completed',
+  metrics: { totalGames: 2, scheduledGames: 2, unscheduledGames: 0, objectiveValue: 2 },
+  assignments: [],
+  unscheduled: [],
+});
+
+const stubServices = (problemSpec: SchedulerProblemSpec, solveResult: SchedulerSolveResult) => {
+  const solveAsync = vi.fn(async (_spec, _ctx, options) => {
+    options?.onProgress?.(problemSpec.games.length, problemSpec.games.length);
+    return solveResult;
+  });
+  vi.spyOn(ServiceFactory, 'getSchedulerProblemSpecService').mockReturnValue({
+    buildProblemSpecForSolve: vi.fn(async () => ({ problemSpec, timeZoneId: 'UTC' })),
+  } as unknown as ReturnType<typeof ServiceFactory.getSchedulerProblemSpecService>);
+  vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue({
+    solveAsync,
+  } as unknown as ReturnType<typeof ServiceFactory.getSchedulerEngineService>);
+  return { solveAsync };
+};
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 1000): Promise<void> => {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timeout waiting for condition');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+
+const request: SchedulerSeasonSolveRequest = {
+  objectives: { primary: 'maximize_scheduled_games' },
+};
+
+describe('SchedulerRunService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('enqueues a queued run and processes it to completion', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+    const service = new SchedulerRunService(repo);
+
+    const enqueued = await service.enqueue(1n, 5n, request);
+    expect(enqueued.status).toBe('queued');
+    expect(enqueued.progress).toEqual({ processed: 0, total: 2 });
+    expect(repo.createCalls).toBe(1);
+
+    await waitFor(() => repo.rows.get(enqueued.runId)?.status === 'completed');
+
+    const finalState = await service.getRun(1n, 5n, enqueued.runId);
+    expect(finalState?.status).toBe('completed');
+    expect(finalState?.progress).toEqual({ processed: 2, total: 2 });
+    expect(finalState?.result?.status).toBe('completed');
+    expect(solveAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the existing run only when the same idempotency key is supplied', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+    const service = new SchedulerRunService(repo);
+
+    const first = await service.enqueue(1n, 5n, request, 'key-1');
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+
+    const second = await service.enqueue(1n, 5n, request, 'key-1');
+    expect(second.runId).toBe(first.runId);
+    expect(repo.createCalls).toBe(1);
+    expect(solveAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh run for each generate when no idempotency key is supplied', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+    const service = new SchedulerRunService(repo);
+
+    const first = await service.enqueue(1n, 5n, request);
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+
+    const second = await service.enqueue(1n, 5n, request);
+    await waitFor(() => repo.rows.get(second.runId)?.status === 'completed');
+
+    expect(second.runId).not.toBe(first.runId);
+    expect(repo.createCalls).toBe(2);
+    expect(solveAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('persists a failure when the solve throws', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    stubServices(problemSpec, buildResult());
+    vi.spyOn(ServiceFactory, 'getSchedulerEngineService').mockReturnValue({
+      solveAsync: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    } as unknown as ReturnType<typeof ServiceFactory.getSchedulerEngineService>);
+    const service = new SchedulerRunService(repo);
+
+    const enqueued = await service.enqueue(1n, 5n, request);
+    await waitFor(() => repo.rows.get(enqueued.runId)?.status === 'failed');
+
+    const failedState = await service.getRun(1n, 5n, enqueued.runId);
+    expect(failedState?.status).toBe('failed');
+    expect(failedState?.error).toBe('boom');
+  });
+
+  it('returns null for an unknown run', async () => {
+    const repo = new FakeRunRepository();
+    const service = new SchedulerRunService(repo);
+    expect(await service.getRun(1n, 5n, 'nope')).toBeNull();
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/schedulerRunService.test.ts
@@ -154,6 +154,28 @@ describe('SchedulerRunService', () => {
     expect(solveAsync).toHaveBeenCalledTimes(1);
   });
 
+  it('restarts processing when an idempotent retry finds a still-queued run', async () => {
+    const repo = new FakeRunRepository();
+    const problemSpec = buildProblemSpec(2);
+    const { solveAsync } = stubServices(problemSpec, buildResult());
+    const service = new SchedulerRunService(repo);
+
+    const first = await service.enqueue(1n, 5n, request, 'key-1');
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+    expect(solveAsync).toHaveBeenCalledTimes(1);
+
+    const stuck = repo.rows.get(first.runId);
+    if (!stuck) throw new Error('expected run row to exist');
+    stuck.status = 'queued';
+
+    const second = await service.enqueue(1n, 5n, request, 'key-1');
+    expect(second.runId).toBe(first.runId);
+    expect(repo.createCalls).toBe(1);
+
+    await waitFor(() => repo.rows.get(first.runId)?.status === 'completed');
+    expect(solveAsync).toHaveBeenCalledTimes(2);
+  });
+
   it('starts a fresh run for each generate when no idempotency key is supplied', async () => {
     const repo = new FakeRunRepository();
     const problemSpec = buildProblemSpec(2);

--- a/draco-nodejs/backend/src/services/schedulerEngineService.ts
+++ b/draco-nodejs/backend/src/services/schedulerEngineService.ts
@@ -42,6 +42,53 @@ interface SlotCandidate {
   umpireIds: string[];
 }
 
+interface SolveSchedules {
+  teamSchedule: Map<string, Interval[]>;
+  fieldSchedule: Map<string, Interval[]>;
+  umpireSchedule: Map<string, Interval[]>;
+  teamDailyCounts: Map<string, Map<string, number>>;
+  umpireDailyCounts: Map<string, Map<string, number>>;
+}
+
+interface SolveContext {
+  problemSpec: SchedulerProblemSpec;
+  runId: string;
+  timeZoneId: string;
+  accountLabel: string;
+  solveStart: number;
+  sortedGames: SchedulerGameRequest[];
+  sortedSlots: SchedulerFieldSlot[];
+  maxPlaceable: number;
+  hard: SchedulerHardConstraints;
+  soft?: SchedulerSoftConstraints;
+  availability: Map<string, Interval[]>;
+  seasonExclusions: Interval[];
+  teamBlackouts: Map<string, Interval[]>;
+  teamExclusions: Map<string, Interval[]>;
+  leagueExclusions: Map<string, Interval[]>;
+  umpireExclusions: Map<string, Interval[]>;
+  umpireDailyLimitById: Map<string, number>;
+  fieldCapacityById: Map<string, number>;
+  fieldLightsById: Map<string, boolean>;
+  fieldGameLengthById: Map<string, number>;
+  schedules: SolveSchedules;
+  assignments: SchedulerAssignment[];
+  unscheduled: SchedulerUnscheduledReason[];
+  earlyOutTriggered: boolean;
+}
+
+export interface SolveContextInput {
+  accountId?: bigint;
+  idempotencyKey?: string;
+  timeZoneId?: string;
+  fieldGameLengthById?: Record<string, number>;
+}
+
+export interface SolveProgressOptions {
+  onProgress?: (processed: number, total: number) => void;
+  yieldEveryN?: number;
+}
+
 const normalizeSchedulerId = (value: string | number): string => {
   return String(value).trim();
 };
@@ -65,7 +112,7 @@ const stableStringify = (value: unknown): string => {
   return JSON.stringify(value);
 };
 
-const buildDeterministicRunId = ({
+export const buildDeterministicRunId = ({
   accountId,
   idempotencyKey,
   problemSpec,
@@ -92,10 +139,45 @@ const buildDeterministicRunId = ({
 };
 
 export class SchedulerEngineService {
-  solve(
+  solve(problemSpec: SchedulerProblemSpec, context?: SolveContextInput): SchedulerSolveResult {
+    const ctx = this.prepareSolve(problemSpec, context);
+    for (let gameIndex = 0; gameIndex < ctx.sortedGames.length; gameIndex += 1) {
+      if (this.placeGameAt(ctx, gameIndex)) {
+        break;
+      }
+    }
+    return this.finalizeSolve(ctx);
+  }
+
+  async solveAsync(
     problemSpec: SchedulerProblemSpec,
-    context?: { accountId?: bigint; idempotencyKey?: string; timeZoneId?: string },
-  ): SchedulerSolveResult {
+    context?: SolveContextInput,
+    options?: SolveProgressOptions,
+  ): Promise<SchedulerSolveResult> {
+    const ctx = this.prepareSolve(problemSpec, context);
+    const total = ctx.sortedGames.length;
+    const yieldEveryN = options?.yieldEveryN && options.yieldEveryN > 0 ? options.yieldEveryN : 50;
+
+    for (let gameIndex = 0; gameIndex < total; gameIndex += 1) {
+      const earlyOut = this.placeGameAt(ctx, gameIndex);
+      if (earlyOut) {
+        options?.onProgress?.(total, total);
+        break;
+      }
+      options?.onProgress?.(gameIndex + 1, total);
+      if ((gameIndex + 1) % yieldEveryN === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+    }
+
+    return this.finalizeSolve(ctx);
+  }
+
+  private prepareSolve(
+    problemSpec: SchedulerProblemSpec,
+    context?: SolveContextInput,
+  ): SolveContext {
+    const solveStart = Date.now();
     this.validateProblemSpec(problemSpec);
 
     const timeZoneId =
@@ -110,45 +192,29 @@ export class SchedulerEngineService {
         idempotencyKey: context?.idempotencyKey,
         problemSpec,
       });
-    const assignments: SchedulerAssignment[] = [];
-    const unscheduled: SchedulerUnscheduledReason[] = [];
 
-    const hard = this.withDefaultHardConstraints(problemSpec.constraints);
     const soft = problemSpec.constraints?.soft;
-    const availability = this.groupUmpireAvailability(
-      problemSpec.umpireAvailability,
-      problemSpec.umpires,
-      problemSpec.season,
-    );
-    const seasonExclusions = this.groupSeasonExclusions(problemSpec.seasonExclusions);
-    const teamExclusions = this.groupTeamExclusions(problemSpec.teamExclusions);
-    const leagueExclusions = this.groupLeagueExclusions(problemSpec.leagueExclusions);
-    const umpireExclusions = this.groupUmpireExclusions(problemSpec.umpireExclusions);
-    const umpireDailyLimitById = this.buildUmpireDailyLimitIndex(problemSpec.umpires);
-    const fieldCapacityById = this.buildFieldCapacityIndex(problemSpec.fields);
-    const fieldLightsById = this.buildFieldLightsIndex(problemSpec.fields);
-    const teamBlackouts = this.groupTeamBlackouts(problemSpec.teamBlackouts);
+    const schedules: SolveSchedules = {
+      teamSchedule: new Map(),
+      fieldSchedule: new Map(),
+      umpireSchedule: new Map(),
+      teamDailyCounts: new Map(),
+      umpireDailyCounts: new Map(),
+    };
 
-    const teamSchedule: Map<string, Interval[]> = new Map();
-    const fieldSchedule: Map<string, Interval[]> = new Map();
-    const umpireSchedule: Map<string, Interval[]> = new Map();
-    const teamDailyCounts: Map<string, Map<string, number>> = new Map();
-    const umpireDailyCounts: Map<string, Map<string, number>> = new Map();
+    this.seedFixedOccupancy(problemSpec.fixedGames, schedules, timeZoneId);
 
-    this.seedFixedOccupancy(
-      problemSpec.fixedGames,
-      { teamSchedule, fieldSchedule, umpireSchedule, teamDailyCounts, umpireDailyCounts },
-      timeZoneId,
-    );
-
-    const sortedGames = [...problemSpec.games].sort((a, b) => {
-      const aStart = a.earliestStart ? new Date(a.earliestStart).getTime() : 0;
-      const bStart = b.earliestStart ? new Date(b.earliestStart).getTime() : 0;
-      if (aStart === bStart) {
-        return String(a.id).localeCompare(String(b.id));
-      }
-      return aStart - bStart;
-    });
+    const sortedGames = problemSpec.games
+      .map((game, index) => ({ game, index }))
+      .sort((a, b) => {
+        const aStart = a.game.earliestStart ? new Date(a.game.earliestStart).getTime() : 0;
+        const bStart = b.game.earliestStart ? new Date(b.game.earliestStart).getTime() : 0;
+        if (aStart !== bStart) {
+          return aStart - bStart;
+        }
+        return a.index - b.index;
+      })
+      .map((entry) => entry.game);
 
     const sortedSlots = [...problemSpec.fieldSlots].sort((a, b) => {
       const aStart = new Date(a.startTime).getTime();
@@ -159,48 +225,100 @@ export class SchedulerEngineService {
       return aStart - bStart;
     });
 
-    for (const game of sortedGames) {
-      const durationMinutes = this.resolveGameDuration(game, problemSpec.season);
-      const candidate: GameCandidateContext = { game, durationMinutes };
-      const assignment = this.findAssignment(
-        candidate,
-        sortedSlots,
-        hard,
-        availability,
-        seasonExclusions,
-        teamBlackouts,
-        teamExclusions,
-        leagueExclusions,
-        umpireExclusions,
-        umpireDailyLimitById,
-        fieldCapacityById,
-        fieldLightsById,
-        {
-          teamSchedule,
-          fieldSchedule,
-          umpireSchedule,
-          teamDailyCounts,
-          umpireDailyCounts,
-        },
-        timeZoneId,
-        soft,
-      );
+    const fieldCapacityById = this.buildFieldCapacityIndex(problemSpec.fields);
+    const maxPlaceable = sortedSlots.reduce(
+      (total, slot) => total + (fieldCapacityById.get(slot.fieldId) ?? 1),
+      0,
+    );
+    const accountLabel = context?.accountId ? context.accountId.toString() : 'n/a';
 
-      if (assignment) {
-        assignments.push(assignment);
-      } else {
-        unscheduled.push({
-          gameId: game.id,
-          reason: 'No valid slot found given hard constraints',
+    console.log(
+      `[scheduler:solve account=${accountLabel} run=${runId}] start: games=${problemSpec.games.length} slots=${problemSpec.fieldSlots.length} maxPlaceable=${maxPlaceable} softActive=${this.hasActiveSoftConstraints(soft)} timeZone=${timeZoneId}`,
+    );
+
+    return {
+      problemSpec,
+      runId,
+      timeZoneId,
+      accountLabel,
+      solveStart,
+      sortedGames,
+      sortedSlots,
+      maxPlaceable,
+      hard: this.withDefaultHardConstraints(problemSpec.constraints),
+      soft,
+      availability: this.groupUmpireAvailability(
+        problemSpec.umpireAvailability,
+        problemSpec.umpires,
+        problemSpec.season,
+      ),
+      seasonExclusions: this.groupSeasonExclusions(problemSpec.seasonExclusions),
+      teamBlackouts: this.groupTeamBlackouts(problemSpec.teamBlackouts),
+      teamExclusions: this.groupTeamExclusions(problemSpec.teamExclusions),
+      leagueExclusions: this.groupLeagueExclusions(problemSpec.leagueExclusions),
+      umpireExclusions: this.groupUmpireExclusions(problemSpec.umpireExclusions),
+      umpireDailyLimitById: this.buildUmpireDailyLimitIndex(problemSpec.umpires),
+      fieldCapacityById,
+      fieldLightsById: this.buildFieldLightsIndex(problemSpec.fields),
+      fieldGameLengthById: new Map(Object.entries(context?.fieldGameLengthById ?? {})),
+      schedules,
+      assignments: [],
+      unscheduled: [],
+      earlyOutTriggered: false,
+    };
+  }
+
+  private placeGameAt(ctx: SolveContext, gameIndex: number): boolean {
+    if (ctx.assignments.length >= ctx.maxPlaceable) {
+      for (let remaining = gameIndex; remaining < ctx.sortedGames.length; remaining += 1) {
+        ctx.unscheduled.push({
+          gameId: ctx.sortedGames[remaining].id,
+          reason: 'No field capacity remaining',
         });
       }
+      ctx.earlyOutTriggered = true;
+      return true;
     }
 
+    const game = ctx.sortedGames[gameIndex];
+    const durationMinutes = this.resolveGameDuration(game, ctx.problemSpec.season);
+    const candidate: GameCandidateContext = { game, durationMinutes };
+    const assignment = this.findAssignment(
+      candidate,
+      ctx.sortedSlots,
+      ctx.hard,
+      ctx.availability,
+      ctx.seasonExclusions,
+      ctx.teamBlackouts,
+      ctx.teamExclusions,
+      ctx.leagueExclusions,
+      ctx.umpireExclusions,
+      ctx.umpireDailyLimitById,
+      ctx.fieldCapacityById,
+      ctx.fieldLightsById,
+      ctx.fieldGameLengthById,
+      ctx.schedules,
+      ctx.timeZoneId,
+      ctx.soft,
+    );
+
+    if (assignment) {
+      ctx.assignments.push(assignment);
+    } else {
+      ctx.unscheduled.push({
+        gameId: game.id,
+        reason: 'No valid slot found given hard constraints',
+      });
+    }
+    return false;
+  }
+
+  private finalizeSolve(ctx: SolveContext): SchedulerSolveResult {
     const metrics = {
-      totalGames: problemSpec.games.length,
-      scheduledGames: assignments.length,
-      unscheduledGames: unscheduled.length,
-      objectiveValue: assignments.length,
+      totalGames: ctx.problemSpec.games.length,
+      scheduledGames: ctx.assignments.length,
+      unscheduledGames: ctx.unscheduled.length,
+      objectiveValue: ctx.assignments.length,
     };
 
     const status: SchedulerSolveResult['status'] =
@@ -210,12 +328,20 @@ export class SchedulerEngineService {
           ? 'partial'
           : 'infeasible';
 
+    const reasonHistogram = ctx.unscheduled.reduce<Record<string, number>>((acc, item) => {
+      acc[item.reason] = (acc[item.reason] ?? 0) + 1;
+      return acc;
+    }, {});
+    console.log(
+      `[scheduler:solve account=${ctx.accountLabel} run=${ctx.runId}] done: status=${status} scheduled=${metrics.scheduledGames} unscheduled=${metrics.unscheduledGames} earlyOut=${ctx.earlyOutTriggered} durationMs=${Date.now() - ctx.solveStart} reasons=${JSON.stringify(reasonHistogram)}`,
+    );
+
     return {
-      runId,
+      runId: ctx.runId,
       status,
       metrics,
-      assignments,
-      unscheduled,
+      assignments: ctx.assignments,
+      unscheduled: ctx.unscheduled,
     };
   }
 
@@ -621,6 +747,7 @@ export class SchedulerEngineService {
     umpireDailyLimitById: Map<string, number>,
     fieldCapacityById: Map<string, number>,
     fieldLightsById: Map<string, boolean>,
+    fieldGameLengthById: Map<string, number>,
     schedules: {
       teamSchedule: Map<string, Interval[]>;
       fieldSchedule: Map<string, Interval[]>;
@@ -633,7 +760,8 @@ export class SchedulerEngineService {
     const start = new Date(slot.startTime);
     const end = new Date(slot.endTime);
 
-    const durationEnd = new Date(start.getTime() + candidate.durationMinutes * 60000);
+    const durationMinutes = fieldGameLengthById.get(slot.fieldId) ?? candidate.durationMinutes;
+    const durationEnd = new Date(start.getTime() + durationMinutes * 60000);
     if (durationEnd > end) {
       return null;
     }
@@ -788,6 +916,7 @@ export class SchedulerEngineService {
     umpireDailyLimitById: Map<string, number>,
     fieldCapacityById: Map<string, number>,
     fieldLightsById: Map<string, boolean>,
+    fieldGameLengthById: Map<string, number>,
     schedules: {
       teamSchedule: Map<string, Interval[]>;
       fieldSchedule: Map<string, Interval[]>;
@@ -827,6 +956,7 @@ export class SchedulerEngineService {
           umpireDailyLimitById,
           fieldCapacityById,
           fieldLightsById,
+          fieldGameLengthById,
           schedules,
           timeZoneId,
         );

--- a/draco-nodejs/backend/src/services/schedulerMatchupGenerationService.ts
+++ b/draco-nodejs/backend/src/services/schedulerMatchupGenerationService.ts
@@ -51,14 +51,17 @@ export class SchedulerMatchupGenerationService {
 
     const teamsByLeague = new Map<
       string,
-      Array<{ teamSeasonId: string; divisionSeasonId: string | null }>
+      Array<{ teamSeasonId: string; divisionSeasonId: string }>
     >();
     for (const row of teamRows) {
+      if (row.divisionseasonid === null || row.divisionseasonid === undefined) {
+        continue;
+      }
       const key = row.leagueseasonid.toString();
       const list = teamsByLeague.get(key) ?? [];
       list.push({
         teamSeasonId: row.teamseasonid.toString(),
-        divisionSeasonId: row.divisionseasonid?.toString() ?? null,
+        divisionSeasonId: row.divisionseasonid.toString(),
       });
       teamsByLeague.set(key, list);
     }
@@ -67,7 +70,7 @@ export class SchedulerMatchupGenerationService {
       const teams = teamsByLeague.get(lc.leagueSeasonId) ?? [];
       if (teams.length === 0) {
         throw new ValidationError(
-          `League season ${lc.leagueSeasonId} has no teams enrolled for this season`,
+          `League season ${lc.leagueSeasonId} has no teams assigned to a division for this season`,
         );
       }
       return {

--- a/draco-nodejs/backend/src/services/schedulerMatchupGeneratorService.ts
+++ b/draco-nodejs/backend/src/services/schedulerMatchupGeneratorService.ts
@@ -18,16 +18,61 @@ export interface GeneratorLeagueInput {
 
 export class SchedulerMatchupGeneratorService {
   generate(leagues: GeneratorLeagueInput[]): SchedulerGenerateMatchupsResult {
-    const allMatchups: SchedulerGameRequest[] = [];
     const summaries: SchedulerMatchupGenerationSummary[] = [];
+    const leagueMatchups: SchedulerGameRequest[][] = [];
 
     for (const league of leagues) {
       const { matchups, summary } = this.generateLeagueMatchups(league);
-      allMatchups.push(...matchups);
+      leagueMatchups.push(this.packIntoRounds(matchups));
       summaries.push(summary);
     }
 
-    return { matchups: allMatchups, summary: summaries };
+    return { matchups: this.interleaveByIndex(leagueMatchups), summary: summaries };
+  }
+
+  /**
+   * Greedily orders a league's matchups into round-robin rounds where each team appears at
+   * most once per round. A team's second game cannot land in the same round as its first, so
+   * every team gets a game before any team gets a second one — to the extent the matchup set
+   * allows. Relative order is otherwise preserved for determinism.
+   */
+  private packIntoRounds(matchups: SchedulerGameRequest[]): SchedulerGameRequest[] {
+    const ordered: SchedulerGameRequest[] = [];
+    let remaining = matchups;
+    while (remaining.length > 0) {
+      const usedTeams = new Set<string>();
+      const leftover: SchedulerGameRequest[] = [];
+      for (const matchup of remaining) {
+        if (usedTeams.has(matchup.homeTeamSeasonId) || usedTeams.has(matchup.visitorTeamSeasonId)) {
+          leftover.push(matchup);
+        } else {
+          ordered.push(matchup);
+          usedTeams.add(matchup.homeTeamSeasonId);
+          usedTeams.add(matchup.visitorTeamSeasonId);
+        }
+      }
+      remaining = leftover;
+    }
+    return ordered;
+  }
+
+  /**
+   * Round-robin merge the per-league lists by position. Each league list is already
+   * round-major, so taking index 0 from every league, then index 1, and so on keeps each
+   * league's repeats spread out while preventing any single league from claiming the
+   * earliest slots ahead of the others.
+   */
+  private interleaveByIndex(lists: SchedulerGameRequest[][]): SchedulerGameRequest[] {
+    const merged: SchedulerGameRequest[] = [];
+    const maxLength = lists.reduce((max, list) => Math.max(max, list.length), 0);
+    for (let index = 0; index < maxLength; index += 1) {
+      for (const list of lists) {
+        if (index < list.length) {
+          merged.push(list[index]);
+        }
+      }
+    }
+    return merged;
   }
 
   private generateLeagueMatchups(league: GeneratorLeagueInput): {

--- a/draco-nodejs/backend/src/services/schedulerProblemSpecService.ts
+++ b/draco-nodejs/backend/src/services/schedulerProblemSpecService.ts
@@ -66,6 +66,12 @@ const formatMinutesToHhmm = (totalMinutes: number): string => {
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 };
 
+interface SkippedField {
+  id: string;
+  name: string;
+  reason: 'not schedule-enabled' | 'no open hours';
+}
+
 export class SchedulerProblemSpecService {
   constructor(
     private readonly schedulerRepo: ISchedulerProblemSpecRepository = RepositoryFactory.getSchedulerProblemSpecRepository(),
@@ -112,7 +118,11 @@ export class SchedulerProblemSpecService {
     accountId: bigint,
     seasonId: bigint,
     request: SchedulerSeasonSolveRequest,
-  ): Promise<{ problemSpec: SchedulerProblemSpec; timeZoneId: string }> {
+  ): Promise<{
+    problemSpec: SchedulerProblemSpec;
+    timeZoneId: string;
+    fieldGameLengthById: Record<string, number>;
+  }> {
     const hasMatchups = Boolean(request.matchups && request.matchups.length > 0);
     const base = await this.loadBaseSpecData(accountId, seasonId, hasMatchups);
 
@@ -148,40 +158,66 @@ export class SchedulerProblemSpecService {
                 maxGamesPerUmpirePerDayDefault,
             },
           };
-    const defaultSoft: NonNullable<SchedulerConstraints>['soft'] = {
-      avoidBackToBackGames: { enabled: true, minRestMinutes: 2880, weight: 3 },
-      spreadGamesAcrossDays: { enabled: true, weight: 2 },
-      balanceEarlyVsLate: { enabled: true, weight: 1 },
+    const problemSpec: SchedulerProblemSpec = {
+      season: base.season,
+      teams: base.teams,
+      fields: base.fields,
+      umpires: base.umpires,
+      games: normalizedGames,
+      fieldSlots: base.fieldSlots,
+      seasonExclusions: base.seasonExclusions,
+      teamExclusions: base.teamExclusions,
+      leagueExclusions: base.leagueExclusions,
+      umpireExclusions: base.umpireExclusions,
+      umpireAvailability: undefined,
+      teamBlackouts: undefined,
+      fixedGames: hasMatchups ? base.fixedGames : undefined,
+      constraints: constraintsWithHardDefaults,
+      objectives: request.objectives,
+      runId: undefined,
     };
-    const constraintsWithDefaults =
-      constraintsWithHardDefaults?.soft !== undefined
-        ? constraintsWithHardDefaults
-        : {
-            ...(constraintsWithHardDefaults ?? {}),
-            soft: defaultSoft,
-          };
+
+    this.logProblemSpecSummary(accountId, seasonId, base, problemSpec);
 
     return {
       timeZoneId: base.timeZoneId,
-      problemSpec: {
-        season: base.season,
-        teams: base.teams,
-        fields: base.fields,
-        umpires: base.umpires,
-        games: normalizedGames,
-        fieldSlots: base.fieldSlots,
-        seasonExclusions: base.seasonExclusions,
-        teamExclusions: base.teamExclusions,
-        leagueExclusions: base.leagueExclusions,
-        umpireExclusions: base.umpireExclusions,
-        umpireAvailability: undefined,
-        teamBlackouts: undefined,
-        fixedGames: hasMatchups ? base.fixedGames : undefined,
-        constraints: constraintsWithDefaults,
-        objectives: request.objectives,
-        runId: undefined,
-      },
+      problemSpec,
+      fieldGameLengthById: base.fieldGameLengthById,
     };
+  }
+
+  private logProblemSpecSummary(
+    accountId: bigint,
+    seasonId: bigint,
+    base: { fieldSlots: SchedulerFieldSlot[]; skippedFields: SkippedField[]; timeZoneId: string },
+    problemSpec: SchedulerProblemSpec,
+  ): void {
+    const prefix = `[scheduler:build account=${accountId.toString()} season=${seasonId.toString()}]`;
+    const fieldsWithSlots = new Set(problemSpec.fieldSlots.map((slot) => slot.fieldId)).size;
+    const soft = problemSpec.constraints?.soft;
+    const softActive = Boolean(
+      soft?.avoidBackToBackGames?.enabled ||
+      soft?.balanceEarlyVsLate?.enabled ||
+      soft?.spreadGamesAcrossDays?.enabled,
+    );
+    console.log(
+      `${prefix} games=${problemSpec.games.length} fields=${problemSpec.fields.length} fieldsWithSlots=${fieldsWithSlots} slots=${problemSpec.fieldSlots.length} teams=${problemSpec.teams.length} umpires=${problemSpec.umpires.length} ` +
+        `seasonExclusions=${problemSpec.seasonExclusions?.length ?? 0} teamExclusions=${problemSpec.teamExclusions?.length ?? 0} ` +
+        `leagueExclusions=${problemSpec.leagueExclusions?.length ?? 0} umpireExclusions=${problemSpec.umpireExclusions?.length ?? 0} ` +
+        `window=${problemSpec.season.startDate}..${problemSpec.season.endDate} timeZone=${base.timeZoneId} softActive=${softActive}`,
+    );
+
+    for (const skipped of base.skippedFields) {
+      console.warn(
+        `${prefix} field skipped (no slots): id=${skipped.id} name="${skipped.name}" reason=${skipped.reason}`,
+      );
+    }
+
+    if (problemSpec.fieldSlots.length === 0) {
+      console.warn(
+        `${prefix} produced 0 field slots — no games can be scheduled. Check field open hours and schedule-enabled flags.`,
+      );
+    }
   }
 
   private normalizeConstraints(
@@ -222,6 +258,8 @@ export class SchedulerProblemSpecService {
       leagueExclusions: SchedulerLeagueExclusion[];
       umpireExclusions: SchedulerUmpireExclusion[];
       fixedGames: SchedulerFixedGame[];
+      skippedFields: SkippedField[];
+      fieldGameLengthById: Record<string, number>;
     }
   > {
     const account = await this.schedulerRepo.findAccount(accountId);
@@ -335,7 +373,7 @@ export class SchedulerProblemSpecService {
     const openHoursByFieldId = this.groupOpenHoursByFieldId(openHoursRecords);
     const closedDatesByFieldId = this.groupClosedDatesByFieldId(closedDateRecords);
 
-    const fieldSlots = this.generateFieldSlots(
+    const { slots: fieldSlots, skippedFields } = this.generateFieldSlots(
       fields,
       openHoursByFieldId,
       closedDatesByFieldId,
@@ -402,6 +440,8 @@ export class SchedulerProblemSpecService {
       umpireExclusions,
       timeZoneId,
       fixedGames,
+      skippedFields,
+      fieldGameLengthById: Object.fromEntries(fieldGameLengthById),
     };
   }
 
@@ -476,17 +516,28 @@ export class SchedulerProblemSpecService {
     seasonConfig: SchedulerSeasonConfig,
     timeZoneId: string,
     window: { startDate: string; endDate: string },
-  ): SchedulerFieldSlot[] {
+  ): { slots: SchedulerFieldSlot[]; skippedFields: SkippedField[] } {
     const slots: SchedulerFieldSlot[] = [];
+    const skippedFields: SkippedField[] = [];
 
     for (const field of fields) {
       if (field.scheduleenabled !== true) {
+        skippedFields.push({
+          id: field.id.toString(),
+          name: field.name,
+          reason: 'not schedule-enabled',
+        });
         continue;
       }
 
       const fieldId = field.id.toString();
       const fieldOpenHours = openHoursByFieldId.get(fieldId) ?? [];
       if (fieldOpenHours.length === 0) {
+        skippedFields.push({
+          id: fieldId,
+          name: field.name,
+          reason: 'no open hours',
+        });
         continue;
       }
 
@@ -579,7 +630,7 @@ export class SchedulerProblemSpecService {
       }
     }
 
-    return slots;
+    return { slots, skippedFields };
   }
 
   private filterSlotsBySeasonExclusionStarts(

--- a/draco-nodejs/backend/src/services/schedulerRunService.ts
+++ b/draco-nodejs/backend/src/services/schedulerRunService.ts
@@ -1,0 +1,146 @@
+import type {
+  SchedulerProblemSpec,
+  SchedulerRunState,
+  SchedulerSeasonSolveRequest,
+} from '@draco/shared-schemas';
+import crypto from 'node:crypto';
+import { RepositoryFactory } from '../repositories/repositoryFactory.js';
+import type { ISchedulerRunRepository } from '../repositories/interfaces/ISchedulerRunRepository.js';
+import { SchedulerRunResponseFormatter } from '../responseFormatters/schedulerRunResponseFormatter.js';
+import { ServiceFactory } from './serviceFactory.js';
+import { buildDeterministicRunId } from './schedulerEngineService.js';
+
+const PROGRESS_PERSIST_INTERVAL = 100;
+const SOLVE_YIELD_EVERY_N = 50;
+
+export class SchedulerRunService {
+  constructor(
+    private readonly runRepository: ISchedulerRunRepository = RepositoryFactory.getSchedulerRunRepository(),
+  ) {}
+
+  async enqueue(
+    accountId: bigint,
+    seasonId: bigint,
+    request: SchedulerSeasonSolveRequest,
+    idempotencyKey?: string,
+  ): Promise<SchedulerRunState> {
+    const schedulerProblemSpecService = ServiceFactory.getSchedulerProblemSpecService();
+    const { problemSpec, timeZoneId, fieldGameLengthById } =
+      await schedulerProblemSpecService.buildProblemSpecForSolve(accountId, seasonId, request);
+
+    const runId = idempotencyKey
+      ? buildDeterministicRunId({ accountId, idempotencyKey, problemSpec })
+      : `sched_account_${accountId.toString()}_${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}`;
+
+    if (idempotencyKey) {
+      const existing = await this.runRepository.findByRunId(accountId, seasonId, runId);
+      if (existing) {
+        return SchedulerRunResponseFormatter.format(existing);
+      }
+    }
+
+    const total = problemSpec.games.length;
+    const created = await this.runRepository.create({
+      runid: runId,
+      accountid: accountId,
+      seasonid: seasonId,
+      status: 'queued',
+      total,
+    });
+
+    const specForRun: SchedulerProblemSpec = { ...problemSpec, runId };
+    this.startRun(
+      accountId,
+      runId,
+      specForRun,
+      timeZoneId,
+      idempotencyKey,
+      total,
+      fieldGameLengthById,
+    );
+
+    return SchedulerRunResponseFormatter.format(created);
+  }
+
+  async getRun(
+    accountId: bigint,
+    seasonId: bigint,
+    runId: string,
+  ): Promise<SchedulerRunState | null> {
+    const run = await this.runRepository.findByRunId(accountId, seasonId, runId);
+    return run ? SchedulerRunResponseFormatter.format(run) : null;
+  }
+
+  private startRun(
+    accountId: bigint,
+    runId: string,
+    problemSpec: SchedulerProblemSpec,
+    timeZoneId: string,
+    idempotencyKey: string | undefined,
+    total: number,
+    fieldGameLengthById: Record<string, number>,
+  ): void {
+    setImmediate(() => {
+      void this.processRun(
+        accountId,
+        runId,
+        problemSpec,
+        timeZoneId,
+        idempotencyKey,
+        total,
+        fieldGameLengthById,
+      );
+    });
+  }
+
+  private async processRun(
+    accountId: bigint,
+    runId: string,
+    problemSpec: SchedulerProblemSpec,
+    timeZoneId: string,
+    idempotencyKey: string | undefined,
+    total: number,
+    fieldGameLengthById: Record<string, number>,
+  ): Promise<void> {
+    const engine = ServiceFactory.getSchedulerEngineService();
+    const logPrefix = `[scheduler:run account=${accountId.toString()} run=${runId}]`;
+
+    try {
+      await this.runRepository.update(runId, { status: 'running', processed: 0, total });
+
+      const result = await engine.solveAsync(
+        problemSpec,
+        { accountId, idempotencyKey, timeZoneId, fieldGameLengthById },
+        {
+          yieldEveryN: SOLVE_YIELD_EVERY_N,
+          onProgress: (processed, progressTotal) => {
+            if (processed % PROGRESS_PERSIST_INTERVAL === 0 && processed !== progressTotal) {
+              void this.runRepository
+                .update(runId, { processed, total: progressTotal })
+                .catch((err) => {
+                  console.error(`${logPrefix} failed to persist progress`, err);
+                });
+            }
+          },
+        },
+      );
+
+      await this.runRepository.update(runId, {
+        status: 'completed',
+        processed: total,
+        total,
+        result: SchedulerRunResponseFormatter.toStoredResult(result),
+        error: null,
+      });
+      console.log(`${logPrefix} completed: status=${result.status}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Schedule generation failed';
+      console.error(`${logPrefix} failed`, err);
+      await this.runRepository
+        .update(runId, { status: 'failed', error: message })
+        .catch((updateErr) => {
+          console.error(`${logPrefix} failed to persist failure`, updateErr);
+        });
+    }
+  }
+}

--- a/draco-nodejs/backend/src/services/schedulerRunService.ts
+++ b/draco-nodejs/backend/src/services/schedulerRunService.ts
@@ -35,6 +35,18 @@ export class SchedulerRunService {
     if (idempotencyKey) {
       const existing = await this.runRepository.findByRunId(accountId, seasonId, runId);
       if (existing) {
+        if (existing.status === 'queued') {
+          const specForExisting: SchedulerProblemSpec = { ...problemSpec, runId };
+          this.startRun(
+            accountId,
+            runId,
+            specForExisting,
+            timeZoneId,
+            idempotencyKey,
+            problemSpec.games.length,
+            fieldGameLengthById,
+          );
+        }
         return SchedulerRunResponseFormatter.format(existing);
       }
     }

--- a/draco-nodejs/backend/src/services/schedulerRunService.ts
+++ b/draco-nodejs/backend/src/services/schedulerRunService.ts
@@ -134,7 +134,11 @@ export class SchedulerRunService {
     const logPrefix = `[scheduler:run account=${accountId.toString()} run=${runId}]`;
 
     try {
-      await this.runRepository.update(runId, { status: 'running', processed: 0, total });
+      const claimed = await this.runRepository.claimQueued(runId, total);
+      if (!claimed) {
+        console.log(`${logPrefix} run already claimed by another worker; skipping`);
+        return;
+      }
 
       const result = await engine.solveAsync(
         problemSpec,

--- a/draco-nodejs/backend/src/services/schedulerRunService.ts
+++ b/draco-nodejs/backend/src/services/schedulerRunService.ts
@@ -3,6 +3,7 @@ import type {
   SchedulerRunState,
   SchedulerSeasonSolveRequest,
 } from '@draco/shared-schemas';
+import type { schedulerrun } from '#prisma/client';
 import crypto from 'node:crypto';
 import { RepositoryFactory } from '../repositories/repositoryFactory.js';
 import type { ISchedulerRunRepository } from '../repositories/interfaces/ISchedulerRunRepository.js';
@@ -32,35 +33,50 @@ export class SchedulerRunService {
       ? buildDeterministicRunId({ accountId, idempotencyKey, problemSpec })
       : `sched_account_${accountId.toString()}_${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}`;
 
+    const total = problemSpec.games.length;
+    const specForRun: SchedulerProblemSpec = { ...problemSpec, runId };
+
+    const resumeExisting = (existing: schedulerrun): SchedulerRunState => {
+      if (existing.status === 'queued') {
+        this.startRun(
+          accountId,
+          runId,
+          specForRun,
+          timeZoneId,
+          idempotencyKey,
+          total,
+          fieldGameLengthById,
+        );
+      }
+      return SchedulerRunResponseFormatter.format(existing);
+    };
+
     if (idempotencyKey) {
       const existing = await this.runRepository.findByRunId(accountId, seasonId, runId);
       if (existing) {
-        if (existing.status === 'queued') {
-          const specForExisting: SchedulerProblemSpec = { ...problemSpec, runId };
-          this.startRun(
-            accountId,
-            runId,
-            specForExisting,
-            timeZoneId,
-            idempotencyKey,
-            problemSpec.games.length,
-            fieldGameLengthById,
-          );
-        }
-        return SchedulerRunResponseFormatter.format(existing);
+        return resumeExisting(existing);
       }
     }
 
-    const total = problemSpec.games.length;
-    const created = await this.runRepository.create({
-      runid: runId,
-      accountid: accountId,
-      seasonid: seasonId,
-      status: 'queued',
-      total,
-    });
+    let created: schedulerrun;
+    try {
+      created = await this.runRepository.create({
+        runid: runId,
+        accountid: accountId,
+        seasonid: seasonId,
+        status: 'queued',
+        total,
+      });
+    } catch (err) {
+      if (idempotencyKey && err instanceof Error && 'code' in err && err.code === 'P2002') {
+        const existing = await this.runRepository.findByRunId(accountId, seasonId, runId);
+        if (existing) {
+          return resumeExisting(existing);
+        }
+      }
+      throw err;
+    }
 
-    const specForRun: SchedulerProblemSpec = { ...problemSpec, runId };
     this.startRun(
       accountId,
       runId,

--- a/draco-nodejs/backend/src/services/schedulerRunService.ts
+++ b/draco-nodejs/backend/src/services/schedulerRunService.ts
@@ -140,13 +140,14 @@ export class SchedulerRunService {
         return;
       }
 
+      const progressStep = Math.min(PROGRESS_PERSIST_INTERVAL, Math.max(1, Math.ceil(total / 20)));
       const result = await engine.solveAsync(
         problemSpec,
         { accountId, idempotencyKey, timeZoneId, fieldGameLengthById },
         {
           yieldEveryN: SOLVE_YIELD_EVERY_N,
           onProgress: (processed, progressTotal) => {
-            if (processed % PROGRESS_PERSIST_INTERVAL === 0 && processed !== progressTotal) {
+            if (processed % progressStep === 0 && processed !== progressTotal) {
               void this.runRepository
                 .update(runId, { processed, total: progressTotal })
                 .catch((err) => {

--- a/draco-nodejs/backend/src/services/serviceFactory.ts
+++ b/draco-nodejs/backend/src/services/serviceFactory.ts
@@ -42,6 +42,7 @@ import { SchedulerEngineService } from './schedulerEngineService.js';
 import { SchedulerApplyService } from './schedulerApplyService.js';
 import { FieldScheduleConfigService } from './fieldScheduleConfigService.js';
 import { SchedulerProblemSpecService } from './schedulerProblemSpecService.js';
+import { SchedulerRunService } from './schedulerRunService.js';
 import { SchedulerSeasonApplyService } from './schedulerSeasonApplyService.js';
 import { SchedulerSeasonWindowConfigService } from './schedulerSeasonWindowConfigService.js';
 import { SchedulerSeasonExclusionsService } from './schedulerSeasonExclusionsService.js';
@@ -158,6 +159,7 @@ export class ServiceFactory {
   private static schedulerApplyService: SchedulerApplyService;
   private static fieldScheduleConfigService: FieldScheduleConfigService;
   private static schedulerProblemSpecService: SchedulerProblemSpecService;
+  private static schedulerRunService: SchedulerRunService;
   private static schedulerSeasonApplyService: SchedulerSeasonApplyService;
   private static schedulerSeasonWindowConfigService: SchedulerSeasonWindowConfigService;
   private static schedulerSeasonExclusionsService: SchedulerSeasonExclusionsService;
@@ -502,6 +504,14 @@ export class ServiceFactory {
     }
 
     return this.fieldScheduleConfigService;
+  }
+
+  static getSchedulerRunService(): SchedulerRunService {
+    if (!this.schedulerRunService) {
+      this.schedulerRunService = new SchedulerRunService();
+    }
+
+    return this.schedulerRunService;
   }
 
   static getSchedulerProblemSpecService(): SchedulerProblemSpecService {

--- a/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/SeasonSummaryWidget.tsx
@@ -34,6 +34,7 @@ interface SeasonSummaryWidgetProps {
   ready: boolean;
   games?: Game[];
   timeZone?: string;
+  title?: string;
 }
 
 const MAX_FIELD_NAME_LENGTH = 40;
@@ -419,6 +420,7 @@ const SeasonSummaryWidget: React.FC<SeasonSummaryWidgetProps> = ({
   ready,
   games = [],
   timeZone = 'UTC',
+  title = 'Season Summary',
 }) => {
   const theme = useTheme();
   const [selectedField, setSelectedField] = useState<SelectedField | null>(null);
@@ -465,7 +467,7 @@ const SeasonSummaryWidget: React.FC<SeasonSummaryWidgetProps> = ({
             }}
           >
             <Typography variant="h6" fontWeight={700} color={theme.palette.widget.headerText}>
-              Season Summary
+              {title}
             </Typography>
             <Typography variant="body2" color={theme.palette.widget.supportingText}>
               {subtitle}

--- a/draco-nodejs/frontend-next/components/schedule/utils/buildScheduleSummary.ts
+++ b/draco-nodejs/frontend-next/components/schedule/utils/buildScheduleSummary.ts
@@ -1,4 +1,4 @@
-import { Game, GameStatus } from '@/types/schedule';
+import { GameStatus } from '@/types/schedule';
 import { convertUTCToZonedDate } from '../../../utils/dateUtils';
 import type {
   SeasonSummary,
@@ -66,8 +66,17 @@ export interface BuildScheduleSummaryOptions {
   teamSeasonId?: string;
 }
 
+export interface ScheduleSummaryGame {
+  gameStatus: number;
+  gameDate: string;
+  fieldId?: string;
+  field?: { id: string; name: string; shortName: string };
+  homeTeamId?: string;
+  visitorTeamId?: string;
+}
+
 export const buildScheduleSummary = (
-  games: Game[],
+  games: ScheduleSummaryGame[],
   options: BuildScheduleSummaryOptions,
 ): SeasonSummary => {
   const { timeZone, teamSeasonId } = options;

--- a/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/ProposalAssignmentRow.tsx
@@ -87,9 +87,11 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
     `Field: ${fieldNameById.get(assignment.fieldId) ?? `Field ${assignment.fieldId}`}`,
   );
   secondaryParts.push(formatLocalTimeRange(assignment.startTime, assignment.endTime, timeZone));
-  if (umpireNames.length === 1) secondaryParts.push(`Umpire: ${umpireNames[0]}`);
-  else if (umpireNames.length > 1) secondaryParts.push(`Umpires: ${umpireNames.join(', ')}`);
-  else secondaryParts.push('Umpire: Unassigned');
+  if (maxUmpires > 0) {
+    if (umpireNames.length === 1) secondaryParts.push(`Umpire: ${umpireNames[0]}`);
+    else if (umpireNames.length > 1) secondaryParts.push(`Umpires: ${umpireNames.join(', ')}`);
+    else secondaryParts.push('Umpire: Unassigned');
+  }
 
   const detailsId = `proposal-assignment-details-${assignment.gameId}`;
 
@@ -168,42 +170,44 @@ export const ProposalAssignmentRow: React.FC<ProposalAssignmentRowProps> = ({
               </Select>
             </FormControl>
 
-            <FormControl size="small" fullWidth>
-              <InputLabel id={`${detailsId}-umpires-label`}>Umpires</InputLabel>
-              <Select
-                labelId={`${detailsId}-umpires-label`}
-                label="Umpires"
-                multiple
-                value={assignment.umpireIds}
-                onChange={handleUmpiresChange}
-                renderValue={(selectedIds) =>
-                  selectedIds.length === 0
-                    ? 'Unassigned'
-                    : selectedIds
-                        .map(
-                          (id) =>
-                            schedulerUmpireNameById.get(id) ??
-                            umpireNameById.get(id) ??
-                            `Umpire ${id}`,
-                        )
-                        .join(', ')
-                }
-              >
-                {umpires.map((umpire) => (
-                  <MenuItem
-                    key={umpire.id}
-                    value={umpire.id}
-                    disabled={
-                      assignment.umpireIds.length >= maxUmpires &&
-                      !assignment.umpireIds.includes(umpire.id)
-                    }
-                  >
-                    <Checkbox checked={assignment.umpireIds.includes(umpire.id)} />
-                    <ListItemText primary={umpire.name} />
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            {maxUmpires > 0 && (
+              <FormControl size="small" fullWidth>
+                <InputLabel id={`${detailsId}-umpires-label`}>Umpires</InputLabel>
+                <Select
+                  labelId={`${detailsId}-umpires-label`}
+                  label="Umpires"
+                  multiple
+                  value={assignment.umpireIds}
+                  onChange={handleUmpiresChange}
+                  renderValue={(selectedIds) =>
+                    selectedIds.length === 0
+                      ? 'Unassigned'
+                      : selectedIds
+                          .map(
+                            (id) =>
+                              schedulerUmpireNameById.get(id) ??
+                              umpireNameById.get(id) ??
+                              `Umpire ${id}`,
+                          )
+                          .join(', ')
+                  }
+                >
+                  {umpires.map((umpire) => (
+                    <MenuItem
+                      key={umpire.id}
+                      value={umpire.id}
+                      disabled={
+                        assignment.umpireIds.length >= maxUmpires &&
+                        !assignment.umpireIds.includes(umpire.id)
+                      }
+                    >
+                      <Checkbox checked={assignment.umpireIds.includes(umpire.id)} />
+                      <ListItemText primary={umpire.name} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
 
             <TextField
               label="Start"

--- a/draco-nodejs/frontend-next/components/scheduler/ScheduleProposalSummary.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/ScheduleProposalSummary.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Box, FormControl, InputLabel, MenuItem, Select, Typography } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import type { SchedulerProblemSpecPreview, SchedulerSolveResult } from '@draco/shared-schemas';
+import SeasonSummaryWidget from '../schedule/SeasonSummaryWidget';
+import { buildScheduleSummary } from '../schedule/utils/buildScheduleSummary';
+import {
+  buildProposalSummaryGames,
+  collectProposalLeagueOptions,
+  collectProposalTeamOptions,
+} from './proposalSummary';
+
+type Assignment = SchedulerSolveResult['assignments'][number];
+type GameRequest = SchedulerProblemSpecPreview['games'][number];
+
+interface ScheduleProposalSummaryProps {
+  assignments: Assignment[];
+  gameRequestById: Map<string, GameRequest>;
+  fieldNameById: Map<string, string>;
+  teamNameById: Map<string, string>;
+  leagueNameById: Map<string, string>;
+  timeZone: string;
+}
+
+export const ScheduleProposalSummary: React.FC<ScheduleProposalSummaryProps> = ({
+  assignments,
+  gameRequestById,
+  fieldNameById,
+  teamNameById,
+  leagueNameById,
+  timeZone,
+}) => {
+  const [leagueFilter, setLeagueFilter] = useState('');
+  const [teamFilter, setTeamFilter] = useState('');
+
+  const leagueOptions = collectProposalLeagueOptions(assignments, gameRequestById, leagueNameById);
+  const teamOptions = collectProposalTeamOptions(
+    assignments,
+    gameRequestById,
+    teamNameById,
+    leagueFilter,
+  );
+
+  const summaryGames = buildProposalSummaryGames(assignments, gameRequestById, fieldNameById, {
+    leagueFilter,
+    teamFilter,
+  });
+
+  const summary = buildScheduleSummary(summaryGames, {
+    timeZone,
+    teamSeasonId: teamFilter || undefined,
+  });
+
+  const handleLeagueChange = (event: SelectChangeEvent) => {
+    setLeagueFilter(event.target.value);
+    setTeamFilter('');
+  };
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 220 }}>
+          <InputLabel id="proposal-summary-league">League</InputLabel>
+          <Select
+            labelId="proposal-summary-league"
+            label="League"
+            value={leagueFilter}
+            onChange={handleLeagueChange}
+          >
+            <MenuItem value="">All leagues</MenuItem>
+            {leagueOptions.map((option) => (
+              <MenuItem key={option.id} value={option.id}>
+                {option.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 220 }}>
+          <InputLabel id="proposal-summary-team">Team</InputLabel>
+          <Select
+            labelId="proposal-summary-team"
+            label="Team"
+            value={teamFilter}
+            onChange={(event) => setTeamFilter(event.target.value)}
+          >
+            <MenuItem value="">All teams</MenuItem>
+            {teamOptions.map((option) => (
+              <MenuItem key={option.id} value={option.id}>
+                {option.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      {summary.totalGames > 0 ? (
+        <SeasonSummaryWidget
+          title="Schedule Proposal Summary"
+          summary={summary}
+          loading={false}
+          ready
+          timeZone={timeZone}
+        />
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          No scheduled games match these filters.
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/draco-nodejs/frontend-next/components/scheduler/SchedulerConstraintsConfig.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SchedulerConstraintsConfig.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import React from 'react';
+import { Box, Chip, Divider, FormControlLabel, Switch, TextField, Typography } from '@mui/material';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  arrayMove,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { CollapsibleSection } from './CollapsibleSection';
+import type {
+  SchedulerConstraintConfig,
+  SchedulerSoftConstraintKey,
+} from '../../utils/schedulerConstraintStorage';
+
+interface SchedulerConstraintsConfigProps {
+  seasonId: string | null;
+  config: SchedulerConstraintConfig;
+  onChange: (config: SchedulerConstraintConfig) => void;
+}
+
+const SOFT_LABELS: Record<SchedulerSoftConstraintKey, string> = {
+  avoidBackToBackGames: 'Avoid back-to-back games',
+  spreadGamesAcrossDays: 'Spread games across days',
+  balanceEarlyVsLate: 'Balance early vs. late games',
+};
+
+const clampNonNegativeInt = (value: string, fallback: number): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+};
+
+interface SortableSoftRowProps {
+  softKey: SchedulerSoftConstraintKey;
+  config: SchedulerConstraintConfig;
+  disabled: boolean;
+  onChange: (config: SchedulerConstraintConfig) => void;
+}
+
+const SortableSoftRow: React.FC<SortableSoftRowProps> = ({
+  softKey,
+  config,
+  disabled,
+  onChange,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: softKey,
+  });
+
+  const enabled =
+    softKey === 'avoidBackToBackGames'
+      ? config.avoidBackToBackGames.enabled
+      : softKey === 'spreadGamesAcrossDays'
+        ? config.spreadGamesAcrossDays.enabled
+        : config.balanceEarlyVsLate.enabled;
+
+  const handleEnabledChange = (next: boolean) => {
+    if (softKey === 'avoidBackToBackGames') {
+      onChange({
+        ...config,
+        avoidBackToBackGames: { ...config.avoidBackToBackGames, enabled: next },
+      });
+    } else if (softKey === 'spreadGamesAcrossDays') {
+      onChange({ ...config, spreadGamesAcrossDays: { enabled: next } });
+    } else {
+      onChange({ ...config, balanceEarlyVsLate: { enabled: next } });
+    }
+  };
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexWrap: 'wrap',
+        opacity: isDragging ? 0.6 : 1,
+        py: 0.5,
+      }}
+    >
+      <Box
+        {...attributes}
+        {...listeners}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          cursor: disabled ? 'default' : 'grab',
+          color: 'text.secondary',
+          touchAction: 'none',
+        }}
+        aria-label={`Reorder ${SOFT_LABELS[softKey]}`}
+      >
+        <DragIndicatorIcon fontSize="small" />
+      </Box>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={enabled}
+            onChange={(event) => handleEnabledChange(event.target.checked)}
+            disabled={disabled}
+          />
+        }
+        label={SOFT_LABELS[softKey]}
+      />
+      {softKey === 'avoidBackToBackGames' && enabled && (
+        <TextField
+          type="number"
+          size="small"
+          label="Min rest (minutes)"
+          value={config.avoidBackToBackGames.minRestMinutes}
+          onChange={(event) =>
+            onChange({
+              ...config,
+              avoidBackToBackGames: {
+                ...config.avoidBackToBackGames,
+                minRestMinutes: clampNonNegativeInt(
+                  event.target.value,
+                  config.avoidBackToBackGames.minRestMinutes,
+                ),
+              },
+            })
+          }
+          inputProps={{ min: 0, step: 30 }}
+          disabled={disabled}
+          sx={{ maxWidth: 180 }}
+        />
+      )}
+    </Box>
+  );
+};
+
+export const SchedulerConstraintsConfig: React.FC<SchedulerConstraintsConfigProps> = ({
+  seasonId,
+  config,
+  onChange,
+}) => {
+  const disabled = !seasonId;
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const enabledCount =
+    (config.avoidBackToBackGames.enabled ? 1 : 0) +
+    (config.spreadGamesAcrossDays.enabled ? 1 : 0) +
+    (config.balanceEarlyVsLate.enabled ? 1 : 0) +
+    (config.maxGamesPerTeamPerDay.enabled ? 1 : 0) +
+    (config.requireLightsAfter.enabled ? 1 : 0);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = config.softOrder.indexOf(active.id as SchedulerSoftConstraintKey);
+    const newIndex = config.softOrder.indexOf(over.id as SchedulerSoftConstraintKey);
+    if (oldIndex < 0 || newIndex < 0) return;
+    onChange({ ...config, softOrder: arrayMove(config.softOrder, oldIndex, newIndex) });
+  };
+
+  return (
+    <>
+      <Divider sx={{ my: 2 }} />
+      <CollapsibleSection
+        title="Scheduling Constraints"
+        headerExtra={
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+            <Chip
+              size="small"
+              label={enabledCount === 0 ? 'None enabled' : `${enabledCount} enabled`}
+            />
+          </Box>
+        }
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box>
+            <Typography variant="subtitle2">Optimization preferences</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Drag to reorder — higher in the list means higher priority.
+            </Typography>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={config.softOrder} strategy={verticalListSortingStrategy}>
+                <Box sx={{ display: 'flex', flexDirection: 'column', mt: 1 }}>
+                  {config.softOrder.map((softKey) => (
+                    <SortableSoftRow
+                      key={softKey}
+                      softKey={softKey}
+                      config={config}
+                      disabled={disabled}
+                      onChange={onChange}
+                    />
+                  ))}
+                </Box>
+              </SortableContext>
+            </DndContext>
+          </Box>
+
+          <Divider />
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Typography variant="subtitle2">Hard limits</Typography>
+
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={config.maxGamesPerTeamPerDay.enabled}
+                    onChange={(event) =>
+                      onChange({
+                        ...config,
+                        maxGamesPerTeamPerDay: {
+                          ...config.maxGamesPerTeamPerDay,
+                          enabled: event.target.checked,
+                        },
+                      })
+                    }
+                    disabled={disabled}
+                  />
+                }
+                label="Limit games per team per day"
+              />
+              {config.maxGamesPerTeamPerDay.enabled && (
+                <TextField
+                  type="number"
+                  size="small"
+                  label="Max games/team/day"
+                  value={config.maxGamesPerTeamPerDay.value}
+                  onChange={(event) =>
+                    onChange({
+                      ...config,
+                      maxGamesPerTeamPerDay: {
+                        ...config.maxGamesPerTeamPerDay,
+                        value: Math.max(
+                          1,
+                          clampNonNegativeInt(
+                            event.target.value,
+                            config.maxGamesPerTeamPerDay.value,
+                          ),
+                        ),
+                      },
+                    })
+                  }
+                  inputProps={{ min: 1, step: 1 }}
+                  disabled={disabled}
+                  sx={{ maxWidth: 200 }}
+                />
+              )}
+            </Box>
+
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={config.requireLightsAfter.enabled}
+                    onChange={(event) =>
+                      onChange({
+                        ...config,
+                        requireLightsAfter: {
+                          ...config.requireLightsAfter,
+                          enabled: event.target.checked,
+                        },
+                      })
+                    }
+                    disabled={disabled}
+                  />
+                }
+                label="Require lights after a set hour"
+              />
+              {config.requireLightsAfter.enabled && (
+                <TextField
+                  type="number"
+                  size="small"
+                  label="Start hour (0–23)"
+                  value={config.requireLightsAfter.startHourLocal}
+                  onChange={(event) => {
+                    const next = clampNonNegativeInt(
+                      event.target.value,
+                      config.requireLightsAfter.startHourLocal,
+                    );
+                    onChange({
+                      ...config,
+                      requireLightsAfter: {
+                        ...config.requireLightsAfter,
+                        startHourLocal: Math.min(23, next),
+                      },
+                    });
+                  }}
+                  inputProps={{ min: 0, max: 23, step: 1 }}
+                  disabled={disabled}
+                  sx={{ maxWidth: 200 }}
+                />
+              )}
+            </Box>
+          </Box>
+        </Box>
+      </CollapsibleSection>
+    </>
+  );
+};

--- a/draco-nodejs/frontend-next/components/scheduler/SchedulerConstraintsConfig.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SchedulerConstraintsConfig.tsx
@@ -98,8 +98,8 @@ const SortableSoftRow: React.FC<SortableSoftRowProps> = ({
       }}
     >
       <Box
-        {...attributes}
-        {...listeners}
+        {...(disabled ? {} : attributes)}
+        {...(disabled ? {} : listeners)}
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -168,6 +168,7 @@ export const SchedulerConstraintsConfig: React.FC<SchedulerConstraintsConfigProp
     (config.requireLightsAfter.enabled ? 1 : 0);
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (disabled) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const oldIndex = config.softOrder.indexOf(active.id as SchedulerSoftConstraintKey);

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerProposalReview.tsx
@@ -19,6 +19,7 @@ import type {
 import { formatDateInTimezone, getDateKeyInTimezone } from '../../utils/dateUtils';
 import { findSelectedFieldClashes } from '../../utils/schedulerAssignmentChecks';
 import { ProposalAssignmentRow } from './ProposalAssignmentRow';
+import { ScheduleProposalSummary } from './ScheduleProposalSummary';
 import { SchedulerSpecPreviewDialog } from './SchedulerSpecPreviewDialog';
 
 type Option = { id: string; name: string };
@@ -134,6 +135,18 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
     [...(specPreview?.games ?? []), ...(generatedMatchups ?? [])].map((game) => [game.id, game]),
   );
 
+  const getMatchupLabel = (gameId: string): string => {
+    const game = gameRequestById.get(gameId);
+    if (!game) {
+      return getGameSummaryLabel(gameId);
+    }
+    const home = teamNameById.get(game.homeTeamSeasonId) ?? 'Unknown Home';
+    const visitor = teamNameById.get(game.visitorTeamSeasonId) ?? 'Unknown Visitor';
+    const league = game.leagueSeasonId ? leagueNameById.get(game.leagueSeasonId) : undefined;
+    const matchup = `${home} vs ${visitor}`;
+    return league ? `[${league}] ${matchup}` : matchup;
+  };
+
   const selectedMode = !proposal || selectedGameIds.size === assignments.length ? 'all' : 'subset';
 
   const toggleExpanded = (gameId: string) => {
@@ -160,6 +173,17 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
               Status: {proposal.status}. Scheduled {proposal.metrics.scheduledGames}/
               {proposal.metrics.totalGames}.
             </Typography>
+
+            {proposal.assignments.length > 0 && (
+              <ScheduleProposalSummary
+                assignments={proposal.assignments}
+                gameRequestById={gameRequestById}
+                fieldNameById={fieldNameById}
+                teamNameById={teamNameById}
+                leagueNameById={leagueNameById}
+                timeZone={timeZone}
+              />
+            )}
 
             {proposal.assignments.length === 0 ? (
               <Alert severity="warning" sx={{ mt: 2 }}>
@@ -262,7 +286,7 @@ export const SeasonSchedulerProposalReview: React.FC<SeasonSchedulerProposalRevi
                       }}
                     >
                       <Typography variant="body2" noWrap>
-                        {getGameSummaryLabel(item.gameId)}
+                        {getMatchupLabel(item.gameId)}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {item.reason}

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../utils/schedulerProposalStorage';
 import {
   buildSolveConstraints,
-  DEFAULT_CONSTRAINT_CONFIG,
+  cloneDefaultConfig,
   loadConstraintConfig,
   saveConstraintConfig,
   type SchedulerConstraintConfig,
@@ -160,7 +160,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     seasonId ? loadScheduleUmpires(accountId, seasonId) : false,
   );
   const [constraintConfig, setConstraintConfig] = useState<SchedulerConstraintConfig>(() =>
-    seasonId ? loadConstraintConfig(accountId, seasonId) : { ...DEFAULT_CONSTRAINT_CONFIG },
+    seasonId ? loadConstraintConfig(accountId, seasonId) : cloneDefaultConfig(),
   );
   const [running, setRunning] = useState(false);
   const [runProgress, setRunProgress] = useState<{ processed: number; total: number } | null>(null);

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Alert, Box, Button, Divider, Typography } from '@mui/material';
+import { Alert, Box, Button, Divider, LinearProgress, Typography } from '@mui/material';
 import type {
   SchedulerGameRequest,
   SchedulerGenerateMatchupsRequest,
@@ -19,12 +19,20 @@ import { SeasonSchedulerConfigPanel } from './SeasonSchedulerConfigPanel';
 import { SeasonSchedulerProposalReview } from './SeasonSchedulerProposalReview';
 import { SchedulerFieldsConfig } from './SchedulerFieldsConfig';
 import { SchedulerUmpiresConfig } from './SchedulerUmpiresConfig';
+import { SchedulerConstraintsConfig } from './SchedulerConstraintsConfig';
 import { loadRoundRobinCounts, type LeagueRoundRobinCount } from './SchedulerRoundRobinConfig';
 import {
   clearPersistedProposal,
   loadPersistedProposal,
   savePersistedProposal,
 } from '../../utils/schedulerProposalStorage';
+import {
+  buildSolveConstraints,
+  DEFAULT_CONSTRAINT_CONFIG,
+  loadConstraintConfig,
+  saveConstraintConfig,
+  type SchedulerConstraintConfig,
+} from '../../utils/schedulerConstraintStorage';
 
 type FieldOption = { id: string; name: string };
 type EntityOption = { id: string; name: string };
@@ -102,7 +110,8 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     upsertSeasonWindowConfig,
     getProblemSpecPreview,
     generateMatchups,
-    solveSeason,
+    enqueueSeasonRun,
+    getSeasonRun,
     applySeason,
     loading,
     error,
@@ -150,6 +159,19 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   const [scheduleUmpires, setScheduleUmpires] = useState(() =>
     seasonId ? loadScheduleUmpires(accountId, seasonId) : false,
   );
+  const [constraintConfig, setConstraintConfig] = useState<SchedulerConstraintConfig>(() =>
+    seasonId ? loadConstraintConfig(accountId, seasonId) : { ...DEFAULT_CONSTRAINT_CONFIG },
+  );
+  const [running, setRunning] = useState(false);
+  const [runProgress, setRunProgress] = useState<{ processed: number; total: number } | null>(null);
+  const pollControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const controllerRef = pollControllerRef;
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (!seasonId) return;
@@ -231,12 +253,20 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
     if (!seasonId) return;
     setRoundRobinCounts(loadRoundRobinCounts(accountId, seasonId));
     setScheduleUmpires(loadScheduleUmpires(accountId, seasonId));
+    setConstraintConfig(loadConstraintConfig(accountId, seasonId));
   }, [accountId, seasonId]);
 
   const handleScheduleUmpiresChange = (value: boolean) => {
     setScheduleUmpires(value);
     if (seasonId) {
       saveScheduleUmpires(accountId, seasonId, value);
+    }
+  };
+
+  const handleConstraintConfigChange = (next: SchedulerConstraintConfig) => {
+    setConstraintConfig(next);
+    if (seasonId) {
+      saveConstraintConfig(accountId, seasonId, next);
     }
   };
 
@@ -304,6 +334,11 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
   };
 
   const handleGenerateMatchups = async () => {
+    pollControllerRef.current?.abort();
+    const controller = new AbortController();
+    pollControllerRef.current = controller;
+    setRunning(true);
+    setRunProgress(null);
     try {
       setError(null);
       clearError();
@@ -354,22 +389,44 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         matchups,
         objectives: { primary: 'maximize_scheduled_games' },
         umpiresPerGame: scheduleUmpires ? umpiresPerGame : 0,
-        constraints:
-          maxGamesPerUmpirePerDay !== undefined
-            ? { hard: { maxGamesPerUmpirePerDay: Math.floor(maxGamesPerUmpirePerDay) } }
-            : undefined,
+        constraints: buildSolveConstraints(constraintConfig, maxGamesPerUmpirePerDay),
       };
 
-      const result = await solveSeason(solveRequest);
-      setProposal(result);
-      setProposalFromGenerated(true);
-      setGeneratedMatchups(matchups);
-      setSelectedGameIds(new Set(result.assignments.map((a) => a.gameId)));
-      setSuccess(
-        `Generated matchups placed (${result.metrics.scheduledGames}/${result.metrics.totalGames} scheduled)`,
-      );
+      const enqueued = await enqueueSeasonRun(solveRequest);
+      setRunProgress(enqueued.progress);
+
+      while (!controller.signal.aborted) {
+        const state = await getSeasonRun(enqueued.runId, controller.signal);
+        if (controller.signal.aborted) return;
+        setRunProgress(state.progress);
+
+        if (state.status === 'completed') {
+          if (!state.result) throw new Error('Schedule run completed without a result');
+          const result = state.result;
+          setProposal(result);
+          setProposalFromGenerated(true);
+          setGeneratedMatchups(matchups);
+          setSelectedGameIds(new Set(result.assignments.map((a) => a.gameId)));
+          setSuccess(
+            `Generated matchups placed (${result.metrics.scheduledGames}/${result.metrics.totalGames} scheduled)`,
+          );
+          return;
+        }
+
+        if (state.status === 'failed') {
+          throw new Error(state.error ?? 'Schedule generation failed');
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
     } catch (err) {
+      if (controller.signal.aborted) return;
       setError(err instanceof Error ? err.message : 'Failed to generate matchups');
+    } finally {
+      if (!controller.signal.aborted) {
+        setRunning(false);
+        setRunProgress(null);
+      }
     }
   };
 
@@ -487,14 +544,38 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
           variant="contained"
           onClick={handleGenerateMatchups}
           disabled={
+            running ||
             !seasonId ||
             !seasonWindowConfig ||
             (leagues.length > 0 && selectedLeagueSeasonIds.length === 0)
           }
         >
-          Generate Schedule
+          {running ? 'Generating…' : 'Generate Schedule'}
         </Button>
       </Box>
+
+      {running && (
+        <Box sx={{ mt: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+            <Typography variant="caption" color="text.secondary">
+              Generating schedule…
+            </Typography>
+            {runProgress && runProgress.total > 0 && (
+              <Typography variant="caption" color="text.secondary">
+                {runProgress.processed}/{runProgress.total} games
+              </Typography>
+            )}
+          </Box>
+          <LinearProgress
+            variant={runProgress && runProgress.total > 0 ? 'determinate' : 'indeterminate'}
+            value={
+              runProgress && runProgress.total > 0
+                ? Math.min(100, Math.round((runProgress.processed / runProgress.total) * 100))
+                : undefined
+            }
+          />
+        </Box>
+      )}
 
       {filterLabel && (
         <Typography variant="caption" color="text.secondary">
@@ -580,6 +661,12 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
         onCreateUmpireExclusion={constraints.handleCreateUmpireExclusion}
         onEditUmpireExclusion={constraints.handleEditUmpireExclusion}
         onDeleteUmpireExclusion={constraints.handleDeleteUmpireExclusion}
+      />
+
+      <SchedulerConstraintsConfig
+        seasonId={seasonId}
+        config={constraintConfig}
+        onChange={handleConstraintConfigChange}
       />
 
       <SeasonSchedulerProposalReview

--- a/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/SeasonSchedulerWidget.tsx
@@ -393,6 +393,7 @@ export const SeasonSchedulerWidget: React.FC<SeasonSchedulerWidgetProps> = ({
       };
 
       const enqueued = await enqueueSeasonRun(solveRequest);
+      if (controller.signal.aborted) return;
       setRunProgress(enqueued.progress);
 
       while (!controller.signal.aborted) {

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/ProposalAssignmentRow.render.test.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/ProposalAssignmentRow.render.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { dracoTheme } from '../../../theme';
+import { ProposalAssignmentRow } from '../ProposalAssignmentRow';
+import type { SchedulerSolveResult } from '@draco/shared-schemas';
+
+const assignment: SchedulerSolveResult['assignments'][number] = {
+  gameId: 'game-1',
+  fieldId: 'field-1',
+  startTime: '2026-05-07T21:45:00.000Z',
+  endTime: '2026-05-07T22:45:00.000Z',
+  umpireIds: [],
+};
+
+const renderRow = (maxUmpires: number) =>
+  render(
+    <ThemeProvider theme={dracoTheme}>
+      <ProposalAssignmentRow
+        assignment={assignment}
+        game={undefined}
+        timeZone="America/New_York"
+        selected
+        expanded={false}
+        fields={[{ id: 'field-1', name: 'Allen Park' }]}
+        umpires={[{ id: 'u1', name: 'Alice' }]}
+        maxUmpires={maxUmpires}
+        fieldNameById={new Map([['field-1', 'Allen Park']])}
+        teamNameById={new Map()}
+        umpireNameById={new Map()}
+        schedulerUmpireNameById={new Map()}
+        leagueNameById={new Map()}
+        onToggleSelection={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        onAssignmentChange={vi.fn()}
+      />
+      ,
+    </ThemeProvider>,
+  );
+
+describe('ProposalAssignmentRow umpire display', () => {
+  it('hides the umpire field when umpire scheduling is off (maxUmpires = 0)', () => {
+    renderRow(0);
+    expect(screen.queryByText(/Umpire: Unassigned/)).not.toBeInTheDocument();
+  });
+
+  it('shows "Umpire: Unassigned" when umpire scheduling is on and none assigned', () => {
+    renderRow(2);
+    expect(screen.getByText(/Umpire: Unassigned/)).toBeInTheDocument();
+  });
+});

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/ProposalAssignmentRow.render.test.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/ProposalAssignmentRow.render.test.tsx
@@ -34,7 +34,6 @@ const renderRow = (maxUmpires: number) =>
         onToggleExpanded={vi.fn()}
         onAssignmentChange={vi.fn()}
       />
-      ,
     </ThemeProvider>,
   );
 

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/SchedulerConstraintsConfig.render.test.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/SchedulerConstraintsConfig.render.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { dracoTheme } from '../../../theme';
+import { SchedulerConstraintsConfig } from '../SchedulerConstraintsConfig';
+import { DEFAULT_CONSTRAINT_CONFIG } from '../../../utils/schedulerConstraintStorage';
+
+const renderConfig = (onChange = vi.fn()) => {
+  render(
+    <ThemeProvider theme={dracoTheme}>
+      <SchedulerConstraintsConfig
+        seasonId="2026"
+        config={DEFAULT_CONSTRAINT_CONFIG}
+        onChange={onChange}
+      />
+    </ThemeProvider>,
+  );
+  return onChange;
+};
+
+const expandSection = () =>
+  fireEvent.click(screen.getByRole('button', { name: /Scheduling Constraints/ }));
+
+describe('SchedulerConstraintsConfig', () => {
+  it('shows all constraints disabled by default', () => {
+    renderConfig();
+    expect(screen.getByText('None enabled')).toBeInTheDocument();
+
+    expandSection();
+    const labels = [
+      'Avoid back-to-back games',
+      'Spread games across days',
+      'Balance early vs. late games',
+      'Limit games per team per day',
+      'Require lights after a set hour',
+    ];
+    for (const label of labels) {
+      expect((screen.getByLabelText(label) as HTMLInputElement).checked).toBe(false);
+    }
+  });
+
+  it('emits an enabled soft constraint when toggled on', () => {
+    const onChange = renderConfig();
+    expandSection();
+
+    fireEvent.click(screen.getByLabelText('Avoid back-to-back games'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        avoidBackToBackGames: expect.objectContaining({ enabled: true }),
+      }),
+    );
+  });
+
+  it('reveals the team-per-day limit field only when enabled', () => {
+    const onChange = renderConfig();
+    expandSection();
+
+    expect(screen.queryByLabelText('Max games/team/day')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Limit games per team per day'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxGamesPerTeamPerDay: expect.objectContaining({ enabled: true }),
+      }),
+    );
+  });
+});

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/SeasonSchedulerProposalReview.render.test.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/SeasonSchedulerProposalReview.render.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { dracoTheme } from '../../../theme';
+import { SeasonSchedulerProposalReview } from '../SeasonSchedulerProposalReview';
+import type { SchedulerSolveResult } from '@draco/shared-schemas';
+
+const baseProposal: SchedulerSolveResult = {
+  runId: 'r1',
+  status: 'partial',
+  metrics: { totalGames: 1, scheduledGames: 0, unscheduledGames: 1, objectiveValue: 0 },
+  assignments: [],
+  unscheduled: [{ gameId: 'gen-264-2284-2288-5', reason: 'No field capacity remaining' }],
+};
+
+const renderReview = (
+  overrides: Partial<React.ComponentProps<typeof SeasonSchedulerProposalReview>> = {},
+) =>
+  render(
+    <ThemeProvider theme={dracoTheme}>
+      <SeasonSchedulerProposalReview
+        proposal={baseProposal}
+        specPreview={null}
+        specPreviewOpen={false}
+        loading={false}
+        timeZone="America/New_York"
+        selectedGameIds={new Set()}
+        fields={[]}
+        umpires={[]}
+        maxUmpires={0}
+        fieldNameById={new Map()}
+        teamNameById={
+          new Map([
+            ['2284', "Blue Collar A's"],
+            ['2288', 'Giants'],
+          ])
+        }
+        umpireNameById={new Map()}
+        leagueNameById={new Map([['264', '30+']])}
+        generatedMatchups={[
+          {
+            id: 'gen-264-2284-2288-5',
+            leagueSeasonId: '264',
+            homeTeamSeasonId: '2284',
+            visitorTeamSeasonId: '2288',
+          },
+        ]}
+        getGameSummaryLabel={(id) => `Game ${id}`}
+        onToggleSelection={vi.fn()}
+        onToggleAll={vi.fn()}
+        onApply={vi.fn()}
+        onAssignmentChange={vi.fn()}
+        onCloseSpecPreview={vi.fn()}
+        {...overrides}
+      />
+    </ThemeProvider>,
+  );
+
+describe('SeasonSchedulerProposalReview unscheduled labels', () => {
+  it('shows the league prefix and team names for an unscheduled generated matchup', () => {
+    renderReview();
+    expect(screen.getByText("[30+] Blue Collar A's vs Giants")).toBeInTheDocument();
+    expect(screen.queryByText(/gen-264-2284-2288-5/)).not.toBeInTheDocument();
+    expect(screen.getByText('No field capacity remaining')).toBeInTheDocument();
+  });
+
+  it('falls back to the game summary label when the matchup is not found', () => {
+    renderReview({ generatedMatchups: null });
+    expect(screen.getByText('Game gen-264-2284-2288-5')).toBeInTheDocument();
+  });
+});

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/proposalSummary.test.ts
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/proposalSummary.test.ts
@@ -95,6 +95,19 @@ describe('proposalSummary', () => {
     expect(summary.byField.map((f) => f.fieldName)).toEqual(['Berkley']);
   });
 
+  it('labels a present-but-unnamed field as "Field {id}" rather than no-field', () => {
+    const games = buildProposalSummaryGames(
+      [assignment('g1', 'f9', '2026-05-03T13:00:00.000Z')],
+      gameRequestById,
+      fieldNameById,
+      { leagueFilter: '', teamFilter: '' },
+    );
+    expect(games[0].field?.name).toBe('Field f9');
+
+    const summary = buildScheduleSummary(games, { timeZone: 'America/New_York' });
+    expect(summary.byField.map((f) => f.fieldName)).toEqual(['Field f9']);
+  });
+
   it('filters by team and exposes home/away when a team is selected', () => {
     const games = buildProposalSummaryGames(assignments, gameRequestById, fieldNameById, {
       leagueFilter: 'L1',

--- a/draco-nodejs/frontend-next/components/scheduler/__tests__/proposalSummary.test.ts
+++ b/draco-nodejs/frontend-next/components/scheduler/__tests__/proposalSummary.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { SchedulerProblemSpecPreview, SchedulerSolveResult } from '@draco/shared-schemas';
+import { GameStatus } from '@/types/schedule';
+import { buildScheduleSummary } from '../../schedule/utils/buildScheduleSummary';
+import {
+  buildProposalSummaryGames,
+  collectProposalLeagueOptions,
+  collectProposalTeamOptions,
+} from '../proposalSummary';
+
+type Assignment = SchedulerSolveResult['assignments'][number];
+type GameRequest = SchedulerProblemSpecPreview['games'][number];
+
+const matchup = (
+  id: string,
+  leagueSeasonId: string,
+  home: string,
+  visitor: string,
+): GameRequest => ({ id, leagueSeasonId, homeTeamSeasonId: home, visitorTeamSeasonId: visitor });
+
+const assignment = (gameId: string, fieldId: string, startTime: string): Assignment => ({
+  gameId,
+  fieldId,
+  startTime,
+  endTime: startTime,
+  umpireIds: [],
+});
+
+const gameRequestById = new Map<string, GameRequest>([
+  ['g1', matchup('g1', 'L1', 't1', 't2')],
+  ['g2', matchup('g2', 'L1', 't1', 't3')],
+  ['g3', matchup('g3', 'L2', 't4', 't5')],
+]);
+
+const assignments: Assignment[] = [
+  assignment('g1', 'f1', '2026-05-03T13:00:00.000Z'),
+  assignment('g2', 'f1', '2026-05-04T13:00:00.000Z'),
+  assignment('g3', 'f2', '2026-05-05T13:00:00.000Z'),
+];
+
+const leagueNameById = new Map([
+  ['L1', 'Adult'],
+  ['L2', 'Senior'],
+]);
+const teamNameById = new Map([
+  ['t1', 'Aces'],
+  ['t2', 'Bats'],
+  ['t3', 'Cats'],
+  ['t4', 'Dawgs'],
+  ['t5', 'Elks'],
+]);
+const fieldNameById = new Map([
+  ['f1', 'Allen Park'],
+  ['f2', 'Berkley'],
+]);
+
+describe('proposalSummary', () => {
+  it('collects league options present in the proposal, sorted by name', () => {
+    expect(collectProposalLeagueOptions(assignments, gameRequestById, leagueNameById)).toEqual([
+      { id: 'L1', name: 'Adult' },
+      { id: 'L2', name: 'Senior' },
+    ]);
+  });
+
+  it('scopes team options to the selected league', () => {
+    const all = collectProposalTeamOptions(assignments, gameRequestById, teamNameById, '');
+    expect(all.map((o) => o.id).sort()).toEqual(['t1', 't2', 't3', 't4', 't5']);
+
+    const l1 = collectProposalTeamOptions(assignments, gameRequestById, teamNameById, 'L1');
+    expect(l1.map((o) => o.id).sort()).toEqual(['t1', 't2', 't3']);
+  });
+
+  it('builds summary games (all scheduled) with no filter', () => {
+    const games = buildProposalSummaryGames(assignments, gameRequestById, fieldNameById, {
+      leagueFilter: '',
+      teamFilter: '',
+    });
+    expect(games).toHaveLength(3);
+    expect(games.every((g) => g.gameStatus === GameStatus.Scheduled)).toBe(true);
+    expect(games[0].field?.name).toBe('Allen Park');
+
+    const summary = buildScheduleSummary(games, { timeZone: 'America/New_York' });
+    expect(summary.totalGames).toBe(3);
+    expect(summary.totalScheduled).toBe(3);
+    expect(summary.totalPlayed).toBe(0);
+  });
+
+  it('filters by league', () => {
+    const games = buildProposalSummaryGames(assignments, gameRequestById, fieldNameById, {
+      leagueFilter: 'L2',
+      teamFilter: '',
+    });
+    expect(games).toHaveLength(1);
+    const summary = buildScheduleSummary(games, { timeZone: 'America/New_York' });
+    expect(summary.byField.map((f) => f.fieldName)).toEqual(['Berkley']);
+  });
+
+  it('filters by team and exposes home/away when a team is selected', () => {
+    const games = buildProposalSummaryGames(assignments, gameRequestById, fieldNameById, {
+      leagueFilter: 'L1',
+      teamFilter: 't1',
+    });
+    expect(games).toHaveLength(2);
+    const summary = buildScheduleSummary(games, {
+      timeZone: 'America/New_York',
+      teamSeasonId: 't1',
+    });
+    expect(summary.homeAway).toEqual({ home: 2, away: 0, played: { home: 0, away: 0 } });
+  });
+});

--- a/draco-nodejs/frontend-next/components/scheduler/proposalSummary.ts
+++ b/draco-nodejs/frontend-next/components/scheduler/proposalSummary.ts
@@ -1,0 +1,86 @@
+import type { SchedulerProblemSpecPreview, SchedulerSolveResult } from '@draco/shared-schemas';
+import { GameStatus } from '@/types/schedule';
+import type { ScheduleSummaryGame } from '../schedule/utils/buildScheduleSummary';
+
+type Assignment = SchedulerSolveResult['assignments'][number];
+type GameRequest = SchedulerProblemSpecPreview['games'][number];
+
+export interface ProposalSummaryOption {
+  id: string;
+  name: string;
+}
+
+export interface ProposalSummaryFilters {
+  leagueFilter: string;
+  teamFilter: string;
+}
+
+export const collectProposalLeagueOptions = (
+  assignments: Assignment[],
+  gameRequestById: Map<string, GameRequest>,
+  leagueNameById: Map<string, string>,
+): ProposalSummaryOption[] => {
+  const leagueIds = new Set<string>();
+  for (const assignment of assignments) {
+    const matchup = gameRequestById.get(assignment.gameId);
+    if (matchup?.leagueSeasonId) {
+      leagueIds.add(matchup.leagueSeasonId);
+    }
+  }
+  return Array.from(leagueIds)
+    .map((id) => ({ id, name: leagueNameById.get(id) ?? `League ${id}` }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const collectProposalTeamOptions = (
+  assignments: Assignment[],
+  gameRequestById: Map<string, GameRequest>,
+  teamNameById: Map<string, string>,
+  leagueFilter: string,
+): ProposalSummaryOption[] => {
+  const teamIds = new Set<string>();
+  for (const assignment of assignments) {
+    const matchup = gameRequestById.get(assignment.gameId);
+    if (!matchup) continue;
+    if (leagueFilter && matchup.leagueSeasonId !== leagueFilter) continue;
+    teamIds.add(matchup.homeTeamSeasonId);
+    teamIds.add(matchup.visitorTeamSeasonId);
+  }
+  return Array.from(teamIds)
+    .map((id) => ({ id, name: teamNameById.get(id) ?? `Team ${id}` }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const buildProposalSummaryGames = (
+  assignments: Assignment[],
+  gameRequestById: Map<string, GameRequest>,
+  fieldNameById: Map<string, string>,
+  filters: ProposalSummaryFilters,
+): ScheduleSummaryGame[] => {
+  const { leagueFilter, teamFilter } = filters;
+  const games: ScheduleSummaryGame[] = [];
+  for (const assignment of assignments) {
+    const matchup = gameRequestById.get(assignment.gameId);
+    if (leagueFilter && matchup?.leagueSeasonId !== leagueFilter) continue;
+    if (
+      teamFilter &&
+      matchup?.homeTeamSeasonId !== teamFilter &&
+      matchup?.visitorTeamSeasonId !== teamFilter
+    ) {
+      continue;
+    }
+    games.push({
+      gameStatus: GameStatus.Scheduled,
+      gameDate: assignment.startTime,
+      fieldId: assignment.fieldId,
+      field: {
+        id: assignment.fieldId,
+        name: fieldNameById.get(assignment.fieldId) ?? '',
+        shortName: '',
+      },
+      homeTeamId: matchup?.homeTeamSeasonId,
+      visitorTeamId: matchup?.visitorTeamSeasonId,
+    });
+  }
+  return games;
+};

--- a/draco-nodejs/frontend-next/components/scheduler/proposalSummary.ts
+++ b/draco-nodejs/frontend-next/components/scheduler/proposalSummary.ts
@@ -75,7 +75,9 @@ export const buildProposalSummaryGames = (
       fieldId: assignment.fieldId,
       field: {
         id: assignment.fieldId,
-        name: fieldNameById.get(assignment.fieldId) ?? '',
+        name: assignment.fieldId
+          ? fieldNameById.get(assignment.fieldId) || `Field ${assignment.fieldId}`
+          : '',
         shortName: '',
       },
       homeTeamId: matchup?.homeTeamSeasonId,

--- a/draco-nodejs/frontend-next/hooks/useSeasonSchedulerOperations.ts
+++ b/draco-nodejs/frontend-next/hooks/useSeasonSchedulerOperations.ts
@@ -143,6 +143,14 @@ export const useSeasonSchedulerOperations = (accountId: string, seasonId: string
         (s, a, i, request: SchedulerSeasonSolveRequest, options?: { idempotencyKey?: string }) =>
           s.solveSeason(a, i, request, options),
       ),
+      enqueueSeasonRun: mutate(
+        (s, a, i, request: SchedulerSeasonSolveRequest, options?: { idempotencyKey?: string }) =>
+          s.enqueueSeasonRun(a, i, request, options),
+      ),
+      getSeasonRun: (runId: string, signal?: AbortSignal) => {
+        const { service, accountId, seasonId } = getContext();
+        return service.getSeasonRun(accountId, seasonId, runId, signal);
+      },
       applySeason: mutate((s, a, i, request: SchedulerSeasonApplyRequest) =>
         s.applySeason(a, i, request),
       ),

--- a/draco-nodejs/frontend-next/services/__tests__/schedulerService.test.ts
+++ b/draco-nodejs/frontend-next/services/__tests__/schedulerService.test.ts
@@ -4,6 +4,8 @@ import {
   getSchedulerSeasonWindowConfig as apiGetWindowConfig,
   upsertSchedulerSeasonWindowConfig as apiUpsertWindowConfig,
   solveSeasonSchedule as apiSolveSeason,
+  enqueueSeasonScheduleRun as apiEnqueueRun,
+  getSeasonScheduleRun as apiGetRun,
   applySeasonSchedule as apiApplySeason,
   listSchedulerSeasonExclusions as apiListSeasonExclusions,
   createSchedulerSeasonExclusion as apiCreateSeasonExclusion,
@@ -27,6 +29,8 @@ vi.mock('@draco/shared-api-client', () => ({
   getSchedulerSeasonWindowConfig: vi.fn(),
   upsertSchedulerSeasonWindowConfig: vi.fn(),
   solveSeasonSchedule: vi.fn(),
+  enqueueSeasonScheduleRun: vi.fn(),
+  getSeasonScheduleRun: vi.fn(),
   applySeasonSchedule: vi.fn(),
   listSchedulerSeasonExclusions: vi.fn(),
   createSchedulerSeasonExclusion: vi.fn(),
@@ -169,6 +173,49 @@ describe('SchedulerService', () => {
       await service.solveSeason(ACCOUNT_ID, SEASON_ID, {} as never);
 
       expect(apiSolveSeason).toHaveBeenCalledWith(expect.objectContaining({ headers: undefined }));
+    });
+  });
+
+  describe('enqueueSeasonRun', () => {
+    it('queues a run and forwards the idempotency key', async () => {
+      const runState = { runId: 'run-1', status: 'queued', progress: { processed: 0, total: 10 } };
+      vi.mocked(apiEnqueueRun).mockResolvedValue(makeOk(runState));
+
+      const request = { objectives: { primary: 'maximize_scheduled_games' } } as never;
+      const result = await service.enqueueSeasonRun(ACCOUNT_ID, SEASON_ID, request, {
+        idempotencyKey: 'idem-9',
+      });
+
+      expect(apiEnqueueRun).toHaveBeenCalledWith({
+        client,
+        path: { accountId: ACCOUNT_ID, seasonId: SEASON_ID },
+        body: request,
+        headers: { 'Idempotency-Key': 'idem-9' },
+        throwOnError: false,
+      });
+      expect((result as Record<string, unknown>).runId).toBe('run-1');
+    });
+  });
+
+  describe('getSeasonRun', () => {
+    it('fetches run status by id and threads the abort signal', async () => {
+      const runState = {
+        runId: 'run-1',
+        status: 'completed',
+        progress: { processed: 10, total: 10 },
+      };
+      vi.mocked(apiGetRun).mockResolvedValue(makeOk(runState));
+      const controller = new AbortController();
+
+      const result = await service.getSeasonRun(ACCOUNT_ID, SEASON_ID, 'run-1', controller.signal);
+
+      expect(apiGetRun).toHaveBeenCalledWith({
+        client,
+        path: { accountId: ACCOUNT_ID, seasonId: SEASON_ID, runId: 'run-1' },
+        signal: controller.signal,
+        throwOnError: false,
+      });
+      expect((result as Record<string, unknown>).status).toBe('completed');
     });
   });
 

--- a/draco-nodejs/frontend-next/services/schedulerService.ts
+++ b/draco-nodejs/frontend-next/services/schedulerService.ts
@@ -13,6 +13,7 @@ import type {
   SchedulerSeasonWindowConfigUpsert,
   SchedulerSeasonApplyRequest,
   SchedulerSeasonSolveRequest,
+  SchedulerRunState,
   SchedulerSolveResult,
   SchedulerTeamExclusion,
   SchedulerTeamExclusionUpsert,
@@ -31,7 +32,9 @@ import {
   deleteSchedulerSeasonExclusion,
   deleteSchedulerTeamExclusion,
   deleteSchedulerUmpireExclusion,
+  enqueueSeasonScheduleRun,
   generateSeasonMatchups,
+  getSeasonScheduleRun,
   getSchedulerProblemSpecPreview,
   getSchedulerSeasonWindowConfig,
   listSchedulerLeagueExclusions,
@@ -124,6 +127,39 @@ export class SchedulerService {
     });
 
     return unwrapApiResult(result, 'Failed to generate schedule proposal');
+  }
+
+  async enqueueSeasonRun(
+    accountId: string,
+    seasonId: string,
+    request: SchedulerSeasonSolveRequest,
+    options?: { idempotencyKey?: string },
+  ): Promise<SchedulerRunState> {
+    const result = await enqueueSeasonScheduleRun({
+      client: this.client,
+      path: { accountId, seasonId },
+      body: request,
+      headers: options?.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : undefined,
+      throwOnError: false,
+    });
+
+    return unwrapApiResult(result, 'Failed to queue schedule generation');
+  }
+
+  async getSeasonRun(
+    accountId: string,
+    seasonId: string,
+    runId: string,
+    signal?: AbortSignal,
+  ): Promise<SchedulerRunState> {
+    const result = await getSeasonScheduleRun({
+      client: this.client,
+      path: { accountId, seasonId, runId },
+      signal,
+      throwOnError: false,
+    });
+
+    return unwrapApiResult(result, 'Failed to load schedule run status');
   }
 
   async generateSeasonMatchups(

--- a/draco-nodejs/frontend-next/utils/__tests__/schedulerConstraintStorage.test.ts
+++ b/draco-nodejs/frontend-next/utils/__tests__/schedulerConstraintStorage.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildSolveConstraints,
+  DEFAULT_CONSTRAINT_CONFIG,
+  loadConstraintConfig,
+  saveConstraintConfig,
+  type SchedulerConstraintConfig,
+} from '../schedulerConstraintStorage';
+
+const cloneDefault = (): SchedulerConstraintConfig => ({
+  ...DEFAULT_CONSTRAINT_CONFIG,
+  softOrder: [...DEFAULT_CONSTRAINT_CONFIG.softOrder],
+  avoidBackToBackGames: { ...DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames },
+  spreadGamesAcrossDays: { ...DEFAULT_CONSTRAINT_CONFIG.spreadGamesAcrossDays },
+  balanceEarlyVsLate: { ...DEFAULT_CONSTRAINT_CONFIG.balanceEarlyVsLate },
+  maxGamesPerTeamPerDay: { ...DEFAULT_CONSTRAINT_CONFIG.maxGamesPerTeamPerDay },
+  requireLightsAfter: { ...DEFAULT_CONSTRAINT_CONFIG.requireLightsAfter },
+});
+
+describe('schedulerConstraintStorage — buildSolveConstraints', () => {
+  it('returns undefined when nothing is enabled and no umpire limit is supplied', () => {
+    expect(buildSolveConstraints(cloneDefault(), undefined)).toBeUndefined();
+  });
+
+  it('includes only the umpire limit when no constraint is enabled', () => {
+    expect(buildSolveConstraints(cloneDefault(), 3)).toEqual({
+      hard: { maxGamesPerUmpirePerDay: 3 },
+    });
+  });
+
+  it('derives soft weights from list order (top = highest)', () => {
+    const config = cloneDefault();
+    config.softOrder = ['spreadGamesAcrossDays', 'balanceEarlyVsLate', 'avoidBackToBackGames'];
+    config.avoidBackToBackGames = { enabled: true, minRestMinutes: 120 };
+    config.spreadGamesAcrossDays = { enabled: true };
+    config.balanceEarlyVsLate = { enabled: true };
+
+    const result = buildSolveConstraints(config, undefined);
+
+    expect(result?.soft?.spreadGamesAcrossDays).toEqual({ enabled: true, weight: 3 });
+    expect(result?.soft?.balanceEarlyVsLate).toEqual({ enabled: true, weight: 2 });
+    expect(result?.soft?.avoidBackToBackGames).toEqual({
+      enabled: true,
+      minRestMinutes: 120,
+      weight: 1,
+    });
+  });
+
+  it('omits disabled soft constraints', () => {
+    const config = cloneDefault();
+    config.spreadGamesAcrossDays = { enabled: true };
+
+    const result = buildSolveConstraints(config, undefined);
+
+    expect(result?.soft?.spreadGamesAcrossDays).toBeDefined();
+    expect(result?.soft?.avoidBackToBackGames).toBeUndefined();
+    expect(result?.soft?.balanceEarlyVsLate).toBeUndefined();
+  });
+
+  it('maps enabled hard limits and merges the umpire limit', () => {
+    const config = cloneDefault();
+    config.maxGamesPerTeamPerDay = { enabled: true, value: 2 };
+    config.requireLightsAfter = { enabled: true, startHourLocal: 19 };
+
+    const result = buildSolveConstraints(config, 4);
+
+    expect(result?.hard).toEqual({
+      maxGamesPerUmpirePerDay: 4,
+      maxGamesPerTeamPerDay: 2,
+      requireLightsAfter: { enabled: true, startHourLocal: 19 },
+    });
+    expect(result?.soft).toBeUndefined();
+  });
+});
+
+describe('schedulerConstraintStorage — persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to all-off when nothing is stored', () => {
+    expect(loadConstraintConfig('1', '2026')).toEqual(DEFAULT_CONSTRAINT_CONFIG);
+  });
+
+  it('round-trips a saved config for the same account and season', () => {
+    const config = cloneDefault();
+    config.softOrder = ['balanceEarlyVsLate', 'avoidBackToBackGames', 'spreadGamesAcrossDays'];
+    config.avoidBackToBackGames = { enabled: true, minRestMinutes: 60 };
+    config.maxGamesPerTeamPerDay = { enabled: true, value: 3 };
+
+    saveConstraintConfig('1', '2026', config);
+
+    expect(loadConstraintConfig('1', '2026')).toEqual(config);
+  });
+
+  it('isolates config by account and season key', () => {
+    const config = cloneDefault();
+    config.spreadGamesAcrossDays = { enabled: true };
+    saveConstraintConfig('1', '2026', config);
+
+    expect(loadConstraintConfig('1', '2025')).toEqual(DEFAULT_CONSTRAINT_CONFIG);
+    expect(loadConstraintConfig('2', '2026')).toEqual(DEFAULT_CONSTRAINT_CONFIG);
+    expect(loadConstraintConfig('1', '2026').spreadGamesAcrossDays.enabled).toBe(true);
+  });
+
+  it('repairs a partial/corrupt softOrder by appending missing keys', () => {
+    window.localStorage.setItem(
+      'scheduler:constraintConfig:1:2026',
+      JSON.stringify({ softOrder: ['balanceEarlyVsLate'] }),
+    );
+
+    const loaded = loadConstraintConfig('1', '2026');
+
+    expect(loaded.softOrder).toEqual([
+      'balanceEarlyVsLate',
+      'avoidBackToBackGames',
+      'spreadGamesAcrossDays',
+    ]);
+  });
+});

--- a/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
@@ -52,7 +52,7 @@ const clampInt = (value: number, min: number, max?: number): number => {
   return max === undefined ? floored : Math.min(max, floored);
 };
 
-const cloneDefaultConfig = (): SchedulerConstraintConfig => ({
+export const cloneDefaultConfig = (): SchedulerConstraintConfig => ({
   softOrder: [...DEFAULT_CONSTRAINT_CONFIG.softOrder],
   avoidBackToBackGames: { ...DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames },
   spreadGamesAcrossDays: { ...DEFAULT_CONSTRAINT_CONFIG.spreadGamesAcrossDays },

--- a/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
@@ -47,6 +47,11 @@ const normalizeSoftOrder = (order: unknown): SchedulerSoftConstraintKey[] => {
 const buildConstraintStorageKey = (accountId: string, seasonId: string): string =>
   `scheduler:constraintConfig:${accountId}:${seasonId}`;
 
+const clampInt = (value: number, min: number, max?: number): number => {
+  const floored = Math.max(min, Math.floor(value));
+  return max === undefined ? floored : Math.min(max, floored);
+};
+
 const cloneDefaultConfig = (): SchedulerConstraintConfig => ({
   softOrder: [...DEFAULT_CONSTRAINT_CONFIG.softOrder],
   avoidBackToBackGames: { ...DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames },
@@ -72,7 +77,7 @@ export const loadConstraintConfig = (
         minRestMinutes:
           typeof parsed.avoidBackToBackGames?.minRestMinutes === 'number' &&
           Number.isFinite(parsed.avoidBackToBackGames.minRestMinutes)
-            ? parsed.avoidBackToBackGames.minRestMinutes
+            ? clampInt(parsed.avoidBackToBackGames.minRestMinutes, 0)
             : DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames.minRestMinutes,
       },
       spreadGamesAcrossDays: { enabled: parsed.spreadGamesAcrossDays?.enabled === true },
@@ -82,7 +87,7 @@ export const loadConstraintConfig = (
         value:
           typeof parsed.maxGamesPerTeamPerDay?.value === 'number' &&
           Number.isFinite(parsed.maxGamesPerTeamPerDay.value)
-            ? parsed.maxGamesPerTeamPerDay.value
+            ? clampInt(parsed.maxGamesPerTeamPerDay.value, 1)
             : DEFAULT_CONSTRAINT_CONFIG.maxGamesPerTeamPerDay.value,
       },
       requireLightsAfter: {
@@ -90,7 +95,7 @@ export const loadConstraintConfig = (
         startHourLocal:
           typeof parsed.requireLightsAfter?.startHourLocal === 'number' &&
           Number.isFinite(parsed.requireLightsAfter.startHourLocal)
-            ? parsed.requireLightsAfter.startHourLocal
+            ? clampInt(parsed.requireLightsAfter.startHourLocal, 0, 23)
             : DEFAULT_CONSTRAINT_CONFIG.requireLightsAfter.startHourLocal,
       },
     };

--- a/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
@@ -1,0 +1,151 @@
+import type { SchedulerSeasonSolveRequest } from '@draco/shared-schemas';
+
+export type SchedulerSoftConstraintKey =
+  | 'avoidBackToBackGames'
+  | 'spreadGamesAcrossDays'
+  | 'balanceEarlyVsLate';
+
+export interface SchedulerConstraintConfig {
+  softOrder: SchedulerSoftConstraintKey[];
+  avoidBackToBackGames: { enabled: boolean; minRestMinutes: number };
+  spreadGamesAcrossDays: { enabled: boolean };
+  balanceEarlyVsLate: { enabled: boolean };
+  maxGamesPerTeamPerDay: { enabled: boolean; value: number };
+  requireLightsAfter: { enabled: boolean; startHourLocal: number };
+}
+
+export const DEFAULT_CONSTRAINT_CONFIG: SchedulerConstraintConfig = {
+  softOrder: ['avoidBackToBackGames', 'spreadGamesAcrossDays', 'balanceEarlyVsLate'],
+  avoidBackToBackGames: { enabled: false, minRestMinutes: 2880 },
+  spreadGamesAcrossDays: { enabled: false },
+  balanceEarlyVsLate: { enabled: false },
+  maxGamesPerTeamPerDay: { enabled: false, value: 1 },
+  requireLightsAfter: { enabled: false, startHourLocal: 18 },
+};
+
+const SOFT_KEYS: SchedulerSoftConstraintKey[] = [
+  'avoidBackToBackGames',
+  'spreadGamesAcrossDays',
+  'balanceEarlyVsLate',
+];
+
+const normalizeSoftOrder = (order: unknown): SchedulerSoftConstraintKey[] => {
+  const provided = Array.isArray(order)
+    ? order.filter((key): key is SchedulerSoftConstraintKey =>
+        SOFT_KEYS.includes(key as SchedulerSoftConstraintKey),
+      )
+    : [];
+  const deduped = Array.from(new Set(provided));
+  for (const key of SOFT_KEYS) {
+    if (!deduped.includes(key)) {
+      deduped.push(key);
+    }
+  }
+  return deduped;
+};
+
+const buildConstraintStorageKey = (accountId: string, seasonId: string): string =>
+  `scheduler:constraintConfig:${accountId}:${seasonId}`;
+
+export const loadConstraintConfig = (
+  accountId: string,
+  seasonId: string,
+): SchedulerConstraintConfig => {
+  if (typeof window === 'undefined') return { ...DEFAULT_CONSTRAINT_CONFIG };
+  try {
+    const raw = window.localStorage.getItem(buildConstraintStorageKey(accountId, seasonId));
+    if (!raw) return { ...DEFAULT_CONSTRAINT_CONFIG };
+    const parsed = JSON.parse(raw) as Partial<SchedulerConstraintConfig>;
+    return {
+      softOrder: normalizeSoftOrder(parsed.softOrder),
+      avoidBackToBackGames: {
+        enabled: parsed.avoidBackToBackGames?.enabled === true,
+        minRestMinutes:
+          typeof parsed.avoidBackToBackGames?.minRestMinutes === 'number' &&
+          Number.isFinite(parsed.avoidBackToBackGames.minRestMinutes)
+            ? parsed.avoidBackToBackGames.minRestMinutes
+            : DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames.minRestMinutes,
+      },
+      spreadGamesAcrossDays: { enabled: parsed.spreadGamesAcrossDays?.enabled === true },
+      balanceEarlyVsLate: { enabled: parsed.balanceEarlyVsLate?.enabled === true },
+      maxGamesPerTeamPerDay: {
+        enabled: parsed.maxGamesPerTeamPerDay?.enabled === true,
+        value:
+          typeof parsed.maxGamesPerTeamPerDay?.value === 'number' &&
+          Number.isFinite(parsed.maxGamesPerTeamPerDay.value)
+            ? parsed.maxGamesPerTeamPerDay.value
+            : DEFAULT_CONSTRAINT_CONFIG.maxGamesPerTeamPerDay.value,
+      },
+      requireLightsAfter: {
+        enabled: parsed.requireLightsAfter?.enabled === true,
+        startHourLocal:
+          typeof parsed.requireLightsAfter?.startHourLocal === 'number' &&
+          Number.isFinite(parsed.requireLightsAfter.startHourLocal)
+            ? parsed.requireLightsAfter.startHourLocal
+            : DEFAULT_CONSTRAINT_CONFIG.requireLightsAfter.startHourLocal,
+      },
+    };
+  } catch {
+    return { ...DEFAULT_CONSTRAINT_CONFIG };
+  }
+};
+
+export const saveConstraintConfig = (
+  accountId: string,
+  seasonId: string,
+  config: SchedulerConstraintConfig,
+): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      buildConstraintStorageKey(accountId, seasonId),
+      JSON.stringify(config),
+    );
+  } catch {}
+};
+
+export const buildSolveConstraints = (
+  config: SchedulerConstraintConfig,
+  maxGamesPerUmpirePerDay?: number,
+): SchedulerSeasonSolveRequest['constraints'] => {
+  const soft: NonNullable<NonNullable<SchedulerSeasonSolveRequest['constraints']>['soft']> = {};
+  config.softOrder.forEach((key, index) => {
+    const weight = config.softOrder.length - index;
+    if (key === 'avoidBackToBackGames' && config.avoidBackToBackGames.enabled) {
+      soft.avoidBackToBackGames = {
+        enabled: true,
+        minRestMinutes: config.avoidBackToBackGames.minRestMinutes,
+        weight,
+      };
+    } else if (key === 'spreadGamesAcrossDays' && config.spreadGamesAcrossDays.enabled) {
+      soft.spreadGamesAcrossDays = { enabled: true, weight };
+    } else if (key === 'balanceEarlyVsLate' && config.balanceEarlyVsLate.enabled) {
+      soft.balanceEarlyVsLate = { enabled: true, weight };
+    }
+  });
+
+  const hard: NonNullable<NonNullable<SchedulerSeasonSolveRequest['constraints']>['hard']> = {};
+  if (maxGamesPerUmpirePerDay !== undefined) {
+    hard.maxGamesPerUmpirePerDay = Math.floor(maxGamesPerUmpirePerDay);
+  }
+  if (config.maxGamesPerTeamPerDay.enabled) {
+    hard.maxGamesPerTeamPerDay = Math.floor(config.maxGamesPerTeamPerDay.value);
+  }
+  if (config.requireLightsAfter.enabled) {
+    hard.requireLightsAfter = {
+      enabled: true,
+      startHourLocal: config.requireLightsAfter.startHourLocal,
+    };
+  }
+
+  const hasSoft = Object.keys(soft).length > 0;
+  const hasHard = Object.keys(hard).length > 0;
+  if (!hasSoft && !hasHard) {
+    return undefined;
+  }
+
+  return {
+    ...(hasHard ? { hard } : {}),
+    ...(hasSoft ? { soft } : {}),
+  };
+};

--- a/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
+++ b/draco-nodejs/frontend-next/utils/schedulerConstraintStorage.ts
@@ -47,14 +47,23 @@ const normalizeSoftOrder = (order: unknown): SchedulerSoftConstraintKey[] => {
 const buildConstraintStorageKey = (accountId: string, seasonId: string): string =>
   `scheduler:constraintConfig:${accountId}:${seasonId}`;
 
+const cloneDefaultConfig = (): SchedulerConstraintConfig => ({
+  softOrder: [...DEFAULT_CONSTRAINT_CONFIG.softOrder],
+  avoidBackToBackGames: { ...DEFAULT_CONSTRAINT_CONFIG.avoidBackToBackGames },
+  spreadGamesAcrossDays: { ...DEFAULT_CONSTRAINT_CONFIG.spreadGamesAcrossDays },
+  balanceEarlyVsLate: { ...DEFAULT_CONSTRAINT_CONFIG.balanceEarlyVsLate },
+  maxGamesPerTeamPerDay: { ...DEFAULT_CONSTRAINT_CONFIG.maxGamesPerTeamPerDay },
+  requireLightsAfter: { ...DEFAULT_CONSTRAINT_CONFIG.requireLightsAfter },
+});
+
 export const loadConstraintConfig = (
   accountId: string,
   seasonId: string,
 ): SchedulerConstraintConfig => {
-  if (typeof window === 'undefined') return { ...DEFAULT_CONSTRAINT_CONFIG };
+  if (typeof window === 'undefined') return cloneDefaultConfig();
   try {
     const raw = window.localStorage.getItem(buildConstraintStorageKey(accountId, seasonId));
-    if (!raw) return { ...DEFAULT_CONSTRAINT_CONFIG };
+    if (!raw) return cloneDefaultConfig();
     const parsed = JSON.parse(raw) as Partial<SchedulerConstraintConfig>;
     return {
       softOrder: normalizeSoftOrder(parsed.softOrder),
@@ -86,7 +95,7 @@ export const loadConstraintConfig = (
       },
     };
   } catch {
-    return { ...DEFAULT_CONSTRAINT_CONFIG };
+    return cloneDefaultConfig();
   }
 };
 

--- a/draco-nodejs/shared/shared-schemas/scheduler.ts
+++ b/draco-nodejs/shared/shared-schemas/scheduler.ts
@@ -627,6 +627,39 @@ export const SchedulerSolveResultSchema = z
     },
   });
 
+export const SchedulerRunLifecycleStatusSchema = z
+  .enum(['queued', 'running', 'completed', 'failed'])
+  .openapi({
+    title: 'SchedulerRunLifecycleStatus',
+    description: 'Lifecycle state of an asynchronous schedule-generation run.',
+  });
+
+export const SchedulerRunProgressSchema = z
+  .object({
+    processed: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  })
+  .openapi({ title: 'SchedulerRunProgress' });
+
+export const SchedulerRunStateSchema = z
+  .object({
+    runId: z.string().trim().min(1),
+    status: SchedulerRunLifecycleStatusSchema,
+    progress: SchedulerRunProgressSchema,
+    result: SchedulerSolveResultSchema.optional(),
+    error: z.string().optional(),
+  })
+  .openapi({
+    title: 'SchedulerRunState',
+    description:
+      'Status of an asynchronous schedule-generation run, including progress and the final result when completed.',
+    example: {
+      runId: 'sched_account_42_ab12cd34ef56gh78',
+      status: 'running',
+      progress: { processed: 120, total: 480 },
+    },
+  });
+
 export const SchedulerApplyModeSchema = z.enum(['all', 'subset']).openapi({
   title: 'SchedulerApplyMode',
   description: 'Whether to apply all assignments or only a subset.',
@@ -763,6 +796,9 @@ export type SchedulerUnscheduledReason = z.infer<typeof SchedulerUnscheduledReas
 export type SchedulerMetrics = z.infer<typeof SchedulerMetricsSchema>;
 export type SchedulerRunStatus = z.infer<typeof SchedulerRunStatusSchema>;
 export type SchedulerSolveResult = z.infer<typeof SchedulerSolveResultSchema>;
+export type SchedulerRunLifecycleStatus = z.infer<typeof SchedulerRunLifecycleStatusSchema>;
+export type SchedulerRunProgress = z.infer<typeof SchedulerRunProgressSchema>;
+export type SchedulerRunState = z.infer<typeof SchedulerRunStateSchema>;
 export type SchedulerApplyMode = z.infer<typeof SchedulerApplyModeSchema>;
 export type SchedulerApplyRequest = z.infer<typeof SchedulerApplyRequestSchema>;
 export type SchedulerApplySkipped = z.infer<typeof SchedulerApplySkippedSchema>;


### PR DESCRIPTION
Implements asynchronous schedule generation: adds enqueue (POST /scheduler/runs) and status (GET /scheduler/runs/{runId}) endpoints and the SchedulerRunState schema in OpenAPI (json/yaml). Introduces a new schedulerrun persistence table (Prisma migration 20260621000000_add_schedulerrun and schema.prisma changes) and repository/service layers (PrismaSchedulerRunRepository, ISchedulerRunRepository, schedulerRunService) plus response formatter and service factory wiring. Refactors solver to support yielding/progress callbacks and an in-process worker that persists progress/results; includes related backend tests. Updates frontend to enqueue and poll runs, adds UI components and tests for the async flow. Adds design docs (docs/scheduler-async-job-proposal.md) and shared-schema updates for run/progress types. Migration must be applied (pnpm exec prisma migrate deploy).