### PR TITLE
Add disableScrollToToday prop to schedule views

### DIFF
--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/schedule/TeamSchedulePage.tsx
@@ -178,6 +178,7 @@ const TeamSchedulePage: React.FC<TeamSchedulePageProps> = ({
     } else {
       setFilterDate(today);
     }
+    setScrollToTodayNonce((nonce) => nonce + 1);
   }
 
   const {

--- a/draco-nodejs/frontend-next/components/schedule/ScheduleControl.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/ScheduleControl.tsx
@@ -47,6 +47,7 @@ export interface ScheduleControlProps {
   summaryContent?: React.ReactNode;
   scrollToTodayNonce?: number;
   onScrollToToday?: () => void;
+  disableScrollToToday?: boolean;
   children?: React.ReactNode;
 }
 
@@ -88,6 +89,7 @@ const ScheduleControl: React.FC<ScheduleControlProps> = ({
   summaryContent,
   scrollToTodayNonce,
   onScrollToToday,
+  disableScrollToToday,
   children,
 }) => {
   return (
@@ -191,6 +193,7 @@ const ScheduleControl: React.FC<ScheduleControlProps> = ({
         navigate={navigate}
         scrollToTodayNonce={scrollToTodayNonce}
         onScrollToToday={onScrollToToday}
+        disableScrollToToday={disableScrollToToday}
       />
     </>
   );

--- a/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/CalendarGrid.tsx
@@ -22,6 +22,7 @@ export interface CalendarGridProps {
   currentMonthDate?: Date;
   loadingGames?: boolean;
   scrollToTodayNonce?: number;
+  disableScrollToToday?: boolean;
 
   // Data
   days: Date[];
@@ -73,6 +74,7 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
   currentMonthDate,
   loadingGames = false,
   scrollToTodayNonce,
+  disableScrollToToday = false,
   days,
   filteredGames,
   minHeight = '300px',
@@ -154,7 +156,7 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
   const todayKey = getDateKeyInTimezone(new Date(), timeZone);
   const todayInView =
     !!todayKey && days.some((day) => getDateKeyInTimezone(day, timeZone) === todayKey);
-  const focusDateKey = todayInView ? todayKey : null;
+  const focusDateKey = disableScrollToToday ? null : todayInView ? todayKey : null;
   const focusCellRef = useScrollToTarget<HTMLDivElement>(focusDateKey, {
     block: 'nearest',
     ready: !loadingGames,

--- a/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/DayListView.tsx
@@ -45,6 +45,7 @@ const DayListView: React.FC<DayListViewProps> = ({
   loadingGames,
   scrollToTodayNonce,
   onScrollToToday,
+  disableScrollToToday,
   readOnly,
 }) => {
   const theme = useTheme();
@@ -132,7 +133,11 @@ const DayListView: React.FC<DayListViewProps> = ({
     (periodStartKey === null || todayKey >= periodStartKey) &&
     (periodEndKey === null || todayKey <= periodEndKey);
   const scrollTargetKey =
-    todayInRange && todayKey && sortedDates !== null && sortedDates.length > 0
+    !disableScrollToToday &&
+    todayInRange &&
+    todayKey &&
+    sortedDates !== null &&
+    sortedDates.length > 0
       ? (sortedDates.find((key) => key >= todayKey) ?? sortedDates[sortedDates.length - 1])
       : undefined;
   const focusGroupRef = useScrollToTarget<HTMLDivElement>(scrollTargetKey, {

--- a/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/MonthView.tsx
@@ -35,6 +35,7 @@ const MonthView: React.FC<ViewComponentProps> = ({
   loadingGames,
   scrollToTodayNonce,
   onScrollToToday,
+  disableScrollToToday,
   readOnly,
 }) => {
   const [currentMonth, setCurrentMonth] = React.useState(filterDate);
@@ -99,6 +100,7 @@ const MonthView: React.FC<ViewComponentProps> = ({
         showZoomColumn={true}
         loadingGames={loadingGames}
         scrollToTodayNonce={scrollToTodayNonce}
+        disableScrollToToday={disableScrollToToday}
         days={monthDays}
         filteredGames={filteredGames}
         minHeight="200px"

--- a/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/views/WeekView.tsx
@@ -32,6 +32,7 @@ const WeekView: React.FC<ViewComponentProps> = ({
   loadingGames,
   scrollToTodayNonce,
   onScrollToToday,
+  disableScrollToToday,
   readOnly,
 }) => {
   const weekDays =
@@ -90,6 +91,7 @@ const WeekView: React.FC<ViewComponentProps> = ({
         showZoomColumn={false}
         loadingGames={loadingGames}
         scrollToTodayNonce={scrollToTodayNonce}
+        disableScrollToToday={disableScrollToToday}
         days={weekDays}
         filteredGames={filteredGames}
         minHeight="300px"

--- a/draco-nodejs/frontend-next/components/scheduler/ProposedScheduleControl.tsx
+++ b/draco-nodejs/frontend-next/components/scheduler/ProposedScheduleControl.tsx
@@ -137,6 +137,7 @@ export const ProposedScheduleControl: React.FC<ProposedScheduleControlProps> = (
       canEditSchedule={false}
       showLeagueTeamFilters
       readOnly
+      disableScrollToToday
     />
   );
 };

--- a/draco-nodejs/frontend-next/types/schedule.ts
+++ b/draco-nodejs/frontend-next/types/schedule.ts
@@ -189,6 +189,7 @@ export interface ViewComponentProps {
   canEditRecap?: (game: GameCardData) => boolean;
   scrollToTodayNonce?: number;
   onScrollToToday?: () => void;
+  disableScrollToToday?: boolean;
   readOnly?: boolean;
 }
 


### PR DESCRIPTION
Introduce a new disableScrollToToday boolean prop to ScheduleControl and ViewComponentProps to allow disabling automatic scroll-to-today behavior. Prop is threaded through ScheduleControl into MonthView, WeekView, DayListView and CalendarGrid; CalendarGrid defaults it to false and uses it to suppress setting the focusDateKey, DayListView uses it to avoid computing a scroll target. ProposedScheduleControl is updated to set disableScrollToToday to true. This preserves existing behavior by default while allowing callers to opt out of auto-scrolling to today.