### PR TITLE
Validate field conflicts and game time range

### DIFF
--- a/draco-nodejs/backend/src/services/__tests__/scheduleService.fieldConflict.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/scheduleService.fieldConflict.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked } from 'vitest';
+
+import { ScheduleService } from '../scheduleService.js';
+import { ServiceFactory } from '../serviceFactory.js';
+import { RepositoryFactory } from '../../repositories/repositoryFactory.js';
+import type { IScheduleRepository } from '../../repositories/interfaces/IScheduleRepository.js';
+import type { EmailService } from '../emailService.js';
+import type { dbScheduleGameWithDetails } from '../../repositories/types/index.js';
+import { ConflictError } from '../../utils/customErrors.js';
+import { partialMock } from '../../test-utils/partialMock.js';
+
+const makeGame = (overrides: Partial<dbScheduleGameWithDetails> = {}): dbScheduleGameWithDetails =>
+  ({
+    id: 1n,
+    leagueid: 10n,
+    hteamid: 100n,
+    vteamid: 200n,
+    gamedate: new Date('2025-06-10T19:00:00Z'),
+    fieldid: 7n,
+    gamestatus: 0,
+    gametype: 0,
+    hscore: 0,
+    vscore: 0,
+    comment: '',
+    umpire1: null,
+    umpire2: null,
+    umpire3: null,
+    umpire4: null,
+    availablefields: null,
+    leagueseason: {
+      id: 10n,
+      seasonid: 5n,
+      leagueid: 1n,
+      league: { id: 1n, name: 'Summer League', accountid: 99n },
+      season: { id: 5n, name: '2025 Season', accountid: 99n, schedulevisible: true },
+    },
+    _count: { gamerecap: 0 },
+    ...overrides,
+  }) as dbScheduleGameWithDetails;
+
+describe('ScheduleService — field booking conflicts', () => {
+  let scheduleRepositoryMock: Mocked<IScheduleRepository>;
+  let service: ScheduleService;
+
+  const accountId = 99n;
+  const seasonId = 5n;
+  const userId = 'user-abc';
+  const gameId = 1n;
+
+  beforeEach(() => {
+    scheduleRepositoryMock = partialMock<IScheduleRepository>({
+      findGameWithAccountContext: vi.fn(),
+      createGame: vi.fn().mockResolvedValue(makeGame()),
+      updateGame: vi.fn().mockResolvedValue(makeGame()),
+      findTeamsInLeagueSeason: vi
+        .fn()
+        .mockResolvedValue([{ id: 100n } as never, { id: 200n } as never]),
+      findFieldConflict: vi.fn().mockResolvedValue(null),
+      getTeamNames: vi.fn().mockResolvedValue(
+        new Map([
+          ['100', 'Home Team'],
+          ['200', 'Visitor Team'],
+        ]),
+      ),
+    });
+
+    vi.spyOn(RepositoryFactory, 'getScheduleRepository').mockReturnValue(scheduleRepositoryMock);
+    vi.spyOn(ServiceFactory, 'getEmailService').mockReturnValue(
+      partialMock<EmailService>({ composeAndSendEmailFromUser: vi.fn() }),
+    );
+
+    service = new ScheduleService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const baseCreatePayload = {
+    leagueSeasonId: '10',
+    gameDate: '2025-06-10T19:00:00Z',
+    homeTeam: { id: '100' },
+    visitorTeam: { id: '200' },
+    field: { id: '7' },
+    comment: '',
+    gameStatus: 0,
+    gameType: 0,
+  };
+
+  describe('createGame', () => {
+    it('throws ConflictError when the field is already booked at that date/time', async () => {
+      scheduleRepositoryMock.findFieldConflict.mockResolvedValue(makeGame({ id: 2n }));
+
+      await expect(
+        service.createGame(accountId, seasonId, baseCreatePayload, userId),
+      ).rejects.toBeInstanceOf(ConflictError);
+
+      expect(scheduleRepositoryMock.findFieldConflict).toHaveBeenCalledWith(
+        7n,
+        new Date('2025-06-10T19:00:00Z'),
+        10n,
+      );
+      expect(scheduleRepositoryMock.createGame).not.toHaveBeenCalled();
+    });
+
+    it('creates the game when no field conflict exists', async () => {
+      await service.createGame(accountId, seasonId, baseCreatePayload, userId);
+
+      expect(scheduleRepositoryMock.createGame).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the conflict check when no field is set', async () => {
+      await service.createGame(accountId, seasonId, { ...baseCreatePayload, field: null }, userId);
+
+      expect(scheduleRepositoryMock.findFieldConflict).not.toHaveBeenCalled();
+      expect(scheduleRepositoryMock.createGame).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateGame', () => {
+    const existingGame = makeGame({
+      id: gameId,
+      gamedate: new Date('2025-06-10T19:00:00Z'),
+      fieldid: 7n,
+    });
+
+    const baseUpdatePayload = { ...baseCreatePayload };
+
+    beforeEach(() => {
+      scheduleRepositoryMock.findGameWithAccountContext.mockResolvedValue(existingGame as never);
+    });
+
+    it('throws ConflictError when the date/time moves onto an occupied slot on the same field', async () => {
+      scheduleRepositoryMock.findFieldConflict.mockResolvedValue(makeGame({ id: 2n }));
+
+      await expect(
+        service.updateGame(
+          accountId,
+          seasonId,
+          gameId,
+          { ...baseUpdatePayload, gameDate: '2025-06-10T21:00:00Z' },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(ConflictError);
+
+      expect(scheduleRepositoryMock.findFieldConflict).toHaveBeenCalledWith(
+        7n,
+        new Date('2025-06-10T21:00:00Z'),
+        10n,
+        gameId,
+      );
+      expect(scheduleRepositoryMock.updateGame).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictError when the field changes to an occupied slot', async () => {
+      scheduleRepositoryMock.findFieldConflict.mockResolvedValue(makeGame({ id: 2n }));
+
+      await expect(
+        service.updateGame(
+          accountId,
+          seasonId,
+          gameId,
+          { ...baseUpdatePayload, field: { id: '8' } },
+          userId,
+        ),
+      ).rejects.toBeInstanceOf(ConflictError);
+
+      expect(scheduleRepositoryMock.findFieldConflict).toHaveBeenCalledWith(
+        8n,
+        new Date('2025-06-10T19:00:00Z'),
+        10n,
+        gameId,
+      );
+    });
+
+    it('does not run the conflict check when field and date are unchanged', async () => {
+      await service.updateGame(
+        accountId,
+        seasonId,
+        gameId,
+        { ...baseUpdatePayload, comment: 'updated note' },
+        userId,
+      );
+
+      expect(scheduleRepositoryMock.findFieldConflict).not.toHaveBeenCalled();
+      expect(scheduleRepositoryMock.updateGame).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not run the conflict check when the field is cleared', async () => {
+      await service.updateGame(
+        accountId,
+        seasonId,
+        gameId,
+        { ...baseUpdatePayload, field: null },
+        userId,
+      );
+
+      expect(scheduleRepositoryMock.findFieldConflict).not.toHaveBeenCalled();
+      expect(scheduleRepositoryMock.updateGame).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/draco-nodejs/backend/src/services/scheduleService.ts
+++ b/draco-nodejs/backend/src/services/scheduleService.ts
@@ -803,15 +803,25 @@ export class ScheduleService {
     }
 
     const fieldId = payload.field?.id ? BigInt(payload.field.id) : undefined;
-    const fieldChanged = payload.field !== undefined && fieldId !== existingGame.fieldid;
 
-    if (fieldChanged && fieldId) {
-      const gameDate = payload.gameDate
-        ? this.parseGameDate(payload.gameDate)
-        : existingGame.gamedate;
+    const effectiveFieldId =
+      payload.field === undefined
+        ? existingGame.fieldid
+        : payload.field === null
+          ? null
+          : (fieldId ?? null);
+    const effectiveGameDate = payload.gameDate
+      ? this.parseGameDate(payload.gameDate)
+      : existingGame.gamedate;
+
+    const fieldOrDateChanged =
+      effectiveFieldId !== existingGame.fieldid ||
+      effectiveGameDate.getTime() !== existingGame.gamedate.getTime();
+
+    if (effectiveFieldId !== null && fieldOrDateChanged) {
       const conflict = await this.scheduleRepository.findFieldConflict(
-        fieldId,
-        gameDate,
+        effectiveFieldId,
+        effectiveGameDate,
         existingGame.leagueid,
         gameId,
       );

--- a/draco-nodejs/frontend-next/components/schedule/__tests__/gameTimeRange.test.ts
+++ b/draco-nodejs/frontend-next/components/schedule/__tests__/gameTimeRange.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isGameTimeWithinAllowedRange } from '../gameTimeRange';
+
+const at = (hour: number, minute = 0): Date => new Date(2025, 5, 10, hour, minute, 0, 0);
+
+describe('isGameTimeWithinAllowedRange', () => {
+  it('rejects times before 9:00 AM', () => {
+    expect(isGameTimeWithinAllowedRange(at(8, 59))).toBe(false);
+    expect(isGameTimeWithinAllowedRange(at(0))).toBe(false);
+  });
+
+  it('accepts 9:00 AM (inclusive lower bound)', () => {
+    expect(isGameTimeWithinAllowedRange(at(9, 0))).toBe(true);
+  });
+
+  it('accepts times within the window', () => {
+    expect(isGameTimeWithinAllowedRange(at(12, 30))).toBe(true);
+    expect(isGameTimeWithinAllowedRange(at(20, 59))).toBe(true);
+  });
+
+  it('accepts 9:00 PM exactly (inclusive upper bound)', () => {
+    expect(isGameTimeWithinAllowedRange(at(21, 0))).toBe(true);
+  });
+
+  it('rejects times after 9:00 PM', () => {
+    expect(isGameTimeWithinAllowedRange(at(21, 1))).toBe(false);
+    expect(isGameTimeWithinAllowedRange(at(22, 0))).toBe(false);
+    expect(isGameTimeWithinAllowedRange(at(23, 30))).toBe(false);
+  });
+});

--- a/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/dialogs/GameDialog.tsx
@@ -29,6 +29,7 @@ import { GameFormProvider } from '../contexts/GameFormContext';
 import GameFormFields from '../forms/GameFormFields';
 import { useGameOperations, GameFormValues } from '../hooks/useGameOperations';
 import { convertUTCToZonedDate, formatGameDateTime } from '../../../utils/dateUtils';
+import { isGameTimeWithinAllowedRange, GAME_TIME_RANGE_MESSAGE } from '../gameTimeRange';
 import type { GameDialogProps } from '../types/sportAdapter';
 
 const preprocessDate = (message: string) =>
@@ -69,6 +70,14 @@ const createGameDialogSchema = (gameStatus: number, timeZone: string) =>
           code: z.ZodIssueCode.custom,
           path: ['homeTeamId'],
           message: 'Home and visitor teams must be different',
+        });
+      }
+
+      if (data.gameTime && !isGameTimeWithinAllowedRange(data.gameTime)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['gameTime'],
+          message: GAME_TIME_RANGE_MESSAGE,
         });
       }
 

--- a/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
+++ b/draco-nodejs/frontend-next/components/schedule/forms/GameFormFields.tsx
@@ -10,9 +10,13 @@ import { getReadOnlyInputProps, getReadOnlyDatePickerInputProps } from '../../..
 import { useGameFormContext } from '../contexts/GameFormContext';
 import { Controller, useFormContext, type FieldPath } from 'react-hook-form';
 import type { GameDialogFormValues } from '../dialogs/GameDialog';
+import { GAME_TIME_MIN_HOUR, GAME_TIME_MAX_HOUR } from '../gameTimeRange';
 import { GameType } from '@/types/schedule';
 
 const EMPTY_LABEL = 'None';
+
+const GAME_TIME_MIN = new Date(2000, 0, 1, GAME_TIME_MIN_HOUR, 0, 0, 0);
+const GAME_TIME_MAX = new Date(2000, 0, 1, GAME_TIME_MAX_HOUR, 0, 0, 0);
 
 type AutoOption = { id: string; label: string };
 
@@ -188,6 +192,8 @@ const GameFormFields: React.FC = () => {
                 value={field.value ?? null}
                 onChange={(time) => field.onChange(time ?? null)}
                 readOnly={!canEditSchedule}
+                minTime={GAME_TIME_MIN}
+                maxTime={GAME_TIME_MAX}
                 slotProps={{
                   textField: {
                     fullWidth: true,

--- a/draco-nodejs/frontend-next/components/schedule/gameTimeRange.ts
+++ b/draco-nodejs/frontend-next/components/schedule/gameTimeRange.ts
@@ -1,6 +1,15 @@
 export const GAME_TIME_MIN_HOUR = 9;
 export const GAME_TIME_MAX_HOUR = 21;
-export const GAME_TIME_RANGE_MESSAGE = 'Game time must be between 9:00 AM and 9:00 PM';
+
+const formatHourLabel = (hour: number): string => {
+  const period = hour < 12 ? 'AM' : 'PM';
+  const twelveHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${twelveHour}:00 ${period}`;
+};
+
+export const GAME_TIME_RANGE_MESSAGE = `Game time must be between ${formatHourLabel(
+  GAME_TIME_MIN_HOUR,
+)} and ${formatHourLabel(GAME_TIME_MAX_HOUR)}`;
 
 export const isGameTimeWithinAllowedRange = (gameTime: Date): boolean => {
   const hour = gameTime.getHours();

--- a/draco-nodejs/frontend-next/components/schedule/gameTimeRange.ts
+++ b/draco-nodejs/frontend-next/components/schedule/gameTimeRange.ts
@@ -1,0 +1,18 @@
+export const GAME_TIME_MIN_HOUR = 9;
+export const GAME_TIME_MAX_HOUR = 21;
+export const GAME_TIME_RANGE_MESSAGE = 'Game time must be between 9:00 AM and 9:00 PM';
+
+export const isGameTimeWithinAllowedRange = (gameTime: Date): boolean => {
+  const hour = gameTime.getHours();
+  const minute = gameTime.getMinutes();
+
+  if (hour < GAME_TIME_MIN_HOUR) {
+    return false;
+  }
+
+  if (hour > GAME_TIME_MAX_HOUR || (hour === GAME_TIME_MAX_HOUR && minute > 0)) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
Backend: add tests for field booking conflicts and update ScheduleService.updateGame to compute effectiveFieldId/effectiveGameDate so conflict checks only run when the field/date actually change (and to skip checks when field is cleared). Frontend: add gameTimeRange utility with allowed hours and message, include unit tests, enforce the time window in GameDialog schema, and set min/max times on the time picker in GameFormFields.