### PR TITLE
Feat/allleagues

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -13834,6 +13834,9 @@
       "BattingStatisticsFilters": {
         "type": "object",
         "properties": {
+          "seasonId": {
+            "type": "string"
+          },
           "leagueId": {
             "type": "string"
           },
@@ -13880,6 +13883,9 @@
       "PitchingStatisticsFilters": {
         "type": "object",
         "properties": {
+          "seasonId": {
+            "type": "string"
+          },
           "leagueId": {
             "type": "string"
           },
@@ -13926,6 +13932,9 @@
       "LeaderStatisticsFilters": {
         "type": "object",
         "properties": {
+          "seasonId": {
+            "type": "string"
+          },
           "leagueId": {
             "type": "string"
           },
@@ -76248,6 +76257,14 @@
               "type": "string"
             },
             "required": false,
+            "name": "seasonId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
             "name": "leagueId",
             "in": "query"
           },
@@ -76398,6 +76415,14 @@
               "type": "string",
               "format": "number"
             }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "seasonId",
+            "in": "query"
           },
           {
             "schema": {
@@ -76635,6 +76660,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "seasonId",
+            "in": "query"
           },
           {
             "schema": {
@@ -77508,6 +77541,14 @@
               "type": "string"
             },
             "required": false,
+            "name": "seasonId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
             "name": "leagueId",
             "in": "query"
           },
@@ -77666,6 +77707,14 @@
               "type": "string",
               "format": "number"
             }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "seasonId",
+            "in": "query"
           },
           {
             "schema": {

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -10348,6 +10348,8 @@ components:
     BattingStatisticsFilters:
       type: object
       properties:
+        seasonId:
+          type: string
         leagueId:
           type: string
         divisionId:
@@ -10381,6 +10383,8 @@ components:
     PitchingStatisticsFilters:
       type: object
       properties:
+        seasonId:
+          type: string
         leagueId:
           type: string
         divisionId:
@@ -10414,6 +10418,8 @@ components:
     LeaderStatisticsFilters:
       type: object
       properties:
+        seasonId:
+          type: string
         leagueId:
           type: string
         divisionId:
@@ -51403,6 +51409,11 @@ paths:
         - schema:
             type: string
           required: false
+          name: seasonId
+          in: query
+        - schema:
+            type: string
+          required: false
           name: leagueId
           in: query
         - schema:
@@ -51502,6 +51513,11 @@ paths:
           schema:
             type: string
             format: number
+        - schema:
+            type: string
+          required: false
+          name: seasonId
+          in: query
         - schema:
             type: string
           required: false
@@ -51656,6 +51672,11 @@ paths:
           description: "Statistic category key (for example: avg, era, hr)."
           schema:
             type: string
+        - schema:
+            type: string
+          required: false
+          name: seasonId
+          in: query
         - schema:
             type: string
           required: false
@@ -52223,6 +52244,11 @@ paths:
         - schema:
             type: string
           required: false
+          name: seasonId
+          in: query
+        - schema:
+            type: string
+          required: false
           name: leagueId
           in: query
         - schema:
@@ -52329,6 +52355,11 @@ paths:
           schema:
             type: string
             format: number
+        - schema:
+            type: string
+          required: false
+          name: seasonId
+          in: query
         - schema:
             type: string
           required: false

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaBattingStatisticsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaBattingStatisticsRepository.ts
@@ -18,6 +18,8 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
     query: BattingStatisticsQueryOptions,
   ): Promise<dbBattingStatisticsRow[]> {
     const {
+      accountId,
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -32,7 +34,11 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
 
     const offset = (page - 1) * pageSize;
     let whereClause = '';
+    const seasonJoin = 'LEFT JOIN season s ON ls.seasonid = s.id';
     const params: (bigint | number)[] = [];
+
+    whereClause += ' AND s.accountid = $' + (params.length + 1);
+    params.push(accountId);
 
     if (leagueId && leagueId !== BigInt(0)) {
       if (isHistorical) {
@@ -41,6 +47,9 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
         whereClause += ' AND ls.id = $' + (params.length + 1);
       }
       params.push(leagueId);
+    } else if (seasonId && seasonId !== BigInt(0)) {
+      whereClause += ' AND ls.seasonid = $' + (params.length + 1);
+      params.push(seasonId);
     }
 
     if (divisionId && divisionId !== BigInt(0)) {
@@ -129,6 +138,7 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
       LEFT JOIN contacts c ON r.contactid = c.id
       LEFT JOIN leagueschedule lg ON bs.gameid = lg.id
       LEFT JOIN leagueseason ls ON lg.leagueid = ls.id
+      ${seasonJoin}
       ${teamJoin}
       WHERE ${includeAllGameTypes ? `lg.gametype IN (${GameType.RegularSeason}, ${GameType.Playoff})` : `lg.gametype = ${GameType.RegularSeason}`}
         ${whereClause}
@@ -238,13 +248,17 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
       return [];
     }
 
-    const { leagueId, teamId, isHistorical, includeAllGameTypes } = query;
+    const { accountId, seasonId, leagueId, teamId, isHistorical, includeAllGameTypes } = query;
     let whereClause = '';
+    const seasonJoin = 'LEFT JOIN season s ON ls.seasonid = s.id';
     const params: (bigint | number | bigint[])[] = [];
 
     // Use parameterized query for player IDs to prevent SQL injection
     const playerIdParamIndex = params.length + 1;
     params.push(playerIds);
+
+    whereClause += ' AND s.accountid = $' + (params.length + 1);
+    params.push(accountId);
 
     if (leagueId && leagueId !== BigInt(0)) {
       if (isHistorical) {
@@ -253,6 +267,9 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
         whereClause += ' AND ls.id = $' + (params.length + 1);
       }
       params.push(leagueId);
+    } else if (seasonId && seasonId !== BigInt(0)) {
+      whereClause += ' AND ls.seasonid = $' + (params.length + 1);
+      params.push(seasonId);
     }
 
     if (teamId && teamId !== BigInt(0)) {
@@ -273,6 +290,7 @@ export class PrismaBattingStatisticsRepository implements IBattingStatisticsRepo
       LEFT JOIN teams t ON ts.teamid = t.id
       LEFT JOIN leagueschedule lg ON bs.gameid = lg.id
       LEFT JOIN leagueseason ls ON lg.leagueid = ls.id
+      ${seasonJoin}
       WHERE c.id = ANY($${playerIdParamIndex}::bigint[])
         AND ${includeAllGameTypes ? `lg.gametype IN (${GameType.RegularSeason}, ${GameType.Playoff})` : `lg.gametype = ${GameType.RegularSeason}`}
         ${whereClause}

--- a/draco-nodejs/backend/src/repositories/implementations/PrismaPitchingStatisticsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/PrismaPitchingStatisticsRepository.ts
@@ -18,6 +18,8 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
     query: PitchingStatisticsQueryOptions,
   ): Promise<dbPitchingStatisticsRow[]> {
     const {
+      accountId,
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -32,7 +34,11 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
 
     const offset = (page - 1) * pageSize;
     let whereClause = '';
+    const seasonJoin = 'LEFT JOIN season s ON ls.seasonid = s.id';
     const params: (bigint | number)[] = [];
+
+    whereClause += ' AND s.accountid = $' + (params.length + 1);
+    params.push(accountId);
 
     if (leagueId && leagueId !== BigInt(0)) {
       if (isHistorical) {
@@ -41,6 +47,9 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
         whereClause += ' AND ls.id = $' + (params.length + 1);
       }
       params.push(leagueId);
+    } else if (seasonId && seasonId !== BigInt(0)) {
+      whereClause += ' AND ls.seasonid = $' + (params.length + 1);
+      params.push(seasonId);
     }
 
     if (divisionId && divisionId !== BigInt(0)) {
@@ -139,6 +148,7 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
       LEFT JOIN contacts c ON r.contactid = c.id
       LEFT JOIN leagueschedule lg ON ps.gameid = lg.id
       LEFT JOIN leagueseason ls ON lg.leagueid = ls.id
+      ${seasonJoin}
       ${teamJoin}
       WHERE ${includeAllGameTypes ? `lg.gametype IN (${GameType.RegularSeason}, ${GameType.Playoff})` : `lg.gametype = ${GameType.RegularSeason}`}
         ${whereClause}
@@ -258,13 +268,17 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
       return [];
     }
 
-    const { leagueId, teamId, isHistorical, includeAllGameTypes } = query;
+    const { accountId, seasonId, leagueId, teamId, isHistorical, includeAllGameTypes } = query;
     let whereClause = '';
+    const seasonJoin = 'LEFT JOIN season s ON ls.seasonid = s.id';
     const params: (bigint | number | bigint[])[] = [];
 
     // Use parameterized query for player IDs to prevent SQL injection
     const playerIdParamIndex = params.length + 1;
     params.push(playerIds);
+
+    whereClause += ' AND s.accountid = $' + (params.length + 1);
+    params.push(accountId);
 
     if (leagueId && leagueId !== BigInt(0)) {
       if (isHistorical) {
@@ -273,6 +287,9 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
         whereClause += ' AND ls.id = $' + (params.length + 1);
       }
       params.push(leagueId);
+    } else if (seasonId && seasonId !== BigInt(0)) {
+      whereClause += ' AND ls.seasonid = $' + (params.length + 1);
+      params.push(seasonId);
     }
 
     if (teamId && teamId !== BigInt(0)) {
@@ -293,6 +310,7 @@ export class PrismaPitchingStatisticsRepository implements IPitchingStatisticsRe
       LEFT JOIN teams t ON ts.teamid = t.id
       LEFT JOIN leagueschedule lg ON ps.gameid = lg.id
       LEFT JOIN leagueseason ls ON lg.leagueid = ls.id
+      ${seasonJoin}
       WHERE c.id = ANY($${playerIdParamIndex}::bigint[])
         AND ${includeAllGameTypes ? `lg.gametype IN (${GameType.RegularSeason}, ${GameType.Playoff})` : `lg.gametype = ${GameType.RegularSeason}`}
         ${whereClause}

--- a/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaBattingStatisticsRepository.test.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaBattingStatisticsRepository.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '#prisma/client';
+import { PrismaBattingStatisticsRepository } from '../PrismaBattingStatisticsRepository.js';
+import type { BattingStatisticsQueryOptions } from '../../interfaces/IBattingStatisticsRepository.js';
+
+const baseQuery: BattingStatisticsQueryOptions = {
+  accountId: 99n,
+  isHistorical: false,
+  sortField: 'avg',
+  sortOrder: 'desc',
+  page: 1,
+  pageSize: 50,
+  minAtBats: 0,
+  includeAllGameTypes: false,
+};
+
+const createRepo = () => {
+  const queryRawUnsafe = vi.fn().mockResolvedValue([]);
+  const prisma = { $queryRawUnsafe: queryRawUnsafe } as unknown as PrismaClient;
+  return { repo: new PrismaBattingStatisticsRepository(prisma), queryRawUnsafe };
+};
+
+describe('PrismaBattingStatisticsRepository account scoping', () => {
+  it('always joins season and scopes by account, even with no league or season filter', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findBattingStatistics(baseQuery);
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('LEFT JOIN season s ON ls.seasonid = s.id');
+    expect(sql).toContain('s.accountid = $1');
+    expect(params).toEqual([99n]);
+  });
+
+  it('enforces account scoping in addition to the league filter', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findBattingStatistics({ ...baseQuery, leagueId: 7n });
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('s.accountid = $1');
+    expect(sql).toContain('ls.id = $2');
+    expect(params).toEqual([99n, 7n]);
+  });
+
+  it('enforces account scoping in addition to the season filter', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findBattingStatistics({ ...baseQuery, seasonId: 3n });
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('s.accountid = $1');
+    expect(sql).toContain('ls.seasonid = $2');
+    expect(params).toEqual([99n, 3n]);
+  });
+
+  it('enforces account scoping for historical single-league queries (master league id)', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findBattingStatistics({ ...baseQuery, isHistorical: true, leagueId: 7n });
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('s.accountid = $1');
+    expect(sql).toContain('ls.leagueid = $2');
+    expect(params).toEqual([99n, 7n]);
+  });
+});

--- a/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaBattingStatisticsRepository.test.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaBattingStatisticsRepository.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { PrismaClient } from '#prisma/client';
 import { PrismaBattingStatisticsRepository } from '../PrismaBattingStatisticsRepository.js';
 import type { BattingStatisticsQueryOptions } from '../../interfaces/IBattingStatisticsRepository.js';
+import { partialPrismaMock } from '../../../test-utils/partialMock.js';
 
 const baseQuery: BattingStatisticsQueryOptions = {
   accountId: 99n,
@@ -16,7 +16,7 @@ const baseQuery: BattingStatisticsQueryOptions = {
 
 const createRepo = () => {
   const queryRawUnsafe = vi.fn().mockResolvedValue([]);
-  const prisma = { $queryRawUnsafe: queryRawUnsafe } as unknown as PrismaClient;
+  const prisma = partialPrismaMock({ $queryRawUnsafe: queryRawUnsafe });
   return { repo: new PrismaBattingStatisticsRepository(prisma), queryRawUnsafe };
 };
 

--- a/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaPitchingStatisticsRepository.test.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaPitchingStatisticsRepository.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '#prisma/client';
+import { PrismaPitchingStatisticsRepository } from '../PrismaPitchingStatisticsRepository.js';
+import type { PitchingStatisticsQueryOptions } from '../../interfaces/IPitchingStatisticsRepository.js';
+
+const baseQuery: PitchingStatisticsQueryOptions = {
+  accountId: 99n,
+  isHistorical: false,
+  sortField: 'era',
+  sortOrder: 'asc',
+  page: 1,
+  pageSize: 50,
+  minInningsPitched: 0,
+  includeAllGameTypes: false,
+};
+
+const createRepo = () => {
+  const queryRawUnsafe = vi.fn().mockResolvedValue([]);
+  const prisma = { $queryRawUnsafe: queryRawUnsafe } as unknown as PrismaClient;
+  return { repo: new PrismaPitchingStatisticsRepository(prisma), queryRawUnsafe };
+};
+
+describe('PrismaPitchingStatisticsRepository account scoping', () => {
+  it('always joins season and scopes by account, even with no league or season filter', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findPitchingStatistics(baseQuery);
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('LEFT JOIN season s ON ls.seasonid = s.id');
+    expect(sql).toContain('s.accountid = $1');
+    expect(params).toEqual([99n]);
+  });
+
+  it('enforces account scoping in addition to the league filter', async () => {
+    const { repo, queryRawUnsafe } = createRepo();
+
+    await repo.findPitchingStatistics({ ...baseQuery, leagueId: 7n });
+
+    const [sql, ...params] = queryRawUnsafe.mock.calls[0];
+    expect(sql).toContain('s.accountid = $1');
+    expect(sql).toContain('ls.id = $2');
+    expect(params).toEqual([99n, 7n]);
+  });
+});

--- a/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaPitchingStatisticsRepository.test.ts
+++ b/draco-nodejs/backend/src/repositories/implementations/__tests__/PrismaPitchingStatisticsRepository.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { PrismaClient } from '#prisma/client';
 import { PrismaPitchingStatisticsRepository } from '../PrismaPitchingStatisticsRepository.js';
 import type { PitchingStatisticsQueryOptions } from '../../interfaces/IPitchingStatisticsRepository.js';
+import { partialPrismaMock } from '../../../test-utils/partialMock.js';
 
 const baseQuery: PitchingStatisticsQueryOptions = {
   accountId: 99n,
@@ -16,7 +16,7 @@ const baseQuery: PitchingStatisticsQueryOptions = {
 
 const createRepo = () => {
   const queryRawUnsafe = vi.fn().mockResolvedValue([]);
-  const prisma = { $queryRawUnsafe: queryRawUnsafe } as unknown as PrismaClient;
+  const prisma = partialPrismaMock({ $queryRawUnsafe: queryRawUnsafe });
   return { repo: new PrismaPitchingStatisticsRepository(prisma), queryRawUnsafe };
 };
 

--- a/draco-nodejs/backend/src/repositories/interfaces/IBattingStatisticsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IBattingStatisticsRepository.ts
@@ -5,6 +5,8 @@ import {
 } from '../types/dbTypes.js';
 
 export interface BattingStatisticsQueryOptions {
+  accountId: bigint;
+  seasonId?: bigint;
   leagueId?: bigint;
   divisionId?: bigint;
   teamId?: bigint;
@@ -18,6 +20,8 @@ export interface BattingStatisticsQueryOptions {
 }
 
 export interface PlayerTeamsQueryOptions {
+  accountId: bigint;
+  seasonId?: bigint;
   leagueId?: bigint;
   teamId?: bigint;
   isHistorical: boolean;

--- a/draco-nodejs/backend/src/repositories/interfaces/IPitchingStatisticsRepository.ts
+++ b/draco-nodejs/backend/src/repositories/interfaces/IPitchingStatisticsRepository.ts
@@ -6,6 +6,8 @@ import {
 import { PlayerTeamsQueryOptions } from './IBattingStatisticsRepository.js';
 
 export interface PitchingStatisticsQueryOptions {
+  accountId: bigint;
+  seasonId?: bigint;
   leagueId?: bigint;
   divisionId?: bigint;
   teamId?: bigint;

--- a/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '#prisma/client';
+import { MinimumCalculator } from '../minimumCalculator.js';
+import { GameStatus, GameType } from '../../types/gameEnums.js';
+
+interface PrismaMockOptions {
+  leagueSeasonIds: bigint[];
+  totalGames: number;
+  numTeams: number;
+}
+
+const createPrismaMock = ({ leagueSeasonIds, totalGames, numTeams }: PrismaMockOptions) => {
+  const findMany = vi.fn().mockResolvedValue(leagueSeasonIds.map((id) => ({ id })));
+  const scheduleCount = vi.fn().mockResolvedValue(totalGames);
+  const teamsCount = vi.fn().mockResolvedValue(numTeams);
+
+  const prisma = {
+    leagueseason: { findMany },
+    leagueschedule: { count: scheduleCount },
+    teamsseason: { count: teamsCount },
+  } as unknown as PrismaClient;
+
+  return { prisma, findMany, scheduleCount, teamsCount };
+};
+
+describe('MinimumCalculator season-wide minimums', () => {
+  it('aggregates games and teams across every league in the season for AB', async () => {
+    const { prisma, findMany, scheduleCount, teamsCount } = createPrismaMock({
+      leagueSeasonIds: [10n, 11n],
+      totalGames: 40,
+      numTeams: 8,
+    });
+    const calculator = new MinimumCalculator(prisma);
+
+    const result = await calculator.calculateSeasonMinAB(5n);
+
+    // (40 games * 2 appearances) / 8 teams * 1.5 = 15
+    expect(result).toBe(15);
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { seasonid: 5n },
+      select: { id: true },
+    });
+    expect(scheduleCount).toHaveBeenCalledWith({
+      where: {
+        leagueid: { in: [10n, 11n] },
+        gametype: GameType.RegularSeason,
+        gamestatus: {
+          in: [GameStatus.Completed, GameStatus.Forfeit, GameStatus.DidNotReport],
+        },
+      },
+    });
+    expect(teamsCount).toHaveBeenCalledWith({
+      where: { leagueseasonid: { in: [10n, 11n] } },
+    });
+  });
+
+  it('uses the 1.0 multiplier for IP', async () => {
+    const { prisma } = createPrismaMock({
+      leagueSeasonIds: [10n, 11n],
+      totalGames: 40,
+      numTeams: 8,
+    });
+    const calculator = new MinimumCalculator(prisma);
+
+    // (40 * 2) / 8 * 1.0 = 10
+    await expect(calculator.calculateSeasonMinIP(5n)).resolves.toBe(10);
+  });
+
+  it('returns 0 when the season has no leagues', async () => {
+    const { prisma, scheduleCount } = createPrismaMock({
+      leagueSeasonIds: [],
+      totalGames: 0,
+      numTeams: 0,
+    });
+    const calculator = new MinimumCalculator(prisma);
+
+    await expect(calculator.calculateSeasonMinAB(5n)).resolves.toBe(0);
+    // Short-circuits before counting games once no leagues exist
+    expect(scheduleCount).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the season has leagues but no teams', async () => {
+    const { prisma } = createPrismaMock({
+      leagueSeasonIds: [10n],
+      totalGames: 12,
+      numTeams: 0,
+    });
+    const calculator = new MinimumCalculator(prisma);
+
+    await expect(calculator.calculateSeasonMinAB(5n)).resolves.toBe(0);
+  });
+});

--- a/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { PrismaClient } from '#prisma/client';
 import { MinimumCalculator } from '../minimumCalculator.js';
 import { GameStatus, GameType } from '../../types/gameEnums.js';
+import { partialPrismaMock } from '../../test-utils/partialMock.js';
 
 interface PrismaMockOptions {
   leagueSeasonIds: bigint[];
@@ -14,11 +14,11 @@ const createPrismaMock = ({ leagueSeasonIds, totalGames, numTeams }: PrismaMockO
   const scheduleCount = vi.fn().mockResolvedValue(totalGames);
   const teamsCount = vi.fn().mockResolvedValue(numTeams);
 
-  const prisma = {
+  const prisma = partialPrismaMock({
     leagueseason: { findMany },
     leagueschedule: { count: scheduleCount },
     teamsseason: { count: teamsCount },
-  } as unknown as PrismaClient;
+  });
 
   return { prisma, findMany, scheduleCount, teamsCount };
 };

--- a/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/minimumCalculator.test.ts
@@ -32,13 +32,12 @@ describe('MinimumCalculator season-wide minimums', () => {
     });
     const calculator = new MinimumCalculator(prisma);
 
-    const result = await calculator.calculateSeasonMinAB(5n);
+    const result = await calculator.calculateSeasonMinAB(5n, 7n);
 
-    // (40 games * 2 appearances) / 8 teams * 1.5 = 15
     expect(result).toBe(15);
 
     expect(findMany).toHaveBeenCalledWith({
-      where: { seasonid: 5n },
+      where: { seasonid: 5n, season: { accountid: 7n } },
       select: { id: true },
     });
     expect(scheduleCount).toHaveBeenCalledWith({
@@ -63,8 +62,7 @@ describe('MinimumCalculator season-wide minimums', () => {
     });
     const calculator = new MinimumCalculator(prisma);
 
-    // (40 * 2) / 8 * 1.0 = 10
-    await expect(calculator.calculateSeasonMinIP(5n)).resolves.toBe(10);
+    await expect(calculator.calculateSeasonMinIP(5n, 7n)).resolves.toBe(10);
   });
 
   it('returns 0 when the season has no leagues', async () => {
@@ -75,8 +73,7 @@ describe('MinimumCalculator season-wide minimums', () => {
     });
     const calculator = new MinimumCalculator(prisma);
 
-    await expect(calculator.calculateSeasonMinAB(5n)).resolves.toBe(0);
-    // Short-circuits before counting games once no leagues exist
+    await expect(calculator.calculateSeasonMinAB(5n, 7n)).resolves.toBe(0);
     expect(scheduleCount).not.toHaveBeenCalled();
   });
 
@@ -88,6 +85,6 @@ describe('MinimumCalculator season-wide minimums', () => {
     });
     const calculator = new MinimumCalculator(prisma);
 
-    await expect(calculator.calculateSeasonMinAB(5n)).resolves.toBe(0);
+    await expect(calculator.calculateSeasonMinAB(5n, 7n)).resolves.toBe(0);
   });
 });

--- a/draco-nodejs/backend/src/services/__tests__/statisticsService.gametypes.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/statisticsService.gametypes.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StatisticsService } from '../statisticsService.js';
+import {
+  BattingStatisticsFiltersSchema,
+  PitchingStatisticsFiltersSchema,
+} from '@draco/shared-schemas';
+import { partialMock, partialPrismaMock } from '../../test-utils/partialMock.js';
+import type {
+  IBattingStatisticsRepository,
+  IContactRepository,
+  ILeagueLeadersDisplayRepository,
+  IPitchingStatisticsRepository,
+  IScheduleRepository,
+} from '../../repositories/interfaces/index.js';
+
+const buildService = () => {
+  const findBattingStatistics = vi.fn().mockResolvedValue([]);
+  const findPitchingStatistics = vi.fn().mockResolvedValue([]);
+
+  const battingRepository = partialMock<IBattingStatisticsRepository>({
+    findBattingStatistics,
+    findTeamsForPlayers: vi.fn().mockResolvedValue([]),
+  });
+  const pitchingRepository = partialMock<IPitchingStatisticsRepository>({
+    findPitchingStatistics,
+    findTeamsForPlayers: vi.fn().mockResolvedValue([]),
+  });
+
+  const service = new StatisticsService(
+    partialPrismaMock({}),
+    battingRepository,
+    pitchingRepository,
+    partialMock<ILeagueLeadersDisplayRepository>({}),
+    partialMock<IContactRepository>({}),
+    partialMock<IScheduleRepository>({}),
+  );
+
+  return { service, findBattingStatistics, findPitchingStatistics };
+};
+
+describe('StatisticsService all-time game-type scoping', () => {
+  it('includes postseason games for historical batting queries', async () => {
+    const { service, findBattingStatistics } = buildService();
+    const filters = BattingStatisticsFiltersSchema.parse({
+      sortField: 'avg',
+      isHistorical: 'true',
+    });
+
+    await service.getBattingStats(1n, filters);
+
+    expect(findBattingStatistics).toHaveBeenCalledWith(
+      expect.objectContaining({ includeAllGameTypes: true }),
+    );
+  });
+
+  it('restricts to regular season for non-historical batting queries by default', async () => {
+    const { service, findBattingStatistics } = buildService();
+    const filters = BattingStatisticsFiltersSchema.parse({ sortField: 'avg' });
+
+    await service.getBattingStats(1n, filters);
+
+    expect(findBattingStatistics).toHaveBeenCalledWith(
+      expect.objectContaining({ includeAllGameTypes: false }),
+    );
+  });
+
+  it('includes postseason games for historical pitching queries', async () => {
+    const { service, findPitchingStatistics } = buildService();
+    const filters = PitchingStatisticsFiltersSchema.parse({
+      sortField: 'era',
+      isHistorical: 'true',
+    });
+
+    await service.getPitchingStats(1n, filters);
+
+    expect(findPitchingStatistics).toHaveBeenCalledWith(
+      expect.objectContaining({ includeAllGameTypes: true }),
+    );
+  });
+
+  it('still honors an explicit includeAllGameTypes flag when not historical', async () => {
+    const { service, findPitchingStatistics } = buildService();
+    const filters = PitchingStatisticsFiltersSchema.parse({
+      sortField: 'era',
+      includeAllGameTypes: 'true',
+    });
+
+    await service.getPitchingStats(1n, filters);
+
+    expect(findPitchingStatistics).toHaveBeenCalledWith(
+      expect.objectContaining({ includeAllGameTypes: true }),
+    );
+  });
+});

--- a/draco-nodejs/backend/src/services/minimumCalculator.ts
+++ b/draco-nodejs/backend/src/services/minimumCalculator.ts
@@ -49,6 +49,22 @@ export class MinimumCalculator {
   }
 
   /**
+   * Calculate minimum AB across all leagues in a season
+   * Formula: (totalGames * 2) / numTeams * 1.5
+   */
+  async calculateSeasonMinAB(seasonId: bigint): Promise<number> {
+    return this.calculateSeasonMin(seasonId, 1.5);
+  }
+
+  /**
+   * Calculate minimum IP across all leagues in a season
+   * Formula: (totalGames * 2) / numTeams * 1.0
+   */
+  async calculateSeasonMinIP(seasonId: bigint): Promise<number> {
+    return this.calculateSeasonMin(seasonId, 1.0);
+  }
+
+  /**
    * Private method to calculate league minimum
    * Matches ASP.NET CalculateMin method exactly
    */
@@ -71,6 +87,51 @@ export class MinimumCalculator {
     const numTeams = await this.prisma.teamsseason.count({
       where: {
         leagueseasonid: leagueSeasonId,
+      },
+    });
+
+    if (numTeams === 0) {
+      return 0;
+    }
+
+    const curMin = (numGames / numTeams) * minMultiplier;
+
+    return Math.max(0, Math.floor(curMin));
+  }
+
+  /**
+   * Private method to calculate a season-wide minimum across all leagues
+   * Mirrors calculateLeagueMin but aggregates every leagueseason in the season
+   */
+  private async calculateSeasonMin(seasonId: bigint, minMultiplier: number): Promise<number> {
+    const leagueSeasons = await this.prisma.leagueseason.findMany({
+      where: { seasonid: seasonId },
+      select: { id: true },
+    });
+    const leagueSeasonIds = leagueSeasons.map((ls) => ls.id);
+
+    if (leagueSeasonIds.length === 0) {
+      return 0;
+    }
+
+    // Count total completed regular-season games across all leagues in the season
+    const totalGames = await this.prisma.leagueschedule.count({
+      where: {
+        leagueid: { in: leagueSeasonIds },
+        gametype: GameType.RegularSeason,
+        gamestatus: {
+          in: [GameStatus.Completed, GameStatus.Forfeit, GameStatus.DidNotReport],
+        },
+      },
+    });
+
+    // Each game involves 2 teams, so multiply by 2
+    const numGames = totalGames * 2;
+
+    // Count number of teams across all leagues in the season
+    const numTeams = await this.prisma.teamsseason.count({
+      where: {
+        leagueseasonid: { in: leagueSeasonIds },
       },
     });
 

--- a/draco-nodejs/backend/src/services/minimumCalculator.ts
+++ b/draco-nodejs/backend/src/services/minimumCalculator.ts
@@ -48,18 +48,10 @@ export class MinimumCalculator {
     return this.calculateTeamMin(teamSeasonId, 1.0);
   }
 
-  /**
-   * Calculate minimum AB across all leagues in a season
-   * Formula: (totalGames * 2) / numTeams * 1.5
-   */
   async calculateSeasonMinAB(seasonId: bigint): Promise<number> {
     return this.calculateSeasonMin(seasonId, 1.5);
   }
 
-  /**
-   * Calculate minimum IP across all leagues in a season
-   * Formula: (totalGames * 2) / numTeams * 1.0
-   */
   async calculateSeasonMinIP(seasonId: bigint): Promise<number> {
     return this.calculateSeasonMin(seasonId, 1.0);
   }
@@ -99,10 +91,6 @@ export class MinimumCalculator {
     return Math.max(0, Math.floor(curMin));
   }
 
-  /**
-   * Private method to calculate a season-wide minimum across all leagues
-   * Mirrors calculateLeagueMin but aggregates every leagueseason in the season
-   */
   private async calculateSeasonMin(seasonId: bigint, minMultiplier: number): Promise<number> {
     const leagueSeasons = await this.prisma.leagueseason.findMany({
       where: { seasonid: seasonId },
@@ -114,7 +102,6 @@ export class MinimumCalculator {
       return 0;
     }
 
-    // Count total completed regular-season games across all leagues in the season
     const totalGames = await this.prisma.leagueschedule.count({
       where: {
         leagueid: { in: leagueSeasonIds },
@@ -125,10 +112,8 @@ export class MinimumCalculator {
       },
     });
 
-    // Each game involves 2 teams, so multiply by 2
     const numGames = totalGames * 2;
 
-    // Count number of teams across all leagues in the season
     const numTeams = await this.prisma.teamsseason.count({
       where: {
         leagueseasonid: { in: leagueSeasonIds },

--- a/draco-nodejs/backend/src/services/minimumCalculator.ts
+++ b/draco-nodejs/backend/src/services/minimumCalculator.ts
@@ -48,12 +48,12 @@ export class MinimumCalculator {
     return this.calculateTeamMin(teamSeasonId, 1.0);
   }
 
-  async calculateSeasonMinAB(seasonId: bigint): Promise<number> {
-    return this.calculateSeasonMin(seasonId, 1.5);
+  async calculateSeasonMinAB(seasonId: bigint, accountId: bigint): Promise<number> {
+    return this.calculateSeasonMin(seasonId, accountId, 1.5);
   }
 
-  async calculateSeasonMinIP(seasonId: bigint): Promise<number> {
-    return this.calculateSeasonMin(seasonId, 1.0);
+  async calculateSeasonMinIP(seasonId: bigint, accountId: bigint): Promise<number> {
+    return this.calculateSeasonMin(seasonId, accountId, 1.0);
   }
 
   /**
@@ -91,9 +91,13 @@ export class MinimumCalculator {
     return Math.max(0, Math.floor(curMin));
   }
 
-  private async calculateSeasonMin(seasonId: bigint, minMultiplier: number): Promise<number> {
+  private async calculateSeasonMin(
+    seasonId: bigint,
+    accountId: bigint,
+    minMultiplier: number,
+  ): Promise<number> {
     const leagueSeasons = await this.prisma.leagueseason.findMany({
-      where: { seasonid: seasonId },
+      where: { seasonid: seasonId, season: { accountid: accountId } },
       select: { id: true },
     });
     const leagueSeasonIds = leagueSeasons.map((ls) => ls.id);

--- a/draco-nodejs/backend/src/services/statisticsService.ts
+++ b/draco-nodejs/backend/src/services/statisticsService.ts
@@ -338,7 +338,7 @@ export class StatisticsService {
       } else if (filters.leagueId) {
         minAB = await this.minimumCalculator.calculateLeagueMinAB(filters.leagueId);
       } else if (filters.seasonId) {
-        minAB = await this.minimumCalculator.calculateSeasonMinAB(filters.seasonId);
+        minAB = await this.minimumCalculator.calculateSeasonMinAB(filters.seasonId, accountId);
       } else {
         minAB = MinimumCalculator.MIN_AB_PER_SEASON;
       }
@@ -352,7 +352,7 @@ export class StatisticsService {
       } else if (filters.leagueId) {
         minIP = await this.minimumCalculator.calculateLeagueMinIP(filters.leagueId);
       } else if (filters.seasonId) {
-        minIP = await this.minimumCalculator.calculateSeasonMinIP(filters.seasonId);
+        minIP = await this.minimumCalculator.calculateSeasonMinIP(filters.seasonId, accountId);
       } else {
         minIP = MinimumCalculator.MIN_IP_PER_SEASON;
       }

--- a/draco-nodejs/backend/src/services/statisticsService.ts
+++ b/draco-nodejs/backend/src/services/statisticsService.ts
@@ -111,17 +111,19 @@ export class StatisticsService {
 
   // Get batting statistics with pagination and filtering
   async getBattingStats(
-    _accountId: bigint,
+    accountId: bigint,
     filters: BattingStatisticsFiltersType,
   ): Promise<PlayerBattingStatsType[]> {
-    const stats = await this.queryBattingStats(filters);
+    const stats = await this.queryBattingStats(filters, accountId);
     return StatsResponseFormatter.formatPlayerBattingStats(stats);
   }
 
   private async queryBattingStats(
     filters: BattingStatisticsFiltersType,
+    accountId: bigint,
   ): Promise<dbBattingStatisticsRow[]> {
     const {
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -138,7 +140,11 @@ export class StatisticsService {
       throw new Error('Sort field is required');
     }
 
+    const effectiveIncludeAllGameTypes = isHistorical || includeAllGameTypes;
+
     const stats = await this.battingStatisticsRepository.findBattingStatistics({
+      accountId,
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -148,10 +154,10 @@ export class StatisticsService {
       page,
       pageSize,
       minAtBats: minAB,
-      includeAllGameTypes,
+      includeAllGameTypes: effectiveIncludeAllGameTypes,
     });
 
-    await this.attachTeamsToStats(stats, filters, (playerIds, query) =>
+    await this.attachTeamsToStats(stats, filters, accountId, (playerIds, query) =>
       this.battingStatisticsRepository.findTeamsForPlayers(playerIds, query),
     );
 
@@ -162,6 +168,7 @@ export class StatisticsService {
   private async attachTeamsToStats(
     stats: Array<dbBattingStatisticsRow | dbPitchingStatisticsRow>,
     filters: StatisticsFilters,
+    accountId: bigint,
     fetchTeams: (
       playerIds: bigint[],
       query: PlayerTeamsQueryOptions,
@@ -174,10 +181,13 @@ export class StatisticsService {
     const playerIds = stats.map((stat) => stat.playerId);
 
     const teamResults = await fetchTeams(playerIds, {
+      accountId,
+      seasonId: filters.seasonId,
       leagueId: filters.leagueId,
       teamId: filters.teamId,
       isHistorical: filters.isHistorical ?? false,
-      includeAllGameTypes: filters.includeAllGameTypes ?? false,
+      includeAllGameTypes:
+        (filters.isHistorical ?? false) || (filters.includeAllGameTypes ?? false),
     });
 
     const teamsByPlayer = new Map<string, string[]>();
@@ -209,10 +219,10 @@ export class StatisticsService {
 
   // Get pitching statistics with pagination and filtering
   async getPitchingStats(
-    _accountId: bigint,
+    accountId: bigint,
     filters: PitchingStatisticsFiltersType,
   ): Promise<PlayerPitchingStatsType[]> {
-    const stats = await this.queryPitchingStats(filters);
+    const stats = await this.queryPitchingStats(filters, accountId);
     return StatsResponseFormatter.formatPlayerPitchingStats(stats);
   }
 
@@ -258,8 +268,10 @@ export class StatisticsService {
 
   private async queryPitchingStats(
     filters: PitchingStatisticsFiltersType,
+    accountId: bigint,
   ): Promise<dbPitchingStatisticsRow[]> {
     const {
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -276,7 +288,11 @@ export class StatisticsService {
       throw new Error('Sort field is required');
     }
 
+    const effectiveIncludeAllGameTypes = isHistorical || includeAllGameTypes;
+
     const stats = await this.pitchingStatisticsRepository.findPitchingStatistics({
+      accountId,
+      seasonId,
       leagueId,
       divisionId,
       teamId,
@@ -286,10 +302,10 @@ export class StatisticsService {
       page,
       pageSize,
       minInningsPitched: minIP,
-      includeAllGameTypes,
+      includeAllGameTypes: effectiveIncludeAllGameTypes,
     });
 
-    await this.attachTeamsToStats(stats, filters, (playerIds, query) =>
+    await this.attachTeamsToStats(stats, filters, accountId, (playerIds, query) =>
       this.pitchingStatisticsRepository.findTeamsForPlayers(playerIds, query),
     );
 
@@ -321,6 +337,8 @@ export class StatisticsService {
         minAB = await this.minimumCalculator.calculateTeamMinAB(filters.teamId);
       } else if (filters.leagueId) {
         minAB = await this.minimumCalculator.calculateLeagueMinAB(filters.leagueId);
+      } else if (filters.seasonId) {
+        minAB = await this.minimumCalculator.calculateSeasonMinAB(filters.seasonId);
       } else {
         minAB = MinimumCalculator.MIN_AB_PER_SEASON;
       }
@@ -333,6 +351,8 @@ export class StatisticsService {
         minIP = await this.minimumCalculator.calculateTeamMinIP(filters.teamId);
       } else if (filters.leagueId) {
         minIP = await this.minimumCalculator.calculateLeagueMinIP(filters.leagueId);
+      } else if (filters.seasonId) {
+        minIP = await this.minimumCalculator.calculateSeasonMinIP(filters.seasonId);
       } else {
         minIP = MinimumCalculator.MIN_IP_PER_SEASON;
       }
@@ -1080,23 +1100,27 @@ export class StatisticsService {
   }
 
   private async getBattingLeaders(
-    _accountId: bigint,
+    accountId: bigint,
     category: string,
     filters: LeaderStatisticsFiltersType,
   ): Promise<LeaderRowType[]> {
     const sortOrder = this.getBattingSortOrder(category);
-    const stats = await this.queryBattingStats({
-      leagueId: filters.leagueId,
-      divisionId: filters.divisionId,
-      teamId: filters.teamId,
-      isHistorical: filters.isHistorical,
-      includeAllGameTypes: filters.includeAllGameTypes,
-      page: filters.page,
-      pageSize: filters.pageSize,
-      minAB: filters.minAB,
-      sortField: category,
-      sortOrder,
-    });
+    const stats = await this.queryBattingStats(
+      {
+        seasonId: filters.seasonId,
+        leagueId: filters.leagueId,
+        divisionId: filters.divisionId,
+        teamId: filters.teamId,
+        isHistorical: filters.isHistorical,
+        includeAllGameTypes: filters.includeAllGameTypes,
+        page: filters.page,
+        pageSize: filters.pageSize,
+        minAB: filters.minAB,
+        sortField: category,
+        sortOrder,
+      },
+      accountId,
+    );
 
     return this.processLeadersWithTies(stats, category, filters.limit, (stat) =>
       this.getStatValue(stat, category),
@@ -1104,23 +1128,27 @@ export class StatisticsService {
   }
 
   private async getPitchingLeaders(
-    _accountId: bigint,
+    accountId: bigint,
     category: string,
     filters: LeaderStatisticsFiltersType,
   ): Promise<LeaderRowType[]> {
     const sortOrder = this.getPitchingSortOrder(category);
-    const stats = await this.queryPitchingStats({
-      leagueId: filters.leagueId,
-      divisionId: filters.divisionId,
-      teamId: filters.teamId,
-      isHistorical: filters.isHistorical,
-      includeAllGameTypes: filters.includeAllGameTypes,
-      page: filters.page,
-      pageSize: filters.pageSize,
-      minIP: filters.minIP,
-      sortField: category,
-      sortOrder,
-    });
+    const stats = await this.queryPitchingStats(
+      {
+        seasonId: filters.seasonId,
+        leagueId: filters.leagueId,
+        divisionId: filters.divisionId,
+        teamId: filters.teamId,
+        isHistorical: filters.isHistorical,
+        includeAllGameTypes: filters.includeAllGameTypes,
+        page: filters.page,
+        pageSize: filters.pageSize,
+        minIP: filters.minIP,
+        sortField: category,
+        sortOrder,
+      },
+      accountId,
+    );
 
     return this.processLeadersWithTies(stats, category, filters.limit, (stat) =>
       this.getPitchingStatValue(stat, category),

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/BattingStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/BattingStatistics.tsx
@@ -72,6 +72,7 @@ export default function BattingStatistics({ accountId, filters }: BattingStatist
           accountId,
           filters.leagueId,
           {
+            seasonId: filters.seasonId,
             divisionId: filters.divisionId,
             isHistorical: filters.isHistorical,
             page,
@@ -112,6 +113,7 @@ export default function BattingStatistics({ accountId, filters }: BattingStatist
     filters.divisionId,
     filters.isHistorical,
     filters.leagueId,
+    filters.seasonId,
     page,
     pageSize,
     sortField,
@@ -154,6 +156,7 @@ export default function BattingStatistics({ accountId, filters }: BattingStatist
       client: apiClient,
       path: { accountId, leagueId: filters.leagueId },
       query: {
+        seasonId: filters.seasonId && filters.seasonId !== '0' ? filters.seasonId : undefined,
         divisionId:
           filters.divisionId && filters.divisionId !== '0' ? filters.divisionId : undefined,
         isHistorical: filters.isHistorical,

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PitchingStatistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/PitchingStatistics.tsx
@@ -77,6 +77,7 @@ export default function PitchingStatistics({ accountId, filters }: PitchingStati
           accountId,
           filters.leagueId,
           {
+            seasonId: filters.seasonId,
             divisionId: filters.divisionId,
             isHistorical: filters.isHistorical,
             page,
@@ -117,6 +118,7 @@ export default function PitchingStatistics({ accountId, filters }: PitchingStati
     filters.divisionId,
     filters.isHistorical,
     filters.leagueId,
+    filters.seasonId,
     page,
     pageSize,
     sortField,
@@ -154,6 +156,7 @@ export default function PitchingStatistics({ accountId, filters }: PitchingStati
       client: apiClient,
       path: { accountId, leagueId: filters.leagueId },
       query: {
+        seasonId: filters.seasonId && filters.seasonId !== '0' ? filters.seasonId : undefined,
         divisionId:
           filters.divisionId && filters.divisionId !== '0' ? filters.divisionId : undefined,
         isHistorical: filters.isHistorical,

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
@@ -66,10 +66,11 @@ export default function Statistics({ accountId }: StatisticsProps) {
   });
   const [filters, setFilters] = useState<StatisticsFilters>(() => {
     const seasonId = searchParams.get('season') ?? '';
+    const leagueId = searchParams.get('league') ?? '';
     return {
       seasonId,
-      leagueId: searchParams.get('league') ?? '',
-      divisionId: searchParams.get('division') ?? '',
+      leagueId,
+      divisionId: leagueId === '0' ? '' : (searchParams.get('division') ?? ''),
       isHistorical: seasonId === '0',
     };
   });

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
@@ -81,8 +81,10 @@ export default function Statistics({ accountId }: StatisticsProps) {
     if (filters.divisionId) params.set('division', filters.divisionId);
     if (tabValue > 0) params.set('tab', String(tabValue));
     const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }, [filters, tabValue, pathname, router]);
+    if (query !== searchParams.toString()) {
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    }
+  }, [filters, tabValue, pathname, router, searchParams]);
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/Statistics.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Box, Container, Typography, Tabs, Tab, Paper } from '@mui/material';
 import AccountPageHeader from '../../../../components/AccountPageHeader';
 import AdPlacement from '../../../../components/ads/AdPlacement';
@@ -52,14 +53,37 @@ interface StatisticsProps {
   accountId: string;
 }
 
+const TAB_COUNT = 6;
+
 export default function Statistics({ accountId }: StatisticsProps) {
-  const [tabValue, setTabValue] = useState(0);
-  const [filters, setFilters] = useState<StatisticsFilters>({
-    seasonId: '',
-    leagueId: '',
-    divisionId: '',
-    isHistorical: false,
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [tabValue, setTabValue] = useState(() => {
+    const parsed = Number(searchParams.get('tab'));
+    return Number.isInteger(parsed) && parsed >= 0 && parsed < TAB_COUNT ? parsed : 0;
   });
+  const [filters, setFilters] = useState<StatisticsFilters>(() => {
+    const seasonId = searchParams.get('season') ?? '';
+    return {
+      seasonId,
+      leagueId: searchParams.get('league') ?? '',
+      divisionId: searchParams.get('division') ?? '',
+      isHistorical: seasonId === '0',
+    };
+  });
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (filters.seasonId) params.set('season', filters.seasonId);
+    if (filters.leagueId) params.set('league', filters.leagueId);
+    if (filters.divisionId) params.set('division', filters.divisionId);
+    if (tabValue > 0) params.set('tab', String(tabValue));
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [filters, tabValue, pathname, router]);
+
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
@@ -67,6 +91,8 @@ export default function Statistics({ accountId }: StatisticsProps) {
   const handleFiltersChange = (newFilters: Partial<StatisticsFilters>) => {
     setFilters((prev) => ({ ...prev, ...newFilters }));
   };
+
+  const isAllLeagues = filters.leagueId === '0';
 
   return (
     <main className="min-h-screen bg-background">
@@ -128,7 +154,16 @@ export default function Statistics({ accountId }: StatisticsProps) {
           </TabPanel>
 
           <TabPanel value={tabValue} index={3}>
-            <TeamStatistics accountId={accountId} seasonId={filters.seasonId} />
+            {isAllLeagues ? (
+              <Box p={3}>
+                <Typography variant="body1" color="text.secondary">
+                  Team statistics are not available when All Leagues is selected. Choose a specific
+                  league to view team statistics.
+                </Typography>
+              </Box>
+            ) : (
+              <TeamStatistics accountId={accountId} seasonId={filters.seasonId} />
+            )}
           </TabPanel>
 
           <TabPanel value={tabValue} index={4}>
@@ -136,7 +171,16 @@ export default function Statistics({ accountId }: StatisticsProps) {
           </TabPanel>
 
           <TabPanel value={tabValue} index={5}>
-            <Standings accountId={accountId} seasonId={filters.seasonId} showHeader={false} />
+            {isAllLeagues ? (
+              <Box p={3}>
+                <Typography variant="body1" color="text.secondary">
+                  Standings are not available when All Leagues is selected. Choose a specific league
+                  to view standings.
+                </Typography>
+              </Box>
+            ) : (
+              <Standings accountId={accountId} seasonId={filters.seasonId} showHeader={false} />
+            )}
           </TabPanel>
         </Paper>
       </Container>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/StatisticsFilters.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/StatisticsFilters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Box,
   FormControl,
@@ -8,8 +8,6 @@ import {
   Select,
   MenuItem,
   SelectChangeEvent,
-  FormControlLabel,
-  Switch,
   Typography,
 } from '@mui/material';
 import { listAccountSeasons, listAllTimeLeagues } from '@draco/shared-api-client';
@@ -63,6 +61,9 @@ export default function StatisticsFilters({
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+
   useEffect(() => {
     const controller = new AbortController();
     const loadSeasons = async () => {
@@ -93,7 +94,7 @@ export default function StatisticsFilters({
         const allSeasons = [allTimeOption, ...mappedSeasons];
         setSeasons(allSeasons);
 
-        if (mappedSeasons.length > 0) {
+        if (mappedSeasons.length > 0 && !filtersRef.current.seasonId) {
           const currentSeason = mappedSeasons.find((s) => s.isCurrent) ?? mappedSeasons[0];
           onChangeRef.current({ seasonId: currentSeason.id });
         }
@@ -156,7 +157,7 @@ export default function StatisticsFilters({
         if (controller.signal.aborted) return;
         setLeagues(formattedLeagues);
 
-        if (formattedLeagues.length > 0) {
+        if (formattedLeagues.length > 0 && !filtersRef.current.leagueId) {
           onChangeRef.current({ leagueId: formattedLeagues[0].id });
         }
       } catch (error) {
@@ -190,7 +191,9 @@ export default function StatisticsFilters({
       const allDivisions = [{ id: '0', name: 'All Divisions' }, ...divisionsData];
       setDivisions(allDivisions);
 
-      onChangeRef.current({ divisionId: '0' });
+      if (!filtersRef.current.divisionId) {
+        onChangeRef.current({ divisionId: '0' });
+      }
     } catch (error) {
       console.error('Error loading divisions:', error);
     } finally {
@@ -218,17 +221,6 @@ export default function StatisticsFilters({
 
   const handleDivisionChange = (event: SelectChangeEvent) => {
     onChange({ divisionId: event.target.value });
-  };
-
-  const handleHistoricalToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const isHistorical = event.target.checked;
-    const seasonId = isHistorical ? '0' : seasons.find((s) => s.id !== '0')?.id || '';
-    onChange({
-      isHistorical,
-      seasonId,
-      leagueId: '',
-      divisionId: '',
-    });
   };
 
   return (
@@ -267,6 +259,7 @@ export default function StatisticsFilters({
               onChange={handleLeagueChange}
               disabled={loading.leagues || !filters.seasonId}
             >
+              <MenuItem value="0">All Leagues</MenuItem>
               {leagues.map((league) => (
                 <MenuItem key={league.id} value={league.id}>
                   {league.name}
@@ -293,19 +286,6 @@ export default function StatisticsFilters({
               ))}
             </Select>
           </FormControl>
-        </Box>
-
-        <Box sx={{ minWidth: 200 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={filters.isHistorical}
-                onChange={handleHistoricalToggle}
-                name="historical"
-              />
-            }
-            label="All-Time Stats"
-          />
         </Box>
       </Box>
     </Box>

--- a/draco-nodejs/frontend-next/app/account/[accountId]/statistics/StatisticsLeaders.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/statistics/StatisticsLeaders.tsx
@@ -59,6 +59,7 @@ export default function StatisticsLeaders({ accountId, filters }: StatisticsLead
             filters.leagueId,
             category.key,
             {
+              seasonId: filters.seasonId,
               divisionId: filters.divisionId,
               isHistorical: filters.isHistorical,
             },
@@ -74,6 +75,7 @@ export default function StatisticsLeaders({ accountId, filters }: StatisticsLead
             filters.leagueId,
             category.key,
             {
+              seasonId: filters.seasonId,
               divisionId: filters.divisionId,
               isHistorical: filters.isHistorical,
             },
@@ -131,6 +133,7 @@ export default function StatisticsLeaders({ accountId, filters }: StatisticsLead
     filters.divisionId,
     filters.isHistorical,
     filters.leagueId,
+    filters.seasonId,
     pitchingCategories,
   ]);
 

--- a/draco-nodejs/frontend-next/components/statistics/LeadersWidget.tsx
+++ b/draco-nodejs/frontend-next/components/statistics/LeadersWidget.tsx
@@ -250,7 +250,7 @@ export default function LeadersWidget(props: LeadersWidgetProps) {
     isTeamVariant && teamSeasonIdForHref
       ? `/account/${accountId}/seasons/${teamSeasonSeasonIdProp}/teams/${teamSeasonIdForHref}/stat-entry`
       : seasonIdProp
-        ? `/account/${accountId}/statistics?seasonId=${seasonIdProp}`
+        ? `/account/${accountId}/statistics?season=${seasonIdProp}`
         : `/account/${accountId}/statistics`;
 
   const teamIdFilter =

--- a/draco-nodejs/frontend-next/e2e/pages/statistics.page.ts
+++ b/draco-nodejs/frontend-next/e2e/pages/statistics.page.ts
@@ -7,7 +7,6 @@ export class StatisticsPage {
   readonly seasonSelect: Locator;
   readonly leagueSelect: Locator;
   readonly divisionSelect: Locator;
-  readonly historicalToggle: Locator;
   readonly filtersHeading: Locator;
 
   constructor(page: Page) {
@@ -16,12 +15,17 @@ export class StatisticsPage {
     this.seasonSelect = page.getByLabel('Season');
     this.leagueSelect = page.getByLabel('League');
     this.divisionSelect = page.getByLabel('Division');
-    this.historicalToggle = page.getByLabel('All-Time Stats');
     this.filtersHeading = page.getByRole('heading', { name: 'Filters' });
   }
 
   async goto(accountId: string) {
     await this.page.goto(`/account/${accountId}/statistics`);
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.heading).toBeVisible({ timeout: 15_000 });
+  }
+
+  async gotoWithQuery(accountId: string, query: string) {
+    await this.page.goto(`/account/${accountId}/statistics?${query}`);
     await this.page.waitForLoadState('domcontentloaded');
     await expect(this.heading).toBeVisible({ timeout: 15_000 });
   }

--- a/draco-nodejs/frontend-next/e2e/tests/sports/statistics.spec.ts
+++ b/draco-nodejs/frontend-next/e2e/tests/sports/statistics.spec.ts
@@ -25,7 +25,13 @@ test.describe('Statistics', () => {
     await expect(statsPage.leagueSelect).toBeVisible();
   });
 
-  test('displays all-time stats toggle', async () => {
-    await expect(statsPage.historicalToggle).toBeVisible();
+  test('restores the All Time season from the URL', async ({ accountId }) => {
+    await statsPage.gotoWithQuery(accountId, 'season=0');
+    await expect(statsPage.seasonSelect).toContainText('All Time');
+  });
+
+  test('restores the All Leagues selection from the URL', async ({ accountId }) => {
+    await statsPage.gotoWithQuery(accountId, 'season=0&league=0');
+    await expect(statsPage.leagueSelect).toContainText('All Leagues');
   });
 });

--- a/draco-nodejs/frontend-next/services/__tests__/statisticsService.test.ts
+++ b/draco-nodejs/frontend-next/services/__tests__/statisticsService.test.ts
@@ -138,6 +138,31 @@ describe('statisticsService', () => {
       );
     });
 
+    it('passes seasonId for the All Leagues case (leagueId "0")', async () => {
+      vi.mocked(listBattingStatistics).mockResolvedValue(makeOkResult([]));
+
+      await fetchBattingStatistics('acct-1', '0', { seasonId: 'season-7' }, { client: mockClient });
+
+      expect(listBattingStatistics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { accountId: 'acct-1', leagueId: '0' },
+          query: expect.objectContaining({ seasonId: 'season-7' }),
+        }),
+      );
+    });
+
+    it('strips a zero-value seasonId from the query', async () => {
+      vi.mocked(listBattingStatistics).mockResolvedValue(makeOkResult([]));
+
+      await fetchBattingStatistics('acct-1', 'league-1', { seasonId: '0' }, { client: mockClient });
+
+      expect(listBattingStatistics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ seasonId: undefined }),
+        }),
+      );
+    });
+
     it('throws ApiClientError on failure', async () => {
       vi.mocked(listBattingStatistics).mockResolvedValue(makeErrorResult('Server error'));
 
@@ -176,6 +201,24 @@ describe('statisticsService', () => {
       expect(listPitchingStatistics).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({ minIP: '20' }),
+        }),
+      );
+    });
+
+    it('passes seasonId for the All Leagues case (leagueId "0")', async () => {
+      vi.mocked(listPitchingStatistics).mockResolvedValue(makeOkResult([]));
+
+      await fetchPitchingStatistics(
+        'acct-1',
+        '0',
+        { seasonId: 'season-7' },
+        { client: mockClient },
+      );
+
+      expect(listPitchingStatistics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { accountId: 'acct-1', leagueId: '0' },
+          query: expect.objectContaining({ seasonId: 'season-7' }),
         }),
       );
     });
@@ -226,6 +269,25 @@ describe('statisticsService', () => {
       expect(listStatisticalLeaders).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({ limit: '5' }),
+        }),
+      );
+    });
+
+    it('passes seasonId for the All Leagues case (leagueId "0")', async () => {
+      vi.mocked(listStatisticalLeaders).mockResolvedValue(makeOkResult([]));
+
+      await fetchStatisticalLeaders(
+        'acct-1',
+        '0',
+        'HR',
+        { seasonId: 'season-7' },
+        { client: mockClient },
+      );
+
+      expect(listStatisticalLeaders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { accountId: 'acct-1', leagueId: '0' },
+          query: expect.objectContaining({ category: 'HR', seasonId: 'season-7' }),
         }),
       );
     });

--- a/draco-nodejs/frontend-next/services/statisticsService.ts
+++ b/draco-nodejs/frontend-next/services/statisticsService.ts
@@ -65,6 +65,7 @@ export async function fetchLeaderCategories(
 }
 
 export interface BattingStatisticsQueryOptions {
+  seasonId?: string;
   divisionId?: string;
   teamId?: string;
   isHistorical?: boolean;
@@ -84,6 +85,7 @@ export async function fetchBattingStatistics(
 ): Promise<PlayerBattingStatsType[]> {
   const client = resolveClient(options);
   const {
+    seasonId,
     divisionId,
     teamId,
     isHistorical,
@@ -99,6 +101,7 @@ export async function fetchBattingStatistics(
     client,
     path: { accountId, leagueId },
     query: {
+      seasonId: sanitizeId(seasonId),
       divisionId: sanitizeId(divisionId),
       teamId: sanitizeId(teamId),
       isHistorical,
@@ -117,6 +120,7 @@ export async function fetchBattingStatistics(
 }
 
 export interface PitchingStatisticsQueryOptions {
+  seasonId?: string;
   divisionId?: string;
   teamId?: string;
   isHistorical?: boolean;
@@ -136,6 +140,7 @@ export async function fetchPitchingStatistics(
 ): Promise<PlayerPitchingStatsType[]> {
   const client = resolveClient(options);
   const {
+    seasonId,
     divisionId,
     teamId,
     isHistorical,
@@ -151,6 +156,7 @@ export async function fetchPitchingStatistics(
     client,
     path: { accountId, leagueId },
     query: {
+      seasonId: sanitizeId(seasonId),
       divisionId: sanitizeId(divisionId),
       teamId: sanitizeId(teamId),
       isHistorical,
@@ -169,6 +175,7 @@ export async function fetchPitchingStatistics(
 }
 
 export interface LeaderQueryOptions {
+  seasonId?: string;
   divisionId?: string;
   teamId?: string;
   isHistorical?: boolean;
@@ -189,6 +196,7 @@ export async function fetchStatisticalLeaders(
 ): Promise<LeaderRowType[]> {
   const client = resolveClient(options);
   const {
+    seasonId,
     divisionId,
     teamId,
     isHistorical,
@@ -205,6 +213,7 @@ export async function fetchStatisticalLeaders(
     path: { accountId, leagueId },
     query: {
       category,
+      seasonId: sanitizeId(seasonId),
       divisionId: sanitizeId(divisionId),
       teamId: sanitizeId(teamId),
       isHistorical,

--- a/draco-nodejs/shared/shared-schemas/statistics.ts
+++ b/draco-nodejs/shared/shared-schemas/statistics.ts
@@ -159,9 +159,7 @@ export const StatisticsFiltersSchema = z.object({
     .default(50),
 });
 
-export const BattingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
-  seasonId: true,
-}).extend({
+export const BattingStatisticsFiltersSchema = StatisticsFiltersSchema.extend({
   minAB: z
     .string()
     .transform((val) => parseInt(val))
@@ -170,9 +168,7 @@ export const BattingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
 });
 
-export const PitchingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
-  seasonId: true,
-}).extend({
+export const PitchingStatisticsFiltersSchema = StatisticsFiltersSchema.extend({
   minIP: z
     .string()
     .transform((val) => parseInt(val))
@@ -181,9 +177,7 @@ export const PitchingStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
   sortOrder: z.enum(['asc', 'desc']).default('asc'),
 });
 
-export const LeaderStatisticsFiltersSchema = StatisticsFiltersSchema.omit({
-  seasonId: true,
-}).extend({
+export const LeaderStatisticsFiltersSchema = StatisticsFiltersSchema.extend({
   minAB: z
     .string()
     .transform((val) => parseInt(val))


### PR DESCRIPTION
## Summary

Adds an **All Leagues** option to the Statistics page and makes All-Time stats behave consistently:

- **All Leagues** filter (value `0`) aggregates Leaders / Batting / Pitching across every league in the selected season. Teams and Standings show an "unsupported in All Leagues" message.
- **All-Time + All Leagues** aggregates across every league and season for the account.
- **All-Time now includes postseason games** (regular season + playoffs) so the all-time tabs match the player career page (e.g. a pitcher's career strikeouts reconcile across both views).
- **Account scoping is now enforced** on the batting / pitching / leaders queries (`season.accountid`), closing an IDOR where the URL `:accountId` was previously ignored in favor of the league/season filter alone.
- **Filter + active tab persist in the URL** (`?season=&league=&division=&tab=`), so the browser Back button restores selections after viewing a player's career stats (and views are shareable).
- Removed the redundant **All-Time Stats** toggle; "All Time" lives in the Season dropdown.

## Approvals

- **shared-schemas change approved by maintainer (@rwalker123).** `shared-schemas/statistics.ts` stops omitting the existing optional `seasonId` field on `Batting/Pitching/LeaderStatisticsFiltersSchema` so the backend can scope All-Leagues queries to a season. The API client was regenerated via `pnpm sync:api`. This edit to the restricted `shared/shared-schemas` directory was explicitly approved before implementation.

## Testing

- Backend: new `minimumCalculator`, `PrismaBatting/PitchingStatisticsRepository`, and `statisticsService` game-type tests; plus existing suites. Lint + type-check pass.
- Frontend: new `statisticsService` seasonId/All-Leagues tests; production build passes.
- E2E: `statistics.spec.ts` updated for the new UI and URL-restore behavior — passes across chromium, firefox, webkit, mobile-chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
