### PR TITLE
Set database timezone to UTC in Prisma adapter

### DIFF
--- a/draco-nodejs/backend/src/lib/prisma.ts
+++ b/draco-nodejs/backend/src/lib/prisma.ts
@@ -59,7 +59,7 @@ type ExtendedPrismaClient = ReturnType<typeof createExtendedPrismaClient>;
 // Build the connection URL with pool configuration
 const baseUrl = process.env.DATABASE_URL || 'postgresql://postgres@localhost:5432/ezrecsports';
 const connectionUrl = buildConnectionUrl(baseUrl, databaseConfig);
-const adapter = new PrismaPg({ connectionString: connectionUrl });
+const adapter = new PrismaPg({ connectionString: connectionUrl, options: '-c timezone=UTC' });
 
 // Create a singleton PrismaClient instance with enhanced configuration
 const prisma =


### PR DESCRIPTION
Add explicit timezone configuration (-c timezone=UTC) to the PrismaPg adapter to ensure consistent UTC handling across database connections and prevent timezone-related data inconsistencies.