### PR TITLE
Add shared role fixtures for permission testing

### DIFF
--- a/draco-nodejs/backend/package.json
+++ b/draco-nodejs/backend/package.json
@@ -67,6 +67,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@draco/shared-role-fixtures": "workspace:*",
     "@eslint/js": "^9.39.4",
     "@hey-api/openapi-ts": "^0.90.10",
     "@types/aws-lambda": "^8.10.161",

--- a/draco-nodejs/backend/src/services/__tests__/permissionFixtures.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/permissionFixtures.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import {
+  PERMISSION_TEST_CASES,
+  ROLE_PERMISSIONS_FIXTURE,
+  RoleName,
+} from '@draco/shared-role-fixtures';
+import { RoleService } from '../roleService.js';
+import { RoleContextData } from '../interfaces/roleInterfaces.js';
+import { ROLE_IDS, ROLE_PERMISSIONS_BY_ID, initializeRoleIds } from '../../config/roles.js';
+import { ROLE_PERMISSIONS } from '../../types/roles.js';
+import { RoleWithContactType, UserRolesType } from '@draco/shared-schemas';
+
+const ROLE_GUIDS: Record<RoleName, string> = {
+  Administrator: '00000000-0000-0000-0000-000000000001',
+  AccountAdmin: '00000000-0000-0000-0000-000000000002',
+  AccountPhotoAdmin: '00000000-0000-0000-0000-000000000003',
+  LeagueAdmin: '00000000-0000-0000-0000-000000000004',
+  TeamAdmin: '00000000-0000-0000-0000-000000000005',
+  TeamPhotoAdmin: '00000000-0000-0000-0000-000000000006',
+};
+
+const sorted = (values: string[]): string[] => [...values].sort();
+
+const toContext = (context: {
+  accountId?: string;
+  teamId?: string;
+  leagueId?: string;
+}): RoleContextData => ({
+  accountId: BigInt(context.accountId ?? '0'),
+  teamId: context.teamId === undefined ? undefined : BigInt(context.teamId),
+  leagueId: context.leagueId === undefined ? undefined : BigInt(context.leagueId),
+});
+
+const buildService = (userRoles: UserRolesType): RoleService => {
+  const service = Object.create(RoleService.prototype) as RoleService;
+  service.getUserRoles = async () => userRoles;
+  return service;
+};
+
+beforeAll(async () => {
+  await initializeRoleIds({
+    aspnetroles: {
+      findMany: async () => Object.entries(ROLE_GUIDS).map(([name, id]) => ({ id, name })),
+    },
+  });
+});
+
+describe('permission fixtures — backend RoleService.hasPermission', () => {
+  it('fixture role table matches backend ROLE_PERMISSIONS (drift guard)', () => {
+    const fixtureNames = Object.keys(ROLE_PERMISSIONS_FIXTURE).sort();
+    const backendNames = Object.keys(ROLE_PERMISSIONS).sort();
+    expect(fixtureNames).toEqual(backendNames);
+
+    for (const name of fixtureNames) {
+      const fixture = ROLE_PERMISSIONS_FIXTURE[name as RoleName];
+      const backend = ROLE_PERMISSIONS[name];
+      expect(fixture.context, `context for ${name}`).toBe(backend.context);
+      expect(sorted(fixture.permissions), `permissions for ${name}`).toEqual(
+        sorted(backend.permissions),
+      );
+    }
+  });
+
+  it('every role is exercised by at least one fixture case (exhaustiveness)', () => {
+    const exercised = new Set<string>();
+    for (const testCase of PERMISSION_TEST_CASES) {
+      for (const role of testCase.contactRoles) exercised.add(ROLE_IDS[role.roleName]);
+      for (const role of testCase.globalRoles) exercised.add(ROLE_IDS[role]);
+    }
+    for (const roleId of Object.keys(ROLE_PERMISSIONS_BY_ID)) {
+      expect(exercised.has(roleId), `role id ${roleId} not exercised`).toBe(true);
+    }
+  });
+
+  for (const testCase of PERMISSION_TEST_CASES) {
+    it(testCase.name, async () => {
+      const contactRoles: RoleWithContactType[] = testCase.contactRoles.map((role) => ({
+        id: '0',
+        roleId: ROLE_IDS[role.roleName],
+        roleName: role.roleName,
+        roleData: role.roleData,
+        accountId: role.accountId,
+        contact: { id: '0' },
+      }));
+
+      const userRoles: UserRolesType = {
+        globalRoles: testCase.globalRoles.map((name) => ROLE_IDS[name]),
+        contactRoles,
+      };
+
+      const service = buildService(userRoles);
+      const result = await service.hasPermission(
+        'user-1',
+        testCase.permission,
+        toContext(testCase.context),
+      );
+
+      expect(result, testCase.rationale ?? testCase.name).toBe(testCase.expected);
+    });
+  }
+});

--- a/draco-nodejs/backend/src/services/roleService.ts
+++ b/draco-nodejs/backend/src/services/roleService.ts
@@ -27,6 +27,7 @@ import {
 import { RoleResponseFormatter } from '../responseFormatters/index.js';
 import { RoleContextData } from './interfaces/roleInterfaces.js';
 import { ValidationError } from '../utils/customErrors.js';
+import { validateRoleContext as validateRoleContextByLevel } from '../utils/roleContext.js';
 import { UserService } from './userService.js';
 import { ServiceFactory } from './serviceFactory.js';
 import { AccountsService } from './accountsService.js';
@@ -568,28 +569,12 @@ export class RoleService implements IRoleService {
    * Validate role context (check if roleData matches context)
    */
   private validateRoleContext(contactRole: RoleWithContactType, context: RoleContextData): boolean {
-    // For account-level roles, just check accountId
-    if (
-      contactRole.roleId === ROLE_IDS[RoleNamesType.ACCOUNT_ADMIN] ||
-      contactRole.roleId === ROLE_IDS[RoleNamesType.ACCOUNT_PHOTO_ADMIN]
-    ) {
-      return contactRole.accountId === context.accountId.toString();
-    }
-
-    // For team-level roles, check if roleData matches teamId
-    if (
-      contactRole.roleId === ROLE_IDS[RoleNamesType.TEAM_ADMIN] ||
-      contactRole.roleId === ROLE_IDS[RoleNamesType.TEAM_PHOTO_ADMIN]
-    ) {
-      return contactRole.roleData === context.teamId?.toString();
-    }
-
-    // For league-level roles, check if roleData matches leagueId
-    if (contactRole.roleId === ROLE_IDS[RoleNamesType.LEAGUE_ADMIN]) {
-      return contactRole.roleData === context.leagueId?.toString();
-    }
-
-    return false;
+    const level = ROLE_PERMISSIONS_BY_ID[contactRole.roleId]?.context;
+    return validateRoleContextByLevel(contactRole, level, {
+      accountId: context.accountId.toString(),
+      teamId: context.teamId?.toString(),
+      leagueId: context.leagueId?.toString(),
+    });
   }
 
   /**

--- a/draco-nodejs/backend/src/utils/roleContext.ts
+++ b/draco-nodejs/backend/src/utils/roleContext.ts
@@ -1,0 +1,43 @@
+export type RoleLevel = 'global' | 'account' | 'team' | 'league';
+
+export interface ContactRoleLike {
+  roleId: string;
+  accountId?: string;
+  roleData?: string;
+}
+
+export interface PermissionContextLike {
+  accountId?: string;
+  teamId?: string;
+  leagueId?: string;
+}
+
+export function validateRoleContext(
+  contactRole: ContactRoleLike,
+  level: RoleLevel | string | undefined,
+  context: PermissionContextLike | undefined,
+): boolean {
+  if (level === 'account') {
+    return Boolean(context?.accountId) && contactRole.accountId === context!.accountId;
+  }
+
+  if (level === 'team') {
+    return (
+      Boolean(context?.accountId) &&
+      Boolean(context?.teamId) &&
+      contactRole.accountId === context!.accountId &&
+      contactRole.roleData === context!.teamId
+    );
+  }
+
+  if (level === 'league') {
+    return (
+      Boolean(context?.accountId) &&
+      Boolean(context?.leagueId) &&
+      contactRole.accountId === context!.accountId &&
+      contactRole.roleData === context!.leagueId
+    );
+  }
+
+  return false;
+}

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -214,7 +214,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     hasRoleInTeam('TeamAdmin', teamSeasonId) ||
     hasRoleInTeam('TeamPhotoAdmin', teamSeasonId);
 
-  const canEditPlayerPhotos = hasPermission('account.contacts.photos.manage', { accountId });
+  const canEditPlayerPhotos = hasPermission('account.contacts.manage', { accountId });
 
   const canViewRosterDetails =
     hasRole('Administrator') ||
@@ -507,10 +507,11 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     hasRoleInTeam('TeamAdmin', teamSeasonId) ||
     hasRoleInTeam('TeamPhotoAdmin', teamSeasonId);
 
-  const canSendTeamCommunications =
-    hasRole('Administrator') ||
-    hasRoleInAccount('AccountAdmin', accountId) ||
-    hasRoleInTeam('TeamAdmin', teamSeasonId);
+  const canSendTeamCommunications = hasPermission('team.communications.send', {
+    accountId,
+    seasonId,
+    teamId: teamSeasonId,
+  });
 
   const canManageInformationMessages =
     hasRole('Administrator') ||

--- a/draco-nodejs/frontend-next/app/account/[accountId]/social-hub/posts/AccountSocialPostsPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/social-hub/posts/AccountSocialPostsPage.tsx
@@ -42,7 +42,7 @@ const AccountSocialPostsPage: React.FC = () => {
     seasonId: currentSeasonId ?? undefined,
   });
   const { hasPermission } = useRole();
-  const canManage = hasPermission('account.manage', accountId ? { accountId } : undefined);
+  const canManage = hasPermission('account.manage', { accountId });
 
   const [posts, setPosts] = React.useState<SocialFeedItemType[]>([]);
   const [loading, setLoading] = React.useState(false);

--- a/draco-nodejs/frontend-next/components/GolfMatchesWidget.tsx
+++ b/draco-nodejs/frontend-next/components/GolfMatchesWidget.tsx
@@ -56,7 +56,7 @@ export default function GolfMatchesWidget({
   const { user } = useAuth();
   const { hasPermission } = useRole();
   const isAuthenticated = !!user;
-  const canManageLeague = hasPermission('account.manage');
+  const canManageLeague = hasPermission('account.manage', { accountId });
 
   const apiClientRef = useRef(apiClient);
   useEffect(() => {

--- a/draco-nodejs/frontend-next/components/auth/ProtectedRoute.tsx
+++ b/draco-nodejs/frontend-next/components/auth/ProtectedRoute.tsx
@@ -93,6 +93,8 @@ const ProtectedRouteContent: React.FC<ProtectedRouteProps> = ({
         } else {
           evaluation = { status: 'pending' };
         }
+      } else if (checkAccountBoundary && !currentAccount) {
+        evaluation = { status: 'pending' };
       } else {
         const hasRequiredPermission =
           checkAccountBoundary && currentAccount

--- a/draco-nodejs/frontend-next/components/golf/substitutes/LeagueSubstitutesPage.tsx
+++ b/draco-nodejs/frontend-next/components/golf/substitutes/LeagueSubstitutesPage.tsx
@@ -67,7 +67,7 @@ export function LeagueSubstitutesPage() {
   const rosterService = useGolfRosters(accountId);
   const { hasPermission } = useRole();
   const { notification, showNotification, hideNotification } = useNotifications();
-  const canManage = hasPermission('account.manage');
+  const canManage = hasPermission('account.manage', { accountId });
 
   const [season, setSeason] = useState<SeasonType | null>(null);
   const [substitutes, setSubstitutes] = useState<GolfSubstituteType[]>([]);

--- a/draco-nodejs/frontend-next/components/social/SocialPostsWidget.tsx
+++ b/draco-nodejs/frontend-next/components/social/SocialPostsWidget.tsx
@@ -31,7 +31,7 @@ const SocialPostsWidget: React.FC<SocialPostsWidgetProps> = ({
   });
   const apiClient = useApiClient();
   const { hasPermission } = useRole();
-  const canManage = hasPermission('account.manage', accountId ? { accountId } : undefined);
+  const canManage = hasPermission('account.manage', { accountId });
   const [state, setState] = useState<{
     items: SocialFeedItemType[];
     error: string | null;

--- a/draco-nodejs/frontend-next/context/RoleContext.tsx
+++ b/draco-nodejs/frontend-next/context/RoleContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useAuth } from './AuthContext';
-import { ROLE_NAME_TO_ID } from '../utils/roleUtils';
+import { ROLE_NAME_TO_ID, evaluatePermission } from '../utils/roleUtils';
 import { useParams } from 'next/navigation';
 import { getCurrentUserRoles, getRoleMetadata } from '@draco/shared-api-client';
 import { unwrapApiResult } from '../utils/apiResult';
@@ -70,21 +70,6 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
       }
     }
     return [];
-  };
-
-  const getPermissionsForRole = (
-    roleId?: string | null,
-  ): { roleId: string; permissions: string[]; context: string } | undefined => {
-    if (!roleMetadata || !roleId) return undefined;
-
-    const candidates = [roleId, roleId.toUpperCase(), roleId.toLowerCase()];
-    for (const candidate of candidates) {
-      const perms = roleMetadata.permissions[candidate];
-      if (perms) {
-        return perms;
-      }
-    }
-    return undefined;
   };
 
   // Update loading state based on auth state
@@ -273,45 +258,7 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
 
   const hasPermission = (permission: string, context?: RoleContext): boolean => {
     if (!userRoles || !roleMetadata) return false;
-
-    // Check global roles first
-    for (const globalRole of userRoles.globalRoles) {
-      const globalRoleId = normalizeRoleId(ROLE_NAME_TO_ID[globalRole] || globalRole);
-      const rolePerms = getPermissionsForRole(globalRoleId);
-      if (
-        rolePerms &&
-        (rolePerms.permissions.includes('*') || rolePerms.permissions.includes(permission))
-      ) {
-        return true;
-      }
-    }
-
-    // Check contact roles
-    for (const contactRole of userRoles.contactRoles) {
-      // Validate context if provided
-      if (context?.accountId && contactRole.accountId !== context.accountId) {
-        continue;
-      }
-      if (context?.teamId && contactRole.roleData !== context.teamId) {
-        continue;
-      }
-      if (context?.leagueId && contactRole.roleData !== context.leagueId) {
-        continue;
-      }
-
-      const contactRoleId = normalizeRoleId(
-        ROLE_NAME_TO_ID[contactRole.roleId] || contactRole.roleId,
-      );
-      const rolePerms = getPermissionsForRole(contactRoleId);
-      if (
-        rolePerms &&
-        (rolePerms.permissions.includes('*') || rolePerms.permissions.includes(permission))
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return evaluatePermission(userRoles, roleMetadata.permissions, permission, context);
   };
 
   const hasRoleInAccount = (roleId: string, accountId: string): boolean => {

--- a/draco-nodejs/frontend-next/context/__tests__/RoleContext.permissions.test.ts
+++ b/draco-nodejs/frontend-next/context/__tests__/RoleContext.permissions.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PERMISSION_TEST_CASES,
+  ROLE_PERMISSIONS_FIXTURE,
+  RoleName,
+} from '@draco/shared-role-fixtures';
+import {
+  evaluatePermission,
+  ROLE_NAME_TO_ID,
+  RolePermissionsByRoleId,
+  UserRolesLike,
+} from '../../utils/roleUtils';
+
+const ROLE_NAMES = Object.keys(ROLE_PERMISSIONS_FIXTURE) as RoleName[];
+
+const buildPermissions = (): RolePermissionsByRoleId => {
+  const permissions: RolePermissionsByRoleId = {};
+  for (const name of ROLE_NAMES) {
+    const roleId = ROLE_NAME_TO_ID[name];
+    permissions[roleId] = {
+      roleId,
+      permissions: ROLE_PERMISSIONS_FIXTURE[name].permissions,
+      context: ROLE_PERMISSIONS_FIXTURE[name].context,
+    };
+  }
+  return permissions;
+};
+
+describe('permission fixtures — frontend evaluatePermission', () => {
+  const permissions = buildPermissions();
+
+  it('every role in metadata is exercised by at least one fixture case (exhaustiveness)', () => {
+    const exercised = new Set<string>();
+    for (const testCase of PERMISSION_TEST_CASES) {
+      for (const role of testCase.contactRoles) exercised.add(ROLE_NAME_TO_ID[role.roleName]);
+      for (const role of testCase.globalRoles) exercised.add(ROLE_NAME_TO_ID[role]);
+    }
+    for (const roleId of Object.keys(permissions)) {
+      expect(exercised.has(roleId), `role id ${roleId} not exercised`).toBe(true);
+    }
+  });
+
+  for (const testCase of PERMISSION_TEST_CASES) {
+    it(testCase.name, () => {
+      const userRoles: UserRolesLike = {
+        globalRoles: testCase.globalRoles,
+        contactRoles: testCase.contactRoles.map((role) => ({
+          roleId: role.roleName,
+          accountId: role.accountId,
+          roleData: role.roleData,
+        })),
+      };
+
+      const result = evaluatePermission(
+        userRoles,
+        permissions,
+        testCase.permission,
+        testCase.context,
+      );
+
+      expect(result, testCase.rationale ?? testCase.name).toBe(testCase.expected);
+    });
+  }
+});

--- a/draco-nodejs/frontend-next/package.json
+++ b/draco-nodejs/frontend-next/package.json
@@ -81,6 +81,7 @@
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
+    "@draco/shared-role-fixtures": "workspace:*",
     "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.2",

--- a/draco-nodejs/frontend-next/utils/roleUtils.ts
+++ b/draco-nodejs/frontend-next/utils/roleUtils.ts
@@ -160,3 +160,101 @@ export function isLeagueBasedRole(roleId: string): boolean {
   const roleName = ROLE_ID_TO_NAME[roleId] || roleId;
   return LEAGUE_BASED_ROLES.includes(roleName);
 }
+
+export type RoleLevel = 'global' | 'account' | 'team' | 'league';
+
+export interface ContactRoleLike {
+  roleId: string;
+  accountId?: string;
+  roleData?: string;
+}
+
+export interface PermissionContextLike {
+  accountId?: string;
+  teamId?: string;
+  leagueId?: string;
+}
+
+export function validateRoleContext(
+  contactRole: ContactRoleLike,
+  level: RoleLevel | string | undefined,
+  context: PermissionContextLike | undefined,
+): boolean {
+  if (level === 'account') {
+    return Boolean(context?.accountId) && contactRole.accountId === context!.accountId;
+  }
+
+  if (level === 'team') {
+    return (
+      Boolean(context?.accountId) &&
+      Boolean(context?.teamId) &&
+      contactRole.accountId === context!.accountId &&
+      contactRole.roleData === context!.teamId
+    );
+  }
+
+  if (level === 'league') {
+    return (
+      Boolean(context?.accountId) &&
+      Boolean(context?.leagueId) &&
+      contactRole.accountId === context!.accountId &&
+      contactRole.roleData === context!.leagueId
+    );
+  }
+
+  return false;
+}
+
+export interface RolePermissionEntry {
+  roleId: string;
+  permissions: string[];
+  context: string;
+}
+
+export type RolePermissionsByRoleId = Record<string, RolePermissionEntry>;
+
+export interface UserRolesLike {
+  globalRoles: string[];
+  contactRoles: ContactRoleLike[];
+}
+
+export function lookupRolePermissions(
+  permissions: RolePermissionsByRoleId | undefined,
+  roleId?: string | null,
+): RolePermissionEntry | undefined {
+  if (!permissions || !roleId) return undefined;
+
+  const candidates = [roleId, roleId.toUpperCase(), roleId.toLowerCase()];
+  for (const candidate of candidates) {
+    const perms = permissions[candidate];
+    if (perms) return perms;
+  }
+  return undefined;
+}
+
+export function evaluatePermission(
+  userRoles: UserRolesLike,
+  permissions: RolePermissionsByRoleId,
+  permission: string,
+  context?: PermissionContextLike,
+): boolean {
+  const grants = (entry: RolePermissionEntry | undefined): boolean =>
+    Boolean(entry) && (entry!.permissions.includes('*') || entry!.permissions.includes(permission));
+
+  for (const globalRole of userRoles.globalRoles) {
+    const entry = lookupRolePermissions(permissions, ROLE_NAME_TO_ID[globalRole] || globalRole);
+    if (grants(entry)) return true;
+  }
+
+  for (const contactRole of userRoles.contactRoles) {
+    const entry = lookupRolePermissions(
+      permissions,
+      ROLE_NAME_TO_ID[contactRole.roleId] || contactRole.roleId,
+    );
+    if (!entry) continue;
+    if (!validateRoleContext(contactRole, entry.context, context)) continue;
+    if (grants(entry)) return true;
+  }
+
+  return false;
+}

--- a/draco-nodejs/shared/shared-role-fixtures/eslint.config.js
+++ b/draco-nodejs/shared/shared-role-fixtures/eslint.config.js
@@ -1,0 +1,40 @@
+import js from '@eslint/js';
+import typescript from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+
+  {
+    files: ['**/*.{js,ts}'],
+    languageOptions: {
+      parser: typescriptParser,
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescript,
+    },
+    rules: {
+      ...typescript.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
+    },
+  },
+
+  {
+    ignores: ['node_modules/', 'dist/', '*.d.ts'],
+  },
+];

--- a/draco-nodejs/shared/shared-role-fixtures/index.ts
+++ b/draco-nodejs/shared/shared-role-fixtures/index.ts
@@ -1,0 +1,331 @@
+export type RoleName =
+  | 'Administrator'
+  | 'AccountAdmin'
+  | 'AccountPhotoAdmin'
+  | 'LeagueAdmin'
+  | 'TeamAdmin'
+  | 'TeamPhotoAdmin';
+
+export type RoleLevel = 'global' | 'account' | 'team' | 'league';
+
+export interface RolePermissionFixture {
+  permissions: string[];
+  context: RoleLevel;
+}
+
+export interface RoleFixture {
+  roleName: RoleName;
+  accountId: string;
+  roleData: string;
+}
+
+export interface PermissionTestContext {
+  accountId?: string;
+  teamId?: string;
+  leagueId?: string;
+}
+
+export interface PermissionTestCase {
+  name: string;
+  contactRoles: RoleFixture[];
+  globalRoles: RoleName[];
+  permission: string;
+  context: PermissionTestContext;
+  expected: boolean;
+  rationale?: string;
+}
+
+export const ROLE_PERMISSIONS_FIXTURE: Record<RoleName, RolePermissionFixture> = {
+  Administrator: {
+    permissions: ['*'],
+    context: 'global',
+  },
+  AccountAdmin: {
+    permissions: [
+      'account.communications.manage',
+      'account.contacts.manage',
+      'account.contacts.photos.manage',
+      'account.dashboard.view',
+      'account.handouts.manage',
+      'account.fields.manage',
+      'account.games.manage',
+      'account.manage',
+      'account.settings.manage',
+      'account.photos.manage',
+      'account.polls.manage',
+      'account.player-surveys.manage',
+      'account.roles.manage',
+      'account.rosters.view',
+      'account.sponsors.manage',
+      'account.umpires.manage',
+      'league.faq.manage',
+      'manage-users',
+      'team.communications.send',
+      'team.handouts.manage',
+      'team.photos.manage',
+      'team.sponsors.manage',
+      'league.manage',
+      'team.manage',
+      'player.manage',
+      'photo.manage',
+      'workout.manage',
+      'player-classified.manage',
+      'player-classified.create-players-wanted',
+      'player-classified.edit-players-wanted',
+      'player-classified.delete-players-wanted',
+      'team.managers.manage',
+    ],
+    context: 'account',
+  },
+  AccountPhotoAdmin: {
+    permissions: ['account.photos.manage', 'account.contacts.photos.manage', 'team.photos.manage'],
+    context: 'account',
+  },
+  LeagueAdmin: {
+    permissions: [
+      'league.manage',
+      'league.teams.manage',
+      'league.players.manage',
+      'league.schedule.manage',
+      'league.faq.manage',
+      'account.contacts.photos.manage',
+      'player-classified.create-players-wanted',
+      'player-classified.edit-players-wanted',
+      'player-classified.delete-players-wanted',
+    ],
+    context: 'league',
+  },
+  TeamAdmin: {
+    permissions: [
+      'team.communications.send',
+      'team.manage',
+      'team.handouts.manage',
+      'team.players.manage',
+      'team.stats.manage',
+      'team.sponsors.manage',
+      'team.photos.manage',
+      'team.managers.manage',
+      'player-classified.create-players-wanted',
+      'player-classified.edit-players-wanted',
+      'player-classified.delete-players-wanted',
+    ],
+    context: 'team',
+  },
+  TeamPhotoAdmin: {
+    permissions: ['team.photos.manage', 'account.contacts.photos.manage'],
+    context: 'team',
+  },
+};
+
+export const PERMISSION_TEST_CASES: readonly PermissionTestCase[] = [
+  {
+    name: 'AccountAdmin granted account permission under team context',
+    contactRoles: [{ roleName: 'AccountAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1', teamId: '5' },
+    expected: true,
+    rationale: 'Defect 1: account-level grant must survive an extra teamId in context.',
+  },
+  {
+    name: 'AccountAdmin granted team.communications.send under team context',
+    contactRoles: [{ roleName: 'AccountAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1', teamId: '5' },
+    expected: true,
+    rationale: 'Defect 1: the original team-page Email button regression.',
+  },
+  {
+    name: 'AccountAdmin granted account permission under league context',
+    contactRoles: [{ roleName: 'AccountAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1', leagueId: '7' },
+    expected: true,
+    rationale: 'Defect 1: account-level grant must survive an extra leagueId in context.',
+  },
+  {
+    name: 'LeagueAdmin denied team-scoped check on colliding id',
+    contactRoles: [{ roleName: 'LeagueAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'account.contacts.photos.manage',
+    context: { accountId: '1', teamId: '7' },
+    expected: false,
+    rationale: 'Defect 2: leagueId 7 must not match teamId 7.',
+  },
+  {
+    name: 'TeamAdmin denied league-scoped check on colliding id',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1', leagueId: '7' },
+    expected: false,
+    rationale: 'Defect 2: teamId 7 must not match leagueId 7.',
+  },
+  {
+    name: 'TeamPhotoAdmin denied league-scoped check on colliding id',
+    contactRoles: [{ roleName: 'TeamPhotoAdmin', accountId: '1', roleData: '9' }],
+    globalRoles: [],
+    permission: 'account.contacts.photos.manage',
+    context: { accountId: '1', leagueId: '9' },
+    expected: false,
+    rationale: 'Defect 2: team-scoped role must not match a league context.',
+  },
+  {
+    name: 'AccountAdmin denied across account boundary',
+    contactRoles: [{ roleName: 'AccountAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '2' },
+    expected: false,
+    rationale: 'Account boundary: role in account 1, context account 2.',
+  },
+  {
+    name: 'TeamAdmin denied right team wrong account',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '5' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '2', teamId: '5' },
+    expected: false,
+    rationale: 'Account boundary: matching teamId but wrong account.',
+  },
+  {
+    name: 'TeamAdmin granted matching team context',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '5' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1', teamId: '5' },
+    expected: true,
+    rationale: 'Team-scoped grant with the correct teamId.',
+  },
+  {
+    name: 'TeamAdmin denied wrong team context',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '5' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1', teamId: '6' },
+    expected: false,
+    rationale: 'Team-scoped role for team 5 must not match team 6.',
+  },
+  {
+    name: 'TeamAdmin denied missing team context',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '5' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1' },
+    expected: false,
+    rationale: 'Strict matching: missing required teamId denies.',
+  },
+  {
+    name: 'LeagueAdmin granted matching league context',
+    contactRoles: [{ roleName: 'LeagueAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'league.faq.manage',
+    context: { accountId: '1', leagueId: '7' },
+    expected: true,
+    rationale: 'League-scoped grant with the correct leagueId.',
+  },
+  {
+    name: 'LeagueAdmin denied wrong league context',
+    contactRoles: [{ roleName: 'LeagueAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'league.faq.manage',
+    context: { accountId: '1', leagueId: '8' },
+    expected: false,
+    rationale: 'League-scoped role for league 7 must not match league 8.',
+  },
+  {
+    name: 'LeagueAdmin denied missing league context',
+    contactRoles: [{ roleName: 'LeagueAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'league.faq.manage',
+    context: { accountId: '1' },
+    expected: false,
+    rationale: 'Strict matching: missing required leagueId denies.',
+  },
+  {
+    name: 'Administrator granted account permission with account context',
+    contactRoles: [],
+    globalRoles: ['Administrator'],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1' },
+    expected: true,
+    rationale: 'Global role holds wildcard.',
+  },
+  {
+    name: 'Administrator granted with empty context',
+    contactRoles: [],
+    globalRoles: ['Administrator'],
+    permission: 'database.cleanup',
+    context: {},
+    expected: true,
+    rationale: 'Administrator wildcard needs no context.',
+  },
+  {
+    name: 'Administrator granted regardless of context ids',
+    contactRoles: [],
+    globalRoles: ['Administrator'],
+    permission: 'account.contacts.manage',
+    context: { accountId: '999', teamId: '999', leagueId: '999' },
+    expected: true,
+    rationale: 'Global role bypasses context filtering entirely.',
+  },
+  {
+    name: 'TeamAdmin denied permission it does not hold',
+    contactRoles: [{ roleName: 'TeamAdmin', accountId: '1', roleData: '5' }],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1', teamId: '5' },
+    expected: false,
+    rationale: 'TeamAdmin does not hold account.contacts.manage.',
+  },
+  {
+    name: 'LeagueAdmin denied permission it does not hold',
+    contactRoles: [{ roleName: 'LeagueAdmin', accountId: '1', roleData: '7' }],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '1', leagueId: '7' },
+    expected: false,
+    rationale: 'LeagueAdmin does not hold team.communications.send.',
+  },
+  {
+    name: 'Multiple roles: TeamAdmin in second account grants',
+    contactRoles: [
+      { roleName: 'AccountAdmin', accountId: '1', roleData: '1' },
+      { roleName: 'TeamAdmin', accountId: '2', roleData: '5' },
+    ],
+    globalRoles: [],
+    permission: 'team.communications.send',
+    context: { accountId: '2', teamId: '5' },
+    expected: true,
+    rationale: 'TeamAdmin in account 2 grants; AccountAdmin in account 1 does not apply.',
+  },
+  {
+    name: 'AccountPhotoAdmin granted account photo permission',
+    contactRoles: [{ roleName: 'AccountPhotoAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'account.contacts.photos.manage',
+    context: { accountId: '1' },
+    expected: true,
+    rationale: 'Account-scoped photo admin holds the permission.',
+  },
+  {
+    name: 'AccountPhotoAdmin denied permission it does not hold',
+    contactRoles: [{ roleName: 'AccountPhotoAdmin', accountId: '1', roleData: '1' }],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1' },
+    expected: false,
+    rationale: 'AccountPhotoAdmin does not hold account.contacts.manage.',
+  },
+  {
+    name: 'No roles denies everything',
+    contactRoles: [],
+    globalRoles: [],
+    permission: 'account.contacts.manage',
+    context: { accountId: '1' },
+    expected: false,
+    rationale: 'Unauthenticated / no roles.',
+  },
+];

--- a/draco-nodejs/shared/shared-role-fixtures/package.json
+++ b/draco-nodejs/shared/shared-role-fixtures/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@draco/shared-role-fixtures",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "lint": "eslint '**/*.{js,ts}'",
+    "lint:fix": "eslint '**/*.{js,ts}' --fix",
+    "test": "echo 'No tests configured for shared-role-fixtures'",
+    "build": "tsc",
+    "format": "prettier --write .",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@types/node": "^24.12.0",
+    "@typescript-eslint/eslint-plugin": "^8.57.2",
+    "@typescript-eslint/parser": "^8.57.2",
+    "eslint": "^9.39.4",
+    "globals": "^17.4.0",
+    "typescript-eslint": "^8.57.2"
+  }
+}

--- a/draco-nodejs/shared/shared-role-fixtures/tsconfig.json
+++ b/draco-nodejs/shared/shared-role-fixtures/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "strict": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@draco/shared-role-fixtures':
+        specifier: workspace:*
+        version: link:../shared/shared-role-fixtures
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
@@ -534,6 +537,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.29.0)
+      '@draco/shared-role-fixtures':
+        specifier: workspace:*
+        version: link:../shared/shared-role-fixtures
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -691,6 +697,30 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      typescript-eslint:
+        specifier: ^8.57.2
+        version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+
+  draco-nodejs/shared/shared-role-fixtures:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
+      '@types/node':
+        specifier: ^24.0.1
+        version: 24.12.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.57.2
+        version: 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.57.2
+        version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
       typescript-eslint:
         specifier: ^8.57.2
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -14683,8 +14713,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -14710,7 +14740,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -14721,21 +14751,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14746,7 +14776,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Create @draco/shared-role-fixtures package with centralized role permission definitions and comprehensive test cases. Extract permission evaluation logic into reusable utilities (validateRoleContext, evaluatePermission) used by both backend RoleService and frontend RoleContext. Add test suites on both sides to verify permission evaluation against shared fixtures. Fix frontend permission checks in multiple components to use proper context parameters.