### PR TITLE
Enable team-admin roster photo/number edits

### DIFF
--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -7810,6 +7810,7 @@
                     "ShowRosterCard",
                     "EnableTeamEmail",
                     "ShowUserInfoOnRosterPage",
+                    "AllowTeamAdminPlayerEdits",
                     "ShowContactInfo",
                     "EditContactInfo",
                     "EmailGameResultsToTeams",
@@ -7901,6 +7902,7 @@
                           "ShowRosterCard",
                           "EnableTeamEmail",
                           "ShowUserInfoOnRosterPage",
+                          "AllowTeamAdminPlayerEdits",
                           "ShowContactInfo",
                           "EditContactInfo",
                           "EmailGameResultsToTeams",
@@ -8059,6 +8061,7 @@
                   "ShowRosterCard",
                   "EnableTeamEmail",
                   "ShowUserInfoOnRosterPage",
+                  "AllowTeamAdminPlayerEdits",
                   "ShowContactInfo",
                   "EditContactInfo",
                   "EmailGameResultsToTeams",
@@ -8150,6 +8153,7 @@
                         "ShowRosterCard",
                         "EnableTeamEmail",
                         "ShowUserInfoOnRosterPage",
+                        "AllowTeamAdminPlayerEdits",
                         "ShowContactInfo",
                         "EditContactInfo",
                         "EmailGameResultsToTeams",
@@ -8319,6 +8323,7 @@
           "ShowRosterCard",
           "EnableTeamEmail",
           "ShowUserInfoOnRosterPage",
+          "AllowTeamAdminPlayerEdits",
           "ShowContactInfo",
           "EditContactInfo",
           "EmailGameResultsToTeams",
@@ -41065,6 +41070,7 @@
                 "ShowRosterCard",
                 "EnableTeamEmail",
                 "ShowUserInfoOnRosterPage",
+                "AllowTeamAdminPlayerEdits",
                 "ShowContactInfo",
                 "EditContactInfo",
                 "EmailGameResultsToTeams",
@@ -69258,6 +69264,248 @@
           },
           "404": {
             "description": "Roster member or team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo": {
+      "put": {
+        "description": "Upload or replace a roster member's photo. Available to account contact managers or, when the AllowTeamAdminPlayerEdits setting is enabled, the team's administrators.",
+        "operationId": "uploadRosterMemberPhoto",
+        "summary": "Upload roster member photo",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Rosters"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "rosterMemberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "photo": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Roster member photo file"
+                  }
+                },
+                "required": [
+                  "photo"
+                ]
+              },
+              "encoding": {
+                "photo": {
+                  "contentType": "image/*"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Photo updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseContact"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Roster member not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a roster member's photo. Available to account contact photo managers or, when the AllowTeamAdminPlayerEdits setting is enabled, the team's administrators.",
+        "operationId": "deleteRosterMemberPhoto",
+        "summary": "Delete roster member photo",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Rosters"
+        ],
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "teamSeasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          },
+          {
+            "name": "rosterMemberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Photo deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseContact"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Roster member not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/draco-nodejs/backend/openapi.json
+++ b/draco-nodejs/backend/openapi.json
@@ -69484,6 +69484,16 @@
               }
             }
           },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Authentication required",
             "content": {

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -47356,6 +47356,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BaseContact"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
         "401":
           description: Authentication required
           content:

--- a/draco-nodejs/backend/openapi.yaml
+++ b/draco-nodejs/backend/openapi.yaml
@@ -5808,6 +5808,7 @@ components:
                   - ShowRosterCard
                   - EnableTeamEmail
                   - ShowUserInfoOnRosterPage
+                  - AllowTeamAdminPlayerEdits
                   - ShowContactInfo
                   - EditContactInfo
                   - EmailGameResultsToTeams
@@ -5879,6 +5880,7 @@ components:
                         - ShowRosterCard
                         - EnableTeamEmail
                         - ShowUserInfoOnRosterPage
+                        - AllowTeamAdminPlayerEdits
                         - ShowContactInfo
                         - EditContactInfo
                         - EmailGameResultsToTeams
@@ -5986,6 +5988,7 @@ components:
                 - ShowRosterCard
                 - EnableTeamEmail
                 - ShowUserInfoOnRosterPage
+                - AllowTeamAdminPlayerEdits
                 - ShowContactInfo
                 - EditContactInfo
                 - EmailGameResultsToTeams
@@ -6057,6 +6060,7 @@ components:
                       - ShowRosterCard
                       - EnableTeamEmail
                       - ShowUserInfoOnRosterPage
+                      - AllowTeamAdminPlayerEdits
                       - ShowContactInfo
                       - EditContactInfo
                       - EmailGameResultsToTeams
@@ -6167,6 +6171,7 @@ components:
         - ShowRosterCard
         - EnableTeamEmail
         - ShowUserInfoOnRosterPage
+        - AllowTeamAdminPlayerEdits
         - ShowContactInfo
         - EditContactInfo
         - EmailGameResultsToTeams
@@ -30114,6 +30119,7 @@ paths:
               - ShowRosterCard
               - EnableTeamEmail
               - ShowUserInfoOnRosterPage
+              - AllowTeamAdminPlayerEdits
               - ShowContactInfo
               - EditContactInfo
               - EmailGameResultsToTeams
@@ -47210,6 +47216,160 @@ paths:
                 $ref: "#/components/schemas/AuthorizationError"
         "404":
           description: Roster member or team not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+  /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo:
+    put:
+      description: Upload or replace a roster member's photo. Available to account
+        contact managers or, when the AllowTeamAdminPlayerEdits setting is
+        enabled, the team's administrators.
+      operationId: uploadRosterMemberPhoto
+      summary: Upload roster member photo
+      security:
+        - bearerAuth: []
+      tags:
+        - Rosters
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: teamSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: rosterMemberId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                photo:
+                  type: string
+                  format: binary
+                  description: Roster member photo file
+              required:
+                - photo
+            encoding:
+              photo:
+                contentType: image/*
+      responses:
+        "200":
+          description: Photo updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseContact"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Roster member not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
+    delete:
+      description: Delete a roster member's photo. Available to account contact photo
+        managers or, when the AllowTeamAdminPlayerEdits setting is enabled, the
+        team's administrators.
+      operationId: deleteRosterMemberPhoto
+      summary: Delete roster member photo
+      security:
+        - bearerAuth: []
+      tags:
+        - Rosters
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: teamSeasonId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+        - name: rosterMemberId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: number
+      responses:
+        "200":
+          description: Photo deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseContact"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationError"
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationError"
+        "404":
+          description: Roster member not found
           content:
             application/json:
               schema:

--- a/draco-nodejs/backend/src/middleware/__tests__/routeProtection.permissionOrTeamAdmin.test.ts
+++ b/draco-nodejs/backend/src/middleware/__tests__/routeProtection.permissionOrTeamAdmin.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { ServiceFactory } from '../../services/serviceFactory.js';
+import { partialMock } from '../../test-utils/partialMock.js';
+import { AuthorizationError } from '../../utils/customErrors.js';
+
+const PERMISSION = 'account.contacts.manage';
+const SETTING_KEY = 'AllowTeamAdminPlayerEdits';
+
+type RoleSvc = ReturnType<typeof ServiceFactory.getRoleService>;
+type SettingsSvc = ReturnType<typeof ServiceFactory.getAccountSettingsService>;
+type TeamSvc = ReturnType<typeof ServiceFactory.getTeamService>;
+type RoleCheck = Awaited<ReturnType<RoleSvc['hasRole']>>;
+type UserRoles = Awaited<ReturnType<RoleSvc['getUserRoles']>>;
+type SettingState = Awaited<ReturnType<SettingsSvc['getAccountSettings']>>[number];
+type TeamSeason = NonNullable<Awaited<ReturnType<TeamSvc['findTeamSeason']>>>;
+
+const buildRequest = (): Request =>
+  partialMock<Request>({
+    user: { id: 'user-1', username: 'tester' },
+    params: { accountId: '5', seasonId: '7', teamSeasonId: '9' },
+    body: {},
+    query: {},
+  });
+
+const settingState = (effectiveValue: boolean): SettingState =>
+  partialMock<SettingState>({
+    definition: partialMock<SettingState['definition']>({ key: SETTING_KEY }),
+    effectiveValue,
+  });
+
+const runMiddleware = async (
+  middleware: (req: Request, res: Response, next: NextFunction) => void,
+  req: Request,
+) => {
+  const next = vi.fn();
+  middleware(req, {} as Response, next);
+  await vi.waitFor(() => expect(next).toHaveBeenCalled());
+  return next;
+};
+
+describe('RouteProtection.requirePermissionOrTeamAdminWithSetting', () => {
+  const hasPermission = vi.fn<RoleSvc['hasPermission']>();
+  const hasRole = vi.fn<RoleSvc['hasRole']>();
+  const getUserRoles = vi.fn<RoleSvc['getUserRoles']>();
+  const getAccountSettings = vi.fn<SettingsSvc['getAccountSettings']>();
+
+  const buildProtection = async () => {
+    const { RouteProtection } = await import('../routeProtection.js');
+    return new RouteProtection();
+  };
+
+  beforeEach(() => {
+    hasPermission.mockReset();
+    hasRole.mockReset();
+    getUserRoles
+      .mockReset()
+      .mockResolvedValue(partialMock<UserRoles>({ globalRoles: [], contactRoles: [] }));
+    getAccountSettings.mockReset();
+
+    vi.spyOn(ServiceFactory, 'getRoleService').mockReturnValue(
+      partialMock<RoleSvc>({ hasPermission, hasRole, getUserRoles }),
+    );
+    vi.spyOn(ServiceFactory, 'getContactService').mockReturnValue(
+      partialMock<ReturnType<typeof ServiceFactory.getContactService>>({}),
+    );
+    vi.spyOn(ServiceFactory, 'getUserService').mockReturnValue(
+      partialMock<ReturnType<typeof ServiceFactory.getUserService>>({}),
+    );
+    vi.spyOn(ServiceFactory, 'getTeamService').mockReturnValue(
+      partialMock<TeamSvc>({
+        findTeamSeason: vi
+          .fn<TeamSvc['findTeamSeason']>()
+          .mockResolvedValue(partialMock<TeamSeason>({ id: '9' })),
+      }),
+    );
+    vi.spyOn(ServiceFactory, 'getAccountSettingsService').mockReturnValue(
+      partialMock<SettingsSvc>({ getAccountSettings }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows an account-permission holder and marks them as an account-level editor', async () => {
+    hasPermission.mockResolvedValue(true);
+    const protection = await buildProtection();
+    const middleware = protection.requirePermissionOrTeamAdminWithSetting(PERMISSION, SETTING_KEY);
+
+    const req = buildRequest();
+    const next = await runMiddleware(middleware, req);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.isAccountLevelEditor).toBe(true);
+    expect(hasRole).not.toHaveBeenCalled();
+    expect(getAccountSettings).not.toHaveBeenCalled();
+  });
+
+  it('allows a team admin when the setting is enabled and marks them as not an account-level editor', async () => {
+    hasPermission.mockResolvedValue(false);
+    hasRole.mockResolvedValue(partialMock<RoleCheck>({ hasRole: true }));
+    getAccountSettings.mockResolvedValue([settingState(true)]);
+    const protection = await buildProtection();
+    const middleware = protection.requirePermissionOrTeamAdminWithSetting(PERMISSION, SETTING_KEY);
+
+    const req = buildRequest();
+    const next = await runMiddleware(middleware, req);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.isAccountLevelEditor).toBe(false);
+  });
+
+  it('denies a team admin when the setting is disabled', async () => {
+    hasPermission.mockResolvedValue(false);
+    hasRole.mockResolvedValue(partialMock<RoleCheck>({ hasRole: true }));
+    getAccountSettings.mockResolvedValue([settingState(false)]);
+    const protection = await buildProtection();
+    const middleware = protection.requirePermissionOrTeamAdminWithSetting(PERMISSION, SETTING_KEY);
+
+    const req = buildRequest();
+    const next = await runMiddleware(middleware, req);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthorizationError);
+    expect(req.isAccountLevelEditor).toBeUndefined();
+  });
+
+  it('denies a user who is neither an account editor nor a team admin', async () => {
+    hasPermission.mockResolvedValue(false);
+    hasRole.mockResolvedValue(partialMock<RoleCheck>({ hasRole: false }));
+    const protection = await buildProtection();
+    const middleware = protection.requirePermissionOrTeamAdminWithSetting(PERMISSION, SETTING_KEY);
+
+    const req = buildRequest();
+    const next = await runMiddleware(middleware, req);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthorizationError);
+    expect(getAccountSettings).not.toHaveBeenCalled();
+  });
+});

--- a/draco-nodejs/backend/src/middleware/fileUpload.ts
+++ b/draco-nodejs/backend/src/middleware/fileUpload.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import multer from 'multer';
+import { ValidationError } from '../utils/customErrors.js';
 
 // Configure multer for file uploads
 const upload = multer({
@@ -13,10 +14,7 @@ const executePhotoUpload = (req: Request, res: Response, next: NextFunction): vo
   upload.single('photo')(req, res, (err: unknown) => {
     if (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      res.status(400).json({
-        success: false,
-        message: message,
-      });
+      next(new ValidationError(message));
       return;
     }
 
@@ -38,13 +36,13 @@ export const parseFormDataJSON = (req: Request, res: Response, next: NextFunctio
         try {
           req.body[field] = JSON.parse(req.body[field]);
         } catch (error) {
-          res.status(400).json({
-            success: false,
-            message:
+          next(
+            new ValidationError(
               error instanceof Error
                 ? error.message
                 : `Invalid ${field} format - must be valid JSON`,
-          });
+            ),
+          );
           return;
         }
       }
@@ -65,18 +63,12 @@ export const validatePhotoUpload = (req: Request, res: Response, next: NextFunct
   const maxSize = 5 * 1024 * 1024; // 5MB
 
   if (!allowedMimeTypes.includes(file.mimetype)) {
-    res.status(400).json({
-      error: 'Invalid file type',
-      details: `Allowed types: ${allowedMimeTypes.join(', ')}`,
-    });
+    next(new ValidationError(`Invalid file type. Allowed types: ${allowedMimeTypes.join(', ')}`));
     return;
   }
 
   if (file.size > maxSize) {
-    res.status(400).json({
-      error: 'File too large',
-      details: `Maximum file size is ${maxSize / (1024 * 1024)}MB`,
-    });
+    next(new ValidationError(`File too large. Maximum file size is ${maxSize / (1024 * 1024)}MB`));
     return;
   }
 

--- a/draco-nodejs/backend/src/middleware/routeProtection.ts
+++ b/draco-nodejs/backend/src/middleware/routeProtection.ts
@@ -240,7 +240,9 @@ export class RouteProtection {
 
       if (hasPermission) {
         req.isAccountLevelEditor = true;
-        req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+        if (!req.userRoles) {
+          req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+        }
         next();
         return;
       }
@@ -265,7 +267,9 @@ export class RouteProtection {
       }
 
       req.isAccountLevelEditor = false;
-      req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+      if (!req.userRoles) {
+        req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+      }
       next();
     });
   };

--- a/draco-nodejs/backend/src/middleware/routeProtection.ts
+++ b/draco-nodejs/backend/src/middleware/routeProtection.ts
@@ -16,20 +16,24 @@ import {
 import { ContactService } from '../services/contactService.js';
 import { UserService } from '../services/userService.js';
 import { ServiceFactory } from '../services/serviceFactory.js';
+import { AccountSettingsService } from '../services/accountSettingsService.js';
 import { TeamService } from '@/services/teamService.js';
 import { getStringParam } from '../utils/paramExtraction.js';
+import { AccountSettingKey } from '@draco/shared-schemas';
 
 export class RouteProtection {
   private roleService: IRoleMiddleware;
   private contactService: ContactService;
   private userService: UserService;
   private teamService: TeamService;
+  private accountSettingsService: AccountSettingsService;
 
   constructor() {
     this.roleService = ServiceFactory.getRoleService();
     this.contactService = ServiceFactory.getContactService();
     this.userService = ServiceFactory.getUserService();
     this.teamService = ServiceFactory.getTeamService();
+    this.accountSettingsService = ServiceFactory.getAccountSettingsService();
   }
 
   /**
@@ -201,6 +205,70 @@ export class RouteProtection {
       }
 
       throw new AuthorizationError("Permission 'account.polls.manage' or TeamAdmin role required");
+    });
+  };
+
+  /**
+   * Middleware allowing access when the user either holds the given account-level
+   * permission, or is a TeamAdmin for the team in context AND the named account
+   * setting is enabled. Sets `req.isAccountLevelEditor` so handlers can apply
+   * narrower field restrictions to the TeamAdmin path.
+   */
+  requirePermissionOrTeamAdminWithSetting = (
+    accountPermission: string,
+    settingKey: AccountSettingKey,
+  ) => {
+    return asyncHandler(async (req: Request, _res: Response, next: NextFunction) => {
+      if (!req.user?.id) {
+        throw new AuthenticationError('Authentication required');
+      }
+
+      const accountId = this.extractAccountId(req) || BigInt(0);
+      const seasonId = this.extractSeasonId(req);
+      const teamId = await this.getTeamSeasonId(accountId, seasonId, req);
+
+      const roleContext: RoleContextData = {
+        accountId,
+        teamId,
+        leagueId: this.extractLeagueId(req),
+        seasonId,
+      };
+
+      const hasPermission = await this.roleService.hasPermission(
+        req.user.id,
+        accountPermission,
+        roleContext,
+      );
+
+      if (hasPermission) {
+        req.isAccountLevelEditor = true;
+        req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+        next();
+        return;
+      }
+
+      const hasTeamAdminRole = await this.roleService.hasRole(
+        req.user.id,
+        ROLE_IDS[RoleNamesType.TEAM_ADMIN],
+        roleContext,
+      );
+
+      if (!hasTeamAdminRole.hasRole) {
+        throw new AuthorizationError(`Permission '${accountPermission}' required`);
+      }
+
+      const settings = await this.accountSettingsService.getAccountSettings(accountId);
+      const settingEnabled = settings.some(
+        (setting) => setting.definition.key === settingKey && Boolean(setting.effectiveValue),
+      );
+
+      if (!settingEnabled) {
+        throw new AuthorizationError('Editing is disabled for this account');
+      }
+
+      req.isAccountLevelEditor = false;
+      req.userRoles = await this.roleService.getUserRoles(req.user.id, accountId);
+      next();
     });
   };
 

--- a/draco-nodejs/backend/src/middleware/routeProtection.ts
+++ b/draco-nodejs/backend/src/middleware/routeProtection.ts
@@ -208,12 +208,6 @@ export class RouteProtection {
     });
   };
 
-  /**
-   * Middleware allowing access when the user either holds the given account-level
-   * permission, or is a TeamAdmin for the team in context AND the named account
-   * setting is enabled. Sets `req.isAccountLevelEditor` so handlers can apply
-   * narrower field restrictions to the TeamAdmin path.
-   */
   requirePermissionOrTeamAdminWithSetting = (
     accountPermission: string,
     settingKey: AccountSettingKey,
@@ -223,7 +217,11 @@ export class RouteProtection {
         throw new AuthenticationError('Authentication required');
       }
 
-      const accountId = this.extractAccountId(req) || BigInt(0);
+      const accountId = req.accountBoundary?.accountId ?? this.extractAccountId(req);
+      if (!accountId) {
+        throw new ValidationError('Account ID required');
+      }
+
       const seasonId = this.extractSeasonId(req);
       const teamId = await this.getTeamSeasonId(accountId, seasonId, req);
 

--- a/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
@@ -935,6 +935,219 @@ export const registerRostersEndpoints = ({ registry, schemaRefs, z }: RegisterCo
       },
     },
   });
+
+  // PUT /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo
+  registry.registerPath({
+    method: 'put',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo',
+    description:
+      "Upload or replace a roster member's photo. Available to account contact managers or, when the AllowTeamAdminPlayerEdits setting is enabled, the team's administrators.",
+    operationId: 'uploadRosterMemberPhoto',
+    summary: 'Upload roster member photo',
+    security: [{ bearerAuth: [] }],
+    tags: ['Rosters'],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'teamSeasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'rosterMemberId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+    ],
+    request: {
+      body: {
+        content: {
+          'multipart/form-data': {
+            schema: z.object({
+              photo: z.string().openapi({
+                type: 'string',
+                format: 'binary',
+                description: 'Roster member photo file',
+              }),
+            }),
+            encoding: {
+              photo: {
+                contentType: 'image/*',
+              },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Photo updated',
+        content: {
+          'application/json': {
+            schema: BaseContactSchemaRef,
+          },
+        },
+      },
+      400: {
+        description: 'Validation error',
+        content: {
+          'application/json': {
+            schema: ValidationErrorSchemaRef,
+          },
+        },
+      },
+      401: {
+        description: 'Authentication required',
+        content: {
+          'application/json': {
+            schema: AuthenticationErrorSchemaRef,
+          },
+        },
+      },
+      403: {
+        description: 'Access denied',
+        content: {
+          'application/json': {
+            schema: AuthorizationErrorSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Roster member not found',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
+          },
+        },
+      },
+      500: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
+
+  // DELETE /api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo
+  registry.registerPath({
+    method: 'delete',
+    path: '/api/accounts/{accountId}/seasons/{seasonId}/teams/{teamSeasonId}/roster/{rosterMemberId}/photo',
+    description:
+      "Delete a roster member's photo. Available to account contact photo managers or, when the AllowTeamAdminPlayerEdits setting is enabled, the team's administrators.",
+    operationId: 'deleteRosterMemberPhoto',
+    summary: 'Delete roster member photo',
+    security: [{ bearerAuth: [] }],
+    tags: ['Rosters'],
+    parameters: [
+      {
+        name: 'accountId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'seasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'teamSeasonId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+      {
+        name: 'rosterMemberId',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'number',
+        },
+      },
+    ],
+    request: {},
+    responses: {
+      200: {
+        description: 'Photo deleted',
+        content: {
+          'application/json': {
+            schema: BaseContactSchemaRef,
+          },
+        },
+      },
+      401: {
+        description: 'Authentication required',
+        content: {
+          'application/json': {
+            schema: AuthenticationErrorSchemaRef,
+          },
+        },
+      },
+      403: {
+        description: 'Access denied',
+        content: {
+          'application/json': {
+            schema: AuthorizationErrorSchemaRef,
+          },
+        },
+      },
+      404: {
+        description: 'Roster member not found',
+        content: {
+          'application/json': {
+            schema: NotFoundErrorSchemaRef,
+          },
+        },
+      },
+      500: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: InternalServerErrorSchemaRef,
+          },
+        },
+      },
+    },
+  });
 };
 
 export default registerRostersEndpoints;

--- a/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
+++ b/draco-nodejs/backend/src/openapi/paths/rosters/index.ts
@@ -1114,6 +1114,14 @@ export const registerRostersEndpoints = ({ registry, schemaRefs, z }: RegisterCo
           },
         },
       },
+      400: {
+        description: 'Validation error',
+        content: {
+          'application/json': {
+            schema: ValidationErrorSchemaRef,
+          },
+        },
+      },
       401: {
         description: 'Authentication required',
         content: {

--- a/draco-nodejs/backend/src/routes/team-roster.ts
+++ b/draco-nodejs/backend/src/routes/team-roster.ts
@@ -9,12 +9,14 @@ import {
   SignRosterMemberSchema,
   UpdateRosterMemberSchema,
 } from '@draco/shared-schemas';
-import { AuthorizationError, NotFoundError } from '../utils/customErrors.js';
+import { AuthorizationError, NotFoundError, ValidationError } from '../utils/customErrors.js';
+import { handlePhotoUploadMiddleware, validatePhotoUpload } from '../middleware/fileUpload.js';
 import prisma from '../lib/prisma.js';
 
 const router = Router({ mergeParams: true });
 const routeProtection = ServiceFactory.getRouteProtection();
 const rosterService = ServiceFactory.getRosterService();
+const contactService = ServiceFactory.getContactService();
 const accountSettingsService = ServiceFactory.getAccountSettingsService();
 const csvExportService = ServiceFactory.getCsvExportService();
 
@@ -190,7 +192,10 @@ router.put(
   '/:teamSeasonId/roster/:rosterMemberId',
   authenticateToken,
   routeProtection.enforceAccountBoundary(),
-  routeProtection.requireAccountAdmin(),
+  routeProtection.requirePermissionOrTeamAdminWithSetting(
+    'account.contacts.manage',
+    'AllowTeamAdminPlayerEdits',
+  ),
   asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const { accountId, seasonId, teamSeasonId, rosterMemberId } = extractBigIntParams(
       req.params,
@@ -202,6 +207,16 @@ router.put(
 
     const updateData = UpdateRosterMemberSchema.parse(req.body);
 
+    if (req.isAccountLevelEditor === false) {
+      const { playerNumber, submittedWaiver, player } = updateData;
+      if (submittedWaiver !== undefined || player !== undefined) {
+        throw new AuthorizationError('Team administrators may only edit the player number');
+      }
+      if (playerNumber === undefined) {
+        throw new ValidationError('No roster updates were provided');
+      }
+    }
+
     const updatedRosterMember = await rosterService.updateRosterMember(
       rosterMemberId,
       teamSeasonId,
@@ -211,6 +226,87 @@ router.put(
     );
 
     res.json(updatedRosterMember);
+  }),
+);
+
+/**
+ * PUT /api/accounts/:accountId/seasons/:seasonId/teams/:teamSeasonId/roster/:rosterMemberId/photo
+ * Upload or replace a roster member's photo (team-scoped)
+ */
+router.put(
+  '/:teamSeasonId/roster/:rosterMemberId/photo',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermissionOrTeamAdminWithSetting(
+    'account.contacts.manage',
+    'AllowTeamAdminPlayerEdits',
+  ),
+  handlePhotoUploadMiddleware,
+  validatePhotoUpload,
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId, rosterMemberId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'teamSeasonId',
+      'rosterMemberId',
+    );
+
+    if (!req.file) {
+      throw new ValidationError('No photo provided');
+    }
+
+    const contactId = await rosterService.getRosterMemberContactId(
+      rosterMemberId,
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+
+    await contactService.uploadContactPhoto(accountId, contactId, req.file);
+
+    const contact = await contactService.getContact(accountId, contactId);
+
+    res.json(contact);
+  }),
+);
+
+/**
+ * DELETE /api/accounts/:accountId/seasons/:seasonId/teams/:teamSeasonId/roster/:rosterMemberId/photo
+ * Delete a roster member's photo (team-scoped)
+ */
+router.delete(
+  '/:teamSeasonId/roster/:rosterMemberId/photo',
+  authenticateToken,
+  routeProtection.enforceAccountBoundary(),
+  routeProtection.requirePermissionOrTeamAdminWithSetting(
+    'account.contacts.photos.manage',
+    'AllowTeamAdminPlayerEdits',
+  ),
+  asyncHandler(async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    const { accountId, seasonId, teamSeasonId, rosterMemberId } = extractBigIntParams(
+      req.params,
+      'accountId',
+      'seasonId',
+      'teamSeasonId',
+      'rosterMemberId',
+    );
+
+    const contactId = await rosterService.getRosterMemberContactId(
+      rosterMemberId,
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+
+    await ServiceFactory.getStorageService().deleteContactPhoto(
+      accountId.toString(),
+      contactId.toString(),
+    );
+
+    const contact = await contactService.getContact(accountId, contactId);
+
+    res.json(contact);
   }),
 );
 

--- a/draco-nodejs/backend/src/routes/team-roster.ts
+++ b/draco-nodejs/backend/src/routes/team-roster.ts
@@ -306,7 +306,7 @@ router.delete(
 
     const contact = await contactService.getContact(accountId, contactId);
 
-    res.json(contact);
+    res.json({ ...contact, photoUrl: undefined });
   }),
 );
 

--- a/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
+++ b/draco-nodejs/backend/src/services/__tests__/rosterService.test.ts
@@ -396,3 +396,70 @@ describe('RosterService.releaseOrActivatePlayer substitute guard', () => {
     expect(rosterRepo.updateRosterSeasonEntry).not.toHaveBeenCalled();
   });
 });
+
+describe('RosterService.getRosterMemberContactId', () => {
+  let rosterRepo: RosterRepositoryStub;
+  let service: RosterService;
+
+  const rosterMemberId = 100n;
+  const teamSeasonId = 10n;
+  const seasonId = 20n;
+  const accountId = 30n;
+  const contactId = 42n;
+
+  beforeEach(() => {
+    rosterRepo = new RosterRepositoryStub();
+
+    vi.spyOn(ServiceFactory, 'getAccountsService').mockReturnValue(
+      {} as ReturnType<typeof ServiceFactory.getAccountsService>,
+    );
+    vi.spyOn(ServiceFactory, 'getDiscordIntegrationService').mockReturnValue(
+      partialMock<ReturnType<typeof ServiceFactory.getDiscordIntegrationService>>({}),
+    );
+
+    service = new RosterService(
+      rosterRepo,
+      partialMock<ITeamRepository>({}),
+      partialMock<IContactRepository>({}),
+      partialMock<ISeasonsRepository>({}),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the contact id for a roster member scoped to the team', async () => {
+    rosterRepo.findRosterMemberForAccount.mockResolvedValue(
+      partialMock<dbRosterMember>({
+        id: rosterMemberId,
+        roster: partialMock<dbRosterMember['roster']>({
+          contacts: partialMock<dbRosterMember['roster']['contacts']>({ id: contactId }),
+        }),
+      }),
+    );
+
+    const result = await service.getRosterMemberContactId(
+      rosterMemberId,
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+
+    expect(result).toBe(contactId);
+    expect(rosterRepo.findRosterMemberForAccount).toHaveBeenCalledWith(
+      rosterMemberId,
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+  });
+
+  it('throws NotFoundError when the roster member is not on the team', async () => {
+    rosterRepo.findRosterMemberForAccount.mockResolvedValue(null);
+
+    await expect(
+      service.getRosterMemberContactId(rosterMemberId, teamSeasonId, seasonId, accountId),
+    ).rejects.toThrow('Roster member not found');
+  });
+});

--- a/draco-nodejs/backend/src/services/rosterService.ts
+++ b/draco-nodejs/backend/src/services/rosterService.ts
@@ -596,6 +596,22 @@ export class RosterService {
     return newContact.id;
   }
 
+  async getRosterMemberContactId(
+    rosterMemberId: bigint,
+    teamSeasonId: bigint,
+    seasonId: bigint,
+    accountId: bigint,
+  ): Promise<bigint> {
+    const rosterMember = await this.getRosterMemberForAccount(
+      rosterMemberId,
+      teamSeasonId,
+      seasonId,
+      accountId,
+    );
+
+    return rosterMember.roster.contacts.id;
+  }
+
   private async getRosterMemberForAccount(
     rosterMemberId: bigint,
     teamSeasonId: bigint,

--- a/draco-nodejs/backend/src/types/requestContext.ts
+++ b/draco-nodejs/backend/src/types/requestContext.ts
@@ -35,6 +35,7 @@ declare global {
       frontendBaseUrl?: string;
       userRoles?: UserRolesType;
       accountBoundary?: AccountBoundaryContext;
+      isAccountLevelEditor?: boolean;
       accountId?: string;
       account?: AccountContext;
       hasAccountRoleAccess?: boolean;

--- a/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
+++ b/draco-nodejs/frontend-next/app/account/[accountId]/seasons/[seasonId]/teams/[teamSeasonId]/TeamPage.tsx
@@ -215,6 +215,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
     hasRoleInTeam('TeamPhotoAdmin', teamSeasonId);
 
   const canEditPlayerPhotos = hasPermission('account.contacts.manage', { accountId });
+  const isTeamAdminForTeam = hasRoleInTeam('TeamAdmin', teamSeasonId);
 
   const canViewRosterDetails =
     hasRole('Administrator') ||
@@ -845,6 +846,7 @@ const TeamPage: React.FC<TeamPageProps> = ({ accountId, seasonId, teamSeasonId }
                 teamSeasonId={teamSeasonId}
                 canViewSensitiveDetails={canViewRosterDetails}
                 canEditPhotos={canEditPlayerPhotos}
+                isTeamAdmin={isTeamAdminForTeam}
               />
             </Box>
 

--- a/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
+++ b/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { GolfCourseWithTeesType, GolfCourseTeeType } from '@draco/shared-schemas';
 import CourseDetailView from '../CourseDetailView';
@@ -209,51 +209,43 @@ describe('CourseDetailView', () => {
   });
 
   describe('reset behavior', () => {
-    it('enables reset button after making changes', async () => {
-      const user = userEvent.setup();
+    it('enables reset button after making changes', () => {
       const course = createMockCourse();
 
       render(<CourseDetailView course={course} editMode={true} onSave={vi.fn()} />);
 
       const courseNameInput = screen.getByDisplayValue('Test Golf Course');
-      await user.clear(courseNameInput);
-      await user.type(courseNameInput, 'Modified');
+      fireEvent.change(courseNameInput, { target: { value: 'Modified' } });
 
       expect(screen.getByRole('button', { name: 'Reset Changes' })).not.toBeDisabled();
     });
 
-    it('resets form to original values when reset button is clicked', async () => {
-      const user = userEvent.setup();
+    it('resets form to original values when reset button is clicked', () => {
       const course = createMockCourse();
 
       render(<CourseDetailView course={course} editMode={true} onSave={vi.fn()} />);
 
       const courseNameInput = screen.getByDisplayValue('Test Golf Course');
-      await user.clear(courseNameInput);
-      await user.type(courseNameInput, 'Temporary Name');
+      fireEvent.change(courseNameInput, { target: { value: 'Temporary Name' } });
 
-      await waitFor(() =>
-        expect(screen.getByRole('button', { name: 'Reset Changes' })).not.toBeDisabled(),
-      );
-      await user.click(screen.getByRole('button', { name: 'Reset Changes' }));
+      const resetButton = screen.getByRole('button', { name: 'Reset Changes' });
+      expect(resetButton).not.toBeDisabled();
+      fireEvent.click(resetButton);
 
       expect(screen.getByDisplayValue('Test Golf Course')).toBeInTheDocument();
     });
 
-    it('disables reset button after resetting', async () => {
-      const user = userEvent.setup();
+    it('disables reset button after resetting', () => {
       const course = createMockCourse();
 
       render(<CourseDetailView course={course} editMode={true} onSave={vi.fn()} />);
 
       const courseNameInput = screen.getByDisplayValue('Test Golf Course');
-      await user.clear(courseNameInput);
-      await user.type(courseNameInput, 'Changed');
+      fireEvent.change(courseNameInput, { target: { value: 'Changed' } });
 
-      await waitFor(() =>
-        expect(screen.getByRole('button', { name: 'Reset Changes' })).not.toBeDisabled(),
-      );
-      await user.click(screen.getByRole('button', { name: 'Reset Changes' }));
+      const resetButton = screen.getByRole('button', { name: 'Reset Changes' });
+      expect(resetButton).not.toBeDisabled();
+      fireEvent.click(resetButton);
 
       expect(screen.getByRole('button', { name: 'Reset Changes' })).toBeDisabled();
     });

--- a/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
+++ b/draco-nodejs/frontend-next/components/golf/courses/__tests__/CourseDetailView.test.tsx
@@ -232,6 +232,9 @@ describe('CourseDetailView', () => {
       await user.clear(courseNameInput);
       await user.type(courseNameInput, 'Temporary Name');
 
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Reset Changes' })).not.toBeDisabled(),
+      );
       await user.click(screen.getByRole('button', { name: 'Reset Changes' }));
 
       expect(screen.getByDisplayValue('Test Golf Course')).toBeInTheDocument();
@@ -247,6 +250,9 @@ describe('CourseDetailView', () => {
       await user.clear(courseNameInput);
       await user.type(courseNameInput, 'Changed');
 
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Reset Changes' })).not.toBeDisabled(),
+      );
       await user.click(screen.getByRole('button', { name: 'Reset Changes' }));
 
       expect(screen.getByRole('button', { name: 'Reset Changes' })).toBeDisabled();

--- a/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
+++ b/draco-nodejs/frontend-next/components/roster/TeamRosterWidget.tsx
@@ -13,10 +13,16 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
 import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
 import UserAvatar from '@/components/users/UserAvatar';
 import ContactPhotoUploadDialog from '@/components/users/ContactPhotoUploadDialog';
 import { useRosterDataManager } from '@/hooks/useRosterDataManager';
+import { useRosterPhoto } from '@/hooks/useRosterPhoto';
 import { useAccountSettings } from '@/hooks/useAccountSettings';
 import { getContactDisplayName } from '@/utils/contactUtils';
 import {
@@ -31,16 +37,19 @@ import {
   getPublicTeamRosterMembers,
   getTeamRosterMembers as apiGetTeamRosterMembers,
   listTeamManagers as apiListTeamManagers,
+  updateRosterMember as apiUpdateRosterMember,
 } from '@draco/shared-api-client';
 import WidgetShell from '@/components/ui/WidgetShell';
-import type {
-  AccountSettingKey,
-  BaseContactType,
-  ContactType,
-  PublicRosterMemberType,
-  PublicTeamRosterResponseType,
-  TeamManagerType,
-  TeamRosterMembersType,
+import {
+  UpdateRosterMemberSchema,
+  type AccountSettingKey,
+  type BaseContactType,
+  type ContactType,
+  type PublicRosterMemberType,
+  type PublicTeamRosterResponseType,
+  type RosterMemberType,
+  type TeamManagerType,
+  type TeamRosterMembersType,
 } from '@draco/shared-schemas';
 import PhotoDeleteDialog from '@/components/users/PhotoDeleteDialog';
 
@@ -50,6 +59,7 @@ interface TeamRosterWidgetProps {
   teamSeasonId: string;
   canViewSensitiveDetails?: boolean;
   canEditPhotos?: boolean;
+  isTeamAdmin?: boolean;
 }
 
 const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
@@ -58,6 +68,7 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
   teamSeasonId,
   canViewSensitiveDetails = false,
   canEditPhotos = false,
+  isTeamAdmin = false,
 }) => {
   const { setError: setRosterError } = useRosterDataManager({
     accountId,
@@ -65,6 +76,11 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
     teamSeasonId,
   });
   const { settings: accountSettings } = useAccountSettings(accountId);
+  const {
+    uploadPhoto,
+    deletePhoto,
+    loading: photoLoading,
+  } = useRosterPhoto(accountId, seasonId, teamSeasonId);
   const apiClient = useApiClient();
   const { token } = useAuth();
   const pathname = usePathname();
@@ -79,13 +95,17 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
   const playerLinkLabel = 'Team Roster';
   const isAuthenticated = Boolean(token);
   const hasPrivateAccess = isAuthenticated && canViewSensitiveDetails;
-  const allowPhotoEdit = Boolean(canEditPhotos);
   const [publicRoster, setPublicRoster] = React.useState<PublicTeamRosterResponseType | null>(null);
   const [publicLoading, setPublicLoading] = React.useState(false);
   const [publicError, setPublicError] = React.useState<string | null>(null);
   const [photoDialogOpen, setPhotoDialogOpen] = React.useState(false);
   const [selectedContact, setSelectedContact] = React.useState<BaseContactType | null>(null);
+  const [selectedRosterMemberId, setSelectedRosterMemberId] = React.useState<string | null>(null);
   const [deleteContactId, setDeleteContactId] = React.useState<string | null>(null);
+  const [editingNumberId, setEditingNumberId] = React.useState<string | null>(null);
+  const [numberDraft, setNumberDraft] = React.useState('');
+  const [savingNumber, setSavingNumber] = React.useState(false);
+  const [numberError, setNumberError] = React.useState<string | null>(null);
   const [privateRosterData, setPrivateRosterData] = React.useState<TeamRosterMembersType | null>(
     null,
   );
@@ -211,6 +231,11 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
   const showGamesPlayed = getSettingValue('TrackGamesPlayed');
   const canShowContactInfo = canViewSensitiveDetails && showContactInfoOnRoster;
 
+  const allowTeamAdminEdits = getSettingValue('AllowTeamAdminPlayerEdits');
+  const canManagePlayers = Boolean(canEditPhotos) || (Boolean(isTeamAdmin) && allowTeamAdminEdits);
+  const allowPhotoEdit = canManagePlayers;
+  const canEditNumber = canManagePlayers;
+
   const effectiveRosterData = hasPrivateAccess ? privateRosterData : null;
   const effectiveLoading = hasPrivateAccess ? privateLoading : publicLoading;
   const effectiveError = hasPrivateAccess ? privateError : publicError;
@@ -254,17 +279,19 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
   const managers = hasPrivateAccess ? privateManagers : [];
   const managerIds = new Set(managers.map((manager) => manager.contact.id));
 
-  const openPhotoDialog = (contact: BaseContactType) => {
+  const openPhotoDialog = (member: RosterMemberType) => {
     if (!allowPhotoEdit) {
       return;
     }
-    setSelectedContact(contact);
+    setSelectedContact(member.player.contact);
+    setSelectedRosterMemberId(member.id);
     setPhotoDialogOpen(true);
   };
 
   const closePhotoDialog = () => {
     setPhotoDialogOpen(false);
     setSelectedContact(null);
+    setSelectedRosterMemberId(null);
   };
 
   const handlePhotoUpdated = (updatedContact: ContactType) => {
@@ -295,16 +322,18 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
     closePhotoDialog();
   };
 
-  const openDeletePhotoDialog = (contact: BaseContactType) => {
+  const openDeletePhotoDialog = (member: RosterMemberType) => {
     if (!allowPhotoEdit) {
       return;
     }
-    setSelectedContact(contact);
-    setDeleteContactId(contact.id);
+    setSelectedContact(member.player.contact);
+    setSelectedRosterMemberId(member.id);
+    setDeleteContactId(member.player.contact.id);
   };
 
   const closeDeletePhotoDialog = () => {
     setDeleteContactId(null);
+    setSelectedRosterMemberId(null);
   };
 
   const handlePhotoDeleted = () => {
@@ -338,6 +367,152 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
     closeDeletePhotoDialog();
   };
 
+  const startEditNumber = (member: RosterMemberType) => {
+    if (!canEditNumber) {
+      return;
+    }
+    setEditingNumberId(member.id);
+    setNumberDraft(member.playerNumber ?? '');
+    setNumberError(null);
+  };
+
+  const cancelEditNumber = () => {
+    setEditingNumberId(null);
+    setNumberDraft('');
+    setNumberError(null);
+    setSavingNumber(false);
+  };
+
+  const saveNumber = async (member: RosterMemberType) => {
+    const parsed = UpdateRosterMemberSchema.shape.playerNumber.safeParse(numberDraft);
+    if (!parsed.success) {
+      setNumberError(parsed.error.issues[0]?.message ?? 'Invalid player number');
+      return;
+    }
+
+    setSavingNumber(true);
+    setNumberError(null);
+
+    try {
+      const result = await apiUpdateRosterMember({
+        client: apiClient,
+        path: { accountId, seasonId, teamSeasonId, rosterMemberId: member.id },
+        body: { playerNumber: parsed.data },
+        throwOnError: false,
+      });
+
+      const updatedMember = unwrapApiResult(result, 'Failed to update number');
+      const updatedNumber = updatedMember.playerNumber;
+
+      setPrivateRosterData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          rosterMembers: prev.rosterMembers.map((rosterMember) =>
+            rosterMember.id === member.id
+              ? { ...rosterMember, playerNumber: updatedNumber }
+              : rosterMember,
+          ),
+        };
+      });
+
+      setEditingNumberId(null);
+      setNumberDraft('');
+    } catch (err) {
+      setNumberError(err instanceof Error ? err.message : 'Failed to update number');
+    } finally {
+      setSavingNumber(false);
+    }
+  };
+
+  const renderNumberCell = (member: RosterMemberType) => {
+    if (editingNumberId === member.id) {
+      return (
+        <TableCell>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <TextField
+              value={numberDraft}
+              onChange={(event) =>
+                setNumberDraft(event.target.value.replace(/\D/g, '').slice(0, 2))
+              }
+              size="small"
+              autoFocus
+              error={Boolean(numberError)}
+              helperText={numberError ?? undefined}
+              disabled={savingNumber}
+              slotProps={{
+                htmlInput: { maxLength: 2, inputMode: 'numeric', 'aria-label': 'Player number' },
+              }}
+              sx={{ width: 88 }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void saveNumber(member);
+                } else if (event.key === 'Escape') {
+                  event.preventDefault();
+                  cancelEditNumber();
+                }
+              }}
+            />
+            <IconButton
+              size="small"
+              color="primary"
+              aria-label="Save player number"
+              disabled={savingNumber}
+              onClick={() => void saveNumber(member)}
+            >
+              <CheckIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              aria-label="Cancel editing player number"
+              disabled={savingNumber}
+              onClick={cancelEditNumber}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </TableCell>
+      );
+    }
+
+    if (!canEditNumber) {
+      return <TableCell>{member.playerNumber || '-'}</TableCell>;
+    }
+
+    return (
+      <TableCell>
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-label="Edit player number"
+          onClick={() => startEditNumber(member)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              startEditNumber(member);
+            }
+          }}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+            cursor: 'pointer',
+            borderRadius: 1,
+            px: 0.5,
+            '&:hover .edit-number-icon': { opacity: 1 },
+          }}
+        >
+          {member.playerNumber || '-'}
+          <EditIcon
+            className="edit-number-icon"
+            sx={{ opacity: 0, fontSize: 14, color: 'text.secondary' }}
+          />
+        </Box>
+      </TableCell>
+    );
+  };
+
   const renderPrivateTable = () => (
     <TableContainer sx={{ width: 'fit-content', maxWidth: '100%' }}>
       <Table size="small" sx={{ width: 'auto' }}>
@@ -368,21 +543,19 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
 
             return (
               <TableRow key={member.id} hover>
-                <TableCell>{member.playerNumber || '-'}</TableCell>
+                {renderNumberCell(member)}
                 <TableCell>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <UserAvatar
                       user={user}
                       size={32}
-                      onClick={
-                        allowPhotoEdit ? () => openPhotoDialog(member.player.contact) : undefined
-                      }
+                      onClick={allowPhotoEdit ? () => openPhotoDialog(member) : undefined}
                       showHoverEffects={allowPhotoEdit}
                       enablePhotoActions={allowPhotoEdit}
                       onPhotoDelete={
                         allowPhotoEdit
                           ? async () => {
-                              openDeletePhotoDialog(member.player.contact);
+                              openDeletePhotoDialog(member);
                             }
                           : undefined
                       }
@@ -580,7 +753,7 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
           {renderContent()}
         </Box>
       </WidgetShell>
-      {photoDialogOpen && selectedContact ? (
+      {photoDialogOpen && selectedContact && selectedRosterMemberId ? (
         <ContactPhotoUploadDialog
           open={photoDialogOpen}
           accountId={accountId}
@@ -589,9 +762,11 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
           onClose={closePhotoDialog}
           onPhotoUpdated={handlePhotoUpdated}
           onError={setRosterError}
+          onUploadPhoto={(file) => uploadPhoto(selectedRosterMemberId, file)}
+          uploading={photoLoading}
         />
       ) : null}
-      {deleteContactId ? (
+      {deleteContactId && selectedRosterMemberId ? (
         <PhotoDeleteDialog
           open
           contactId={deleteContactId}
@@ -599,6 +774,8 @@ const TeamRosterWidget: React.FC<TeamRosterWidgetProps> = ({
           onClose={closeDeletePhotoDialog}
           onSuccess={handlePhotoDeleted}
           accountId={accountId}
+          onDeletePhoto={() => deletePhoto(selectedRosterMemberId)}
+          deleting={photoLoading}
         />
       ) : null}
     </>

--- a/draco-nodejs/frontend-next/components/roster/__tests__/TeamRosterWidget.numberEdit.test.tsx
+++ b/draco-nodejs/frontend-next/components/roster/__tests__/TeamRosterWidget.numberEdit.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import TeamRosterWidget from '../TeamRosterWidget';
+import { dracoTheme } from '../../../theme';
+import type { TeamRosterMembersType } from '@draco/shared-schemas';
+
+const mockUpdateRosterMember = vi.fn();
+const mockGetTeamRosterMembers = vi.fn();
+const mockListTeamManagers = vi.fn();
+const mockGetPublicTeamRosterMembers = vi.fn();
+
+vi.mock('@draco/shared-api-client', () => ({
+  updateRosterMember: (...args: unknown[]) => mockUpdateRosterMember(...args),
+  getTeamRosterMembers: (...args: unknown[]) => mockGetTeamRosterMembers(...args),
+  listTeamManagers: (...args: unknown[]) => mockListTeamManagers(...args),
+  getPublicTeamRosterMembers: (...args: unknown[]) => mockGetPublicTeamRosterMembers(...args),
+}));
+
+vi.mock('@/hooks/useApiClient', () => {
+  const client = {};
+  return { useApiClient: () => client };
+});
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('@/hooks/useRosterDataManager', () => ({
+  useRosterDataManager: () => ({ setError: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useRosterPhoto', () => ({
+  useRosterPhoto: () => ({ uploadPhoto: vi.fn(), deletePhoto: vi.fn(), loading: false }),
+}));
+
+vi.mock('@/hooks/useAccountSettings', () => ({
+  useAccountSettings: () => ({
+    settings: [
+      { definition: { key: 'AllowTeamAdminPlayerEdits' }, effectiveValue: true },
+      { definition: { key: 'TrackGamesPlayed' }, effectiveValue: false },
+    ],
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/account/1/seasons/2/teams/3',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/users/UserAvatar', () => ({
+  default: () => <div data-testid="user-avatar" />,
+}));
+
+const buildRoster = (playerNumber: string): TeamRosterMembersType =>
+  ({
+    teamSeason: { id: '3', name: 'Test Team' },
+    rosterMembers: [
+      {
+        id: '100',
+        playerNumber,
+        inactive: false,
+        dateAdded: null,
+        player: {
+          id: '200',
+          submittedDriversLicense: false,
+          firstYear: 2020,
+          contact: { id: '300', firstName: 'Jane', lastName: 'Doe' },
+        },
+      },
+    ],
+  }) as unknown as TeamRosterMembersType;
+
+const renderWidget = () =>
+  render(
+    <ThemeProvider theme={dracoTheme}>
+      <TeamRosterWidget
+        accountId="1"
+        seasonId="2"
+        teamSeasonId="3"
+        canViewSensitiveDetails
+        isTeamAdmin
+      />
+    </ThemeProvider>,
+  );
+
+describe('TeamRosterWidget inline player-number editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTeamRosterMembers.mockResolvedValue({ data: buildRoster('7') });
+    mockListTeamManagers.mockResolvedValue({ data: [] });
+  });
+
+  const enterEditMode = async (user: ReturnType<typeof userEvent.setup>) => {
+    const editTrigger = await screen.findByRole('button', { name: 'Edit player number' });
+    await user.click(editTrigger);
+    return screen.findByRole('textbox', { name: 'Player number' });
+  };
+
+  it('strips non-digit characters from the input so only numbers can be entered', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    const input = (await enterEditMode(user)) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'a1b2c');
+
+    expect(input.value).toBe('12');
+  });
+
+  it('caps the entered number at two digits', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    const input = (await enterEditMode(user)) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, '12345');
+
+    expect(input.value).toBe('12');
+  });
+
+  it('saves a valid number and updates only after the server responds (no optimistic update)', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate: (value: { data: unknown }) => void = () => {};
+    mockUpdateRosterMember.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+
+    renderWidget();
+
+    const input = await enterEditMode(user);
+    await user.clear(input);
+    await user.type(input, '23');
+    await user.click(screen.getByRole('button', { name: 'Save player number' }));
+
+    expect(mockUpdateRosterMember).toHaveBeenCalledTimes(1);
+    expect(mockUpdateRosterMember.mock.calls[0][0]).toMatchObject({
+      path: { accountId: '1', seasonId: '2', teamSeasonId: '3', rosterMemberId: '100' },
+      body: { playerNumber: '23' },
+    });
+
+    // Still in edit mode with no optimistic value applied while the request is pending.
+    expect(screen.getByRole('textbox', { name: 'Player number' })).toBeInTheDocument();
+
+    resolveUpdate({ data: { ...buildRoster('23').rosterMembers[0] } });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox', { name: 'Player number' })).not.toBeInTheDocument();
+    });
+    const editTrigger = await screen.findByRole('button', { name: 'Edit player number' });
+    expect(within(editTrigger).getByText('23')).toBeInTheDocument();
+  });
+
+  it('cancels editing and restores the original number without calling the API', async () => {
+    const user = userEvent.setup();
+    renderWidget();
+
+    const input = await enterEditMode(user);
+    await user.clear(input);
+    await user.type(input, '12');
+    await user.click(screen.getByRole('button', { name: 'Cancel editing player number' }));
+
+    const editTrigger = await screen.findByRole('button', { name: 'Edit player number' });
+    expect(within(editTrigger).getByText('7')).toBeInTheDocument();
+    expect(mockUpdateRosterMember).not.toHaveBeenCalled();
+  });
+});

--- a/draco-nodejs/frontend-next/components/roster/__tests__/TeamRosterWidget.numberEdit.test.tsx
+++ b/draco-nodejs/frontend-next/components/roster/__tests__/TeamRosterWidget.numberEdit.test.tsx
@@ -59,24 +59,23 @@ vi.mock('@/components/users/UserAvatar', () => ({
   default: () => <div data-testid="user-avatar" />,
 }));
 
-const buildRoster = (playerNumber: string): TeamRosterMembersType =>
-  ({
-    teamSeason: { id: '3', name: 'Test Team' },
-    rosterMembers: [
-      {
-        id: '100',
-        playerNumber,
-        inactive: false,
-        dateAdded: null,
-        player: {
-          id: '200',
-          submittedDriversLicense: false,
-          firstYear: 2020,
-          contact: { id: '300', firstName: 'Jane', lastName: 'Doe' },
-        },
+const buildRoster = (playerNumber: string): TeamRosterMembersType => ({
+  teamSeason: { id: '3', name: 'Test Team' },
+  rosterMembers: [
+    {
+      id: '100',
+      playerNumber,
+      inactive: false,
+      dateAdded: null,
+      player: {
+        id: '200',
+        submittedDriversLicense: false,
+        firstYear: 2020,
+        contact: { id: '300', firstName: 'Jane', lastName: 'Doe' },
       },
-    ],
-  }) as unknown as TeamRosterMembersType;
+    },
+  ],
+});
 
 const renderWidget = () =>
   render(

--- a/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
@@ -106,16 +106,22 @@ const ContactPhotoUploadDialog: React.FC<ContactPhotoUploadDialogProps> = ({
       return;
     }
 
-    const result = onUploadPhoto
-      ? await onUploadPhoto(selectedFile)
-      : await uploadContactPhoto(contact, selectedFile);
-    if (result.success && result.contact) {
-      handlePhotoUpdated(result.contact);
-      return;
+    try {
+      const result = onUploadPhoto
+        ? await onUploadPhoto(selectedFile)
+        : await uploadContactPhoto(contact, selectedFile);
+      if (result.success && result.contact) {
+        handlePhotoUpdated(result.contact);
+        return;
+      }
+      const failure = result.error || 'Failed to update contact photo';
+      showNotification(failure, 'error');
+      onError?.(failure);
+    } catch (err) {
+      const failure = err instanceof Error ? err.message : 'Failed to update contact photo';
+      showNotification(failure, 'error');
+      onError?.(failure);
     }
-    const failure = result.error || 'Failed to update contact photo';
-    showNotification(failure, 'error');
-    onError?.(failure);
   };
 
   if (!contact) {

--- a/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
@@ -27,6 +27,10 @@ interface ContactPhotoUploadDialogProps {
   onClose: () => void;
   onPhotoUpdated?: (contact: ContactType) => void;
   onError?: (message: string) => void;
+  onUploadPhoto?: (
+    file: File,
+  ) => Promise<{ success: boolean; contact?: ContactType; error?: string }>;
+  uploading?: boolean;
 }
 
 const ContactPhotoUploadDialog: React.FC<ContactPhotoUploadDialogProps> = ({
@@ -37,13 +41,20 @@ const ContactPhotoUploadDialog: React.FC<ContactPhotoUploadDialogProps> = ({
   onClose,
   onPhotoUpdated,
   onError,
+  onUploadPhoto,
+  uploading = false,
 }) => {
   const avatarRef = useRef<EditableContactAvatarHandle | null>(null);
   const photoSize = getPhotoSize();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const { notification, showNotification, hideNotification } = useNotifications();
-  const { uploadContactPhoto, loading, clearError } = useContactPhotoUpload(accountId);
+  const {
+    uploadContactPhoto,
+    loading: internalLoading,
+    clearError,
+  } = useContactPhotoUpload(accountId);
+  const loading = onUploadPhoto ? uploading : internalLoading;
 
   useEffect(() => {
     return () => {
@@ -95,7 +106,9 @@ const ContactPhotoUploadDialog: React.FC<ContactPhotoUploadDialogProps> = ({
       return;
     }
 
-    const result = await uploadContactPhoto(contact, selectedFile);
+    const result = onUploadPhoto
+      ? await onUploadPhoto(selectedFile)
+      : await uploadContactPhoto(contact, selectedFile);
     if (result.success && result.contact) {
       handlePhotoUpdated(result.contact);
       return;

--- a/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/ContactPhotoUploadDialog.tsx
@@ -19,7 +19,7 @@ import { getPhotoSize } from '@/config/contacts';
 import NotificationSnackbar from '../common/NotificationSnackbar';
 import { useNotifications } from '../../hooks/useNotifications';
 
-interface ContactPhotoUploadDialogProps {
+interface ContactPhotoUploadDialogBaseProps {
   open: boolean;
   accountId: string;
   contact: BaseContactType | null;
@@ -27,11 +27,19 @@ interface ContactPhotoUploadDialogProps {
   onClose: () => void;
   onPhotoUpdated?: (contact: ContactType) => void;
   onError?: (message: string) => void;
-  onUploadPhoto?: (
-    file: File,
-  ) => Promise<{ success: boolean; contact?: ContactType; error?: string }>;
-  uploading?: boolean;
 }
+
+type ContactPhotoUploadOverrideProps =
+  | { onUploadPhoto?: undefined; uploading?: undefined }
+  | {
+      onUploadPhoto: (
+        file: File,
+      ) => Promise<{ success: boolean; contact?: ContactType; error?: string }>;
+      uploading: boolean;
+    };
+
+type ContactPhotoUploadDialogProps = ContactPhotoUploadDialogBaseProps &
+  ContactPhotoUploadOverrideProps;
 
 const ContactPhotoUploadDialog: React.FC<ContactPhotoUploadDialogProps> = ({
   open,

--- a/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
@@ -45,12 +45,16 @@ const PhotoDeleteDialog: React.FC<PhotoDeleteDialogProps> = ({
     setError(null);
 
     if (onDeletePhoto) {
-      const overrideResult = await onDeletePhoto();
-      if (overrideResult.success) {
-        onSuccess?.({ message: 'Photo deleted successfully', contactId });
-        onClose();
-      } else {
-        setError(overrideResult.error || 'Failed to delete photo');
+      try {
+        const overrideResult = await onDeletePhoto();
+        if (overrideResult.success) {
+          onSuccess?.({ message: 'Photo deleted successfully', contactId });
+          onClose();
+        } else {
+          setError(overrideResult.error || 'Failed to delete photo');
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete photo');
       }
       return;
     }

--- a/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
@@ -15,6 +15,8 @@ interface PhotoDeleteDialogProps {
   onClose: () => void;
   onSuccess?: (result: { message: string; contactId: string }) => void;
   accountId: string;
+  onDeletePhoto?: () => Promise<{ success: boolean; error?: string }>;
+  deleting?: boolean;
 }
 
 /**
@@ -28,9 +30,12 @@ const PhotoDeleteDialog: React.FC<PhotoDeleteDialogProps> = ({
   onClose,
   onSuccess,
   accountId,
+  onDeletePhoto,
+  deleting = false,
 }) => {
   const [error, setError] = useState<string | null>(null);
-  const { deletePhoto, loading } = usePhotoOperations(accountId);
+  const { deletePhoto, loading: internalLoading } = usePhotoOperations(accountId);
+  const loading = onDeletePhoto ? deleting : internalLoading;
 
   // Handle photo deletion with internal error handling
   const handleDeletePhoto = async () => {
@@ -38,6 +43,17 @@ const PhotoDeleteDialog: React.FC<PhotoDeleteDialogProps> = ({
 
     // Clear any previous errors
     setError(null);
+
+    if (onDeletePhoto) {
+      const overrideResult = await onDeletePhoto();
+      if (overrideResult.success) {
+        onSuccess?.({ message: 'Photo deleted successfully', contactId });
+        onClose();
+      } else {
+        setError(overrideResult.error || 'Failed to delete photo');
+      }
+      return;
+    }
 
     const result = await deletePhoto(contactId);
 

--- a/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
+++ b/draco-nodejs/frontend-next/components/users/PhotoDeleteDialog.tsx
@@ -8,16 +8,20 @@ import UserAvatar from './UserAvatar';
 import type { BaseContactType } from '@draco/shared-schemas';
 import ConfirmDeleteDialog from '../social/ConfirmDeleteDialog';
 
-interface PhotoDeleteDialogProps {
+interface PhotoDeleteDialogBaseProps {
   open: boolean;
   contactId: string | null;
   contact?: Pick<BaseContactType, 'id' | 'firstName' | 'lastName' | 'photoUrl'> | null;
   onClose: () => void;
   onSuccess?: (result: { message: string; contactId: string }) => void;
   accountId: string;
-  onDeletePhoto?: () => Promise<{ success: boolean; error?: string }>;
-  deleting?: boolean;
 }
+
+type PhotoDeleteOverrideProps =
+  | { onDeletePhoto?: undefined; deleting?: undefined }
+  | { onDeletePhoto: () => Promise<{ success: boolean; error?: string }>; deleting: boolean };
+
+type PhotoDeleteDialogProps = PhotoDeleteDialogBaseProps & PhotoDeleteOverrideProps;
 
 /**
  * PhotoDeleteDialog Component

--- a/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
+++ b/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import type { ContactType } from '@draco/shared-schemas';
+import {
+  uploadRosterMemberPhoto as apiUploadRosterMemberPhoto,
+  deleteRosterMemberPhoto as apiDeleteRosterMemberPhoto,
+} from '@draco/shared-api-client';
+import { formDataBodySerializer } from '@draco/shared-api-client/generated/client';
+import { addCacheBuster, validateContactPhotoFile } from '../config/contacts';
+import { unwrapApiResult } from '../utils/apiResult';
+import { useApiClient } from './useApiClient';
+
+export interface RosterPhotoResult {
+  success: boolean;
+  contact?: ContactType;
+  error?: string;
+}
+
+interface ApiContact {
+  id: string;
+  firstName: string;
+  lastName: string;
+  middleName?: string;
+  email?: string;
+  userId?: string;
+  loginEmail?: string;
+  photoUrl?: string;
+}
+
+const toContact = (contact: ApiContact): ContactType => ({
+  id: contact.id,
+  firstName: contact.firstName,
+  lastName: contact.lastName,
+  middleName: contact.middleName,
+  email: contact.email,
+  userId: contact.userId,
+  loginEmail: contact.loginEmail,
+  photoUrl: contact.photoUrl ? addCacheBuster(contact.photoUrl, Date.now()) : undefined,
+});
+
+/**
+ * Hook for uploading and deleting a roster member's photo via the team-scoped
+ * roster endpoints. Used from the team roster page so account admins and
+ * (when enabled) team admins share a single authorization path.
+ */
+export const useRosterPhoto = (accountId: string, seasonId: string, teamSeasonId: string) => {
+  const apiClient = useApiClient();
+  const [loading, setLoading] = useState(false);
+
+  const uploadPhoto = async (rosterMemberId: string, file: File): Promise<RosterPhotoResult> => {
+    const validationError = validateContactPhotoFile(file);
+    if (validationError) {
+      return { success: false, error: validationError };
+    }
+
+    try {
+      setLoading(true);
+      const result = await apiUploadRosterMemberPhoto({
+        path: { accountId, seasonId, teamSeasonId, rosterMemberId },
+        client: apiClient,
+        throwOnError: false,
+        body: { photo: file },
+        ...formDataBodySerializer,
+        headers: { 'Content-Type': null },
+      });
+      const contact = unwrapApiResult(result, 'Failed to update player photo');
+      return { success: true, contact: toContact(contact) };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Failed to update player photo',
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deletePhoto = async (rosterMemberId: string): Promise<RosterPhotoResult> => {
+    try {
+      setLoading(true);
+      const result = await apiDeleteRosterMemberPhoto({
+        path: { accountId, seasonId, teamSeasonId, rosterMemberId },
+        client: apiClient,
+        throwOnError: false,
+      });
+      const contact = unwrapApiResult(result, 'Failed to delete player photo');
+      return { success: true, contact: toContact(contact) };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Failed to delete player photo',
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { uploadPhoto, deletePhoto, loading };
+};

--- a/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
+++ b/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
@@ -39,11 +39,6 @@ const toContact = (contact: ApiContact): ContactType => ({
   photoUrl: contact.photoUrl ? addCacheBuster(contact.photoUrl, Date.now()) : undefined,
 });
 
-/**
- * Hook for uploading and deleting a roster member's photo via the team-scoped
- * roster endpoints. Used from the team roster page so account admins and
- * (when enabled) team admins share a single authorization path.
- */
 export const useRosterPhoto = (accountId: string, seasonId: string, teamSeasonId: string) => {
   const apiClient = useApiClient();
   const [loading, setLoading] = useState(false);

--- a/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
+++ b/draco-nodejs/frontend-next/hooks/useRosterPhoto.ts
@@ -17,18 +17,11 @@ export interface RosterPhotoResult {
   error?: string;
 }
 
-interface ApiContact {
-  id: string;
-  firstName: string;
-  lastName: string;
-  middleName?: string;
-  email?: string;
-  userId?: string;
-  loginEmail?: string;
-  photoUrl?: string;
-}
+type RosterPhotoContact = NonNullable<
+  Awaited<ReturnType<typeof apiUploadRosterMemberPhoto>>['data']
+>;
 
-const toContact = (contact: ApiContact): ContactType => ({
+const toContact = (contact: RosterPhotoContact): ContactType => ({
   id: contact.id,
   firstName: contact.firstName,
   lastName: contact.lastName,

--- a/draco-nodejs/frontend-next/vitest.config.ts
+++ b/draco-nodejs/frontend-next/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
+    testTimeout: 15000,
     exclude: ['e2e/**', 'node_modules/**'],
     css: {
       modules: {

--- a/draco-nodejs/frontend-next/vitest.config.ts
+++ b/draco-nodejs/frontend-next/vitest.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
-    testTimeout: 15000,
     exclude: ['e2e/**', 'node_modules/**'],
     css: {
       modules: {

--- a/draco-nodejs/shared/shared-schemas/accountSettings.ts
+++ b/draco-nodejs/shared/shared-schemas/accountSettings.ts
@@ -17,6 +17,7 @@ export const ACCOUNT_SETTING_KEYS = [
   'ShowRosterCard',
   'EnableTeamEmail',
   'ShowUserInfoOnRosterPage',
+  'AllowTeamAdminPlayerEdits',
   'ShowContactInfo',
   'EditContactInfo',
   'EmailGameResultsToTeams',
@@ -575,6 +576,24 @@ export const ACCOUNT_SETTING_DEFINITIONS: AccountSettingDefinition[] = [
         id: 'roster.contactInformation',
         type: 'widget',
         displayName: 'Roster Contact Information block',
+        expectedValue: true,
+      },
+    ],
+  }),
+  booleanSetting({
+    key: 'AllowTeamAdminPlayerEdits',
+    label: 'Allow Team Admins to edit player photo and number',
+    description:
+      "When enabled, team administrators can edit a player's photo and jersey number from the team roster page.",
+    groupId: AccountSettingGroupEnum.enum.teamPages,
+    groupLabel: 'Team Pages',
+    sortOrder: 25,
+    defaultValue: false,
+    componentGates: [
+      {
+        id: 'roster.teamAdminPlayerEdits',
+        type: 'widget',
+        displayName: 'Team Admin Player Edit Controls',
         expectedValue: true,
       },
     ],


### PR DESCRIPTION
Adds a new account setting, `AllowTeamAdminPlayerEdits`, and wires it through shared schemas, OpenAPI, and route protection so TeamAdmins can edit roster photos and player numbers when enabled. Backend now supports team-scoped roster photo upload/delete endpoints and enforces that TeamAdmins can only edit player numbers (not other roster fields) without account-level permissions. Frontend updates TeamRosterWidget to support inline player-number editing and team-scoped photo actions via a new `useRosterPhoto` hook, with dialog overrides and targeted tests for permission behavior and non-optimistic number updates.