### PR TITLE
Remove WidgetShell wrappers from scoreboards

### DIFF
--- a/draco-nodejs/frontend-next/components/TodayScoreboard.tsx
+++ b/draco-nodejs/frontend-next/components/TodayScoreboard.tsx
@@ -3,8 +3,6 @@ import ScoreboardBase from './ScoreboardBase';
 import { Game } from './GameListDisplay';
 import { createGamesLoader } from '../utils/gameTransformers';
 import { useApiClient } from '../hooks/useApiClient';
-import WidgetShell from './ui/WidgetShell';
-import { Typography } from '@mui/material';
 
 interface TodayScoreboardProps {
   accountId: string;
@@ -43,38 +41,6 @@ const TodayScoreboard: React.FC<TodayScoreboardProps> = ({
     return await gamesLoader(today, tomorrow, signal);
   };
 
-  const renderWrapper = (
-    content: React.ReactNode,
-    state: 'loading' | 'error' | 'empty' | 'content',
-  ): React.ReactNode => {
-    if (state === 'empty') {
-      return null;
-    }
-
-    return (
-      <WidgetShell
-        title={
-          <Typography variant="h6" fontWeight={700} color="text.primary">
-            Today&apos;s Games
-          </Typography>
-        }
-        subtitle={
-          <Typography variant="body2" color="text.secondary">
-            Latest scores and results from today.
-          </Typography>
-        }
-        accent="primary"
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-        }}
-      >
-        {content}
-      </WidgetShell>
-    );
-  };
-
   return (
     <ScoreboardBase
       accountId={accountId}
@@ -83,9 +49,8 @@ const TodayScoreboard: React.FC<TodayScoreboardProps> = ({
       timeOnly
       currentSeasonId={currentSeasonId}
       onGamesLoaded={onGamesLoaded}
-      title="Today"
+      title="Today's Games"
       loadGames={loadTodayGames}
-      renderWrapper={renderWrapper}
       liveSessionGameIds={liveSessionGameIds}
       canStartLiveScoring={canStartLiveScoring}
       onStartLiveScoring={onStartLiveScoring}

--- a/draco-nodejs/frontend-next/components/YesterdayScoreboard.tsx
+++ b/draco-nodejs/frontend-next/components/YesterdayScoreboard.tsx
@@ -3,8 +3,6 @@ import ScoreboardBase from './ScoreboardBase';
 import { Game } from './GameListDisplay';
 import { createGamesLoader } from '../utils/gameTransformers';
 import { useApiClient } from '../hooks/useApiClient';
-import WidgetShell from './ui/WidgetShell';
-import { Typography } from '@mui/material';
 
 interface YesterdayScoreboardProps {
   accountId: string;
@@ -33,38 +31,6 @@ const YesterdayScoreboard: React.FC<YesterdayScoreboardProps> = ({
     return await gamesLoader(yesterday, today, signal);
   };
 
-  const renderWrapper = (
-    content: React.ReactNode,
-    state: 'loading' | 'error' | 'empty' | 'content',
-  ): React.ReactNode => {
-    if (state === 'empty') {
-      return null;
-    }
-
-    return (
-      <WidgetShell
-        title={
-          <Typography variant="h6" fontWeight={700} color="text.primary">
-            Yesterday&apos;s Games
-          </Typography>
-        }
-        subtitle={
-          <Typography variant="body2" color="text.secondary">
-            Recap the action from yesterday.
-          </Typography>
-        }
-        accent="primary"
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-        }}
-      >
-        {content}
-      </WidgetShell>
-    );
-  };
-
   return (
     <ScoreboardBase
       accountId={accountId}
@@ -72,9 +38,8 @@ const YesterdayScoreboard: React.FC<YesterdayScoreboardProps> = ({
       layout={layout}
       currentSeasonId={currentSeasonId}
       onGamesLoaded={onGamesLoaded}
-      title="Yesterday"
+      title="Yesterday's Games"
       loadGames={loadYesterdayGames}
-      renderWrapper={renderWrapper}
     />
   );
 };


### PR DESCRIPTION
Remove custom renderWrapper and related UI imports from TodayScoreboard and YesterdayScoreboard. The WidgetShell and Typography imports and the renderWrapper functions were deleted, and the components now pass updated titles ("Today's Games" / "Yesterday's Games") directly to ScoreboardBase while no longer providing a renderWrapper prop. This simplifies the components and removes duplicate presentation logic and unused imports.